### PR TITLE
hasBody enhancement

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -334,7 +334,8 @@ isChunked :: H.HttpVersion -> Bool
 isChunked = (==) H.http11
 
 hasBody :: H.Status -> Request -> Bool
-hasBody s req = s /= (H.Status 204 "") && requestMethod req /= "HEAD"
+hasBody s req = s /= (H.Status 204 "") && s /= H.status304 &&
+                H.statusCode s >= 200 && requestMethod req /= "HEAD"
 
 sendResponse :: T.Handle
              -> Request -> Socket -> Response -> IO Bool


### PR DESCRIPTION
According to RFC 2616, 1xx and 304 MUST NOT have its body. This patch fixes this.
Actually I use 304 for Mighttpd.
