### PR TITLE
The Server: field hack for proxy

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -111,8 +111,6 @@ import qualified Network.HTTP.Types as H
 import qualified Data.CaseInsensitive as CI
 import System.IO (hPutStrLn, stderr)
 
-import Data.List (delete)
-
 #if WINDOWS
 import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.MVar as MV
@@ -616,9 +614,8 @@ withManager timeout f = do
 serverHeader :: H.RequestHeaders -> H.RequestHeaders
 serverHeader hdrs = case lookup key hdrs of
     Nothing  -> server : hdrs
-    Just svr -> servers svr : delete (key,svr) hdrs
+    Just _ -> hdrs
  where
     key = "Server"
     ver = B.pack $ "Warp/" ++ warpVersion
     server = (key, ver)
-    servers svr = (key, S.concat [svr, " ", ver])


### PR DESCRIPTION
serverHeader was added by me when I uses Warp as a server only.
This function adds the Server: field if not exists and appends
values if exists.

After start using it as a proxy server, it appeared that this
feature is inconvenient. A proxy server should not add the
Server: field according to specification. (It should add the Via:
field.)

So, let's not add the Server: field if exists. This works in many
cases.
