### PR TITLE
Added the ability to include user actions in the wai development handler

### DIFF
--- a/wai-handler-devel/run-onreloadapp.hs
+++ b/wai-handler-devel/run-onreloadapp.hs
@@ -1,0 +1,21 @@
+
+import Network.Wai.Handler.DevelServer (runQuitWithReloadActions)
+import System.Directory(findExecutable)
+import System.Process(readProcess)
+
+main = runQuitWithReloadActions 4000 "SmallApp" "smallApp" (const $ return []) [browserRefresh] 
+
+browserRefresh = do
+  exe <- findExecutable "xdotool"
+  case exe of 
+    Nothing -> do
+      putStrLn "Install xdotool for automatic browser refresh"
+      return $ return () 
+    Just xdotool -> do
+      putStrLn "Please click on the browser window..."
+      pid <- readProcess xdotool ["selectwindow"] ""
+      return $ do
+        current <- readProcess xdotool ["getwindowfocus"] ""
+        let cmds = ["windowfocus", pid, "key", "F5", "windowfocus", current]
+        _ <- readProcess xdotool  cmds ""
+        return ()


### PR DESCRIPTION
Also added an example demonstrating a compelling use case: The user
clicks on the browser the first time the app loads. Each successive time
the server is reloaded, the browser is automatically refreshed (sent the
F5 key). This example requires xdotool (linux only?) to collect the
window pid and send the F5 keypress to the browser. 

This example is just a minor convenience, but it's one that I've grown 
accustomed to with other development environments. The general 
feature might be useful for other reasons as well, though I'm out of 
interesting examples.
