### PR TITLE
Update wai-websockets to work with conduit

### DIFF
--- a/wai-websockets/Network/Wai/Handler/WebSockets.hs
+++ b/wai-websockets/Network/Wai/Handler/WebSockets.hs
@@ -3,24 +3,44 @@ module Network.Wai.Handler.WebSockets
     ( intercept
     ) where
 
-import Network.Wai (Request, requestHeaders, rawPathInfo, requestHeaders)
-import Network.Socket (Socket)
-import Data.Char (toLower)
-import Data.Enumerator (Iteratee)
+import Control.Monad.IO.Class (liftIO)
 import Data.ByteString (ByteString)
+import Data.Char (toLower)
+import Network.Socket (Socket)
+import Network.Wai (Request, requestHeaders, rawPathInfo, requestHeaders)
 import qualified Data.ByteString.Char8 as S
-import Network.WebSockets (WebSockets, runWebSockets, RequestHttpPart(RequestHttpPart), Protocol)
+import qualified Data.Conduit as C
+import qualified Data.Enumerator as E
 import qualified Network.WebSockets as WS
-import Network.Socket.Enumerator (iterSocket)
+import qualified Network.WebSockets.Internal as WS
 
-intercept :: Protocol p
-          => (WS.Request -> WebSockets p ())
+-- | For use with 'settingsIntercept' from the Warp web server.
+intercept :: WS.Protocol p
+          => (WS.Request -> WS.WebSockets p ())
           -> Request
-          -> Maybe (Socket -> Iteratee ByteString IO ())
-intercept app req =
-    case lookup "upgrade" $ requestHeaders req of
-        Just s | S.map toLower s=="websocket" -> Just $ \socket -> do
-            runWebSockets req' app (iterSocket socket)
-        _ -> Nothing
+          -> Maybe (C.BufferedSource IO ByteString -> Socket -> C.ResourceT IO ())
+intercept app req = case lookup "upgrade" $ requestHeaders req of
+    Just s
+        | S.map toLower s == "websocket" -> Just $ runWebSockets req' app
+        | otherwise                      -> Nothing
+    _                                    -> Nothing
   where
-    req' = RequestHttpPart (rawPathInfo req) (requestHeaders req)
+    req' = WS.RequestHttpPart (rawPathInfo req) (requestHeaders req)
+
+-- | Internal function to run the WebSocket iteratee using the conduit library
+runWebSockets :: WS.Protocol p
+              => WS.RequestHttpPart
+              -> (WS.Request -> WS.WebSockets p ())
+              -> C.BufferedSource IO ByteString
+              -> Socket
+              -> C.ResourceT IO ()
+runWebSockets req app source sock = do
+    step <- liftIO $ E.runIteratee $ WS.runWebSockets req app send
+    source C.$$ C.sinkState (E.returnI step) push close
+  where
+    send  = WS.iterSocket sock
+    close = const $ return ()
+
+    push iter bs = do
+        step <- liftIO $ E.runIteratee $ E.enumList 1 [bs] E.$$ iter
+        return (E.returnI step, C.Processing)

--- a/wai-websockets/wai-websockets.cabal
+++ b/wai-websockets/wai-websockets.cabal
@@ -1,5 +1,5 @@
 Name:                wai-websockets
-Version:             1.0.0
+Version:             1.1.0
 Synopsis:            Provide a bridge betweeen WAI and the websockets package.
 License:             BSD3
 License-file:        LICENSE
@@ -19,13 +19,15 @@ flag example
 Library
   Build-Depends:     base                          >= 3        && < 5
                    , bytestring                >= 0.9.1.4  && < 0.10
+                   , conduit                   >= 0.0      && < 0.1
                    , wai                           >= 1.0      && < 1.1
                    , enumerator                >= 0.4.8    && < 0.5
                    , network-enumerator            >= 0.1.2    && < 0.2
                    , blaze-builder                 >= 0.2.1.4  && < 0.4
                    , case-insensitive              >= 0.2
                    , network                   >= 2.2.1.5 && < 2.4
-                   , websockets                    >= 0.4      && < 0.5
+                   , transformers              >= 0.2     && < 0.3
+                   , websockets                    >= 0.5.1    && < 0.6
   Exposed-modules:   Network.Wai.Handler.WebSockets
   ghc-options:       -Wall
 
@@ -35,6 +37,7 @@ Executable           wai-websockets-example
   else
     buildable: False
   Build-Depends:     base >=3 && < 5,
+                     conduit,
                      wai-websockets,
                      websockets,
                      network-enumerator,


### PR DESCRIPTION
The `websockets` library is still based on `enumerator` for now, so there will be a small overhead. However, it seems to work well, and I didn't have to change anything in the `server.lhs` example.
