### PR TITLE
Add library interface

### DIFF
--- a/wai-eventsource/src/Main.hs
+++ b/wai-eventsource/src/Main.hs
@@ -2,41 +2,22 @@
 module Main where
 
 import Control.Monad
-import Control.Monad.Trans
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Chan
 import Network.Wai.Handler.Warp (run)
 import Network.Wai
 import Network.HTTP.Types (statusOK)
-import qualified Data.Conduit as C
 import Data.Time.Clock.POSIX
 import Blaze.ByteString.Builder.Char.Utf8 (fromString)
-import Blaze.ByteString.Builder (Builder)
 
-import EventStream
-
+import Network.Wai.EventSource
 
 app :: Chan ServerEvent -> Application
 app chan req =
     case pathInfo req of
         []     -> return $ ResponseFile statusOK [("Content-Type", "text/html")] "static/index.html" Nothing
-        ["es"] -> do
-            chan' <- liftIO $ dupChan chan
-            return $ res chan'
+        ["es"] -> eventSourceApp chan req
         _ -> error "unexpected pathInfo"
-
-
-res :: Chan ServerEvent -> Response
-res chan = ResponseSource statusOK [("Content-Type", "text/event-stream")] (resE chan)
-
-
-resE :: Chan ServerEvent -> C.Source IO Builder
-resE chan =
-  C.sourceIO ign (\_ -> ign) (\_ -> fmap (f . eventToBuilder) $ readChan chan)
-  where
-    ign = return ()
-    f Nothing = C.Closed
-    f (Just b) = C.Open b
 
 
 source :: Chan ServerEvent -> IO ()

--- a/wai-eventsource/src/Network/Wai/EventSource.hs
+++ b/wai-eventsource/src/Network/Wai/EventSource.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.Wai.EventSource (
+    ServerEvent(..),
+    eventSourceApp
+    ) where
+
+import           Blaze.ByteString.Builder (Builder)
+import           Control.Concurrent.Chan (Chan, dupChan, readChan)
+import           Control.Monad.Trans (liftIO)
+import qualified Data.Conduit as C
+import           Network.HTTP.Types (statusOK)
+import           Network.Wai (Application, Response(..))
+
+import Network.Wai.EventSource.EventStream
+
+-- | Make a new WAI EventSource application reading events from
+-- the given channel.
+eventSourceApp :: Chan ServerEvent -> Application
+eventSourceApp chan _ = do
+  chan' <- liftIO $ dupChan chan
+  return $ res chan'
+
+res :: Chan ServerEvent -> Response
+res chan = ResponseSource statusOK [("Content-Type", "text/event-stream")] $ resE chan
+
+resE :: Chan ServerEvent -> C.Source IO Builder
+resE chan =
+  C.sourceIO ign (const ign) (const $ fmap (f . eventToBuilder) $ readChan chan)
+  where
+    ign = return ()
+    f Nothing = C.Closed
+    f (Just b) = C.Open b

--- a/wai-eventsource/src/Network/Wai/EventSource/EventStream.hs
+++ b/wai-eventsource/src/Network/Wai/EventSource/EventStream.hs
@@ -5,7 +5,7 @@
     A WAI adapter to the HTML5 Server-Sent Events API.  Push-mode and
     pull-mode interfaces are both available.
 -}
-module EventStream (
+module Network.Wai.EventSource.EventStream (
     ServerEvent(..),
     eventToBuilder
     ) where

--- a/wai-eventsource/wai-eventsource.cabal
+++ b/wai-eventsource/wai-eventsource.cabal
@@ -12,7 +12,23 @@ Cabal-version:       >=1.2
 
 flag example
 
--- TODO: Library interface
+
+Library
+  Build-depends:
+      base                      >= 4.3 && < 5
+    , bytestring                >= 0.9.1.4  && < 0.10
+    , blaze-builder             >= 0.3 && < 0.4
+    , conduit                   >= 0.0 && < 0.1
+    , MonadCatchIO-transformers >= 0.2.1 && < 0.3
+    , mtl                       >= 2 && < 3
+    , http-types                >= 0.6      && < 0.7
+    , wai                       >= 0.4
+    , warp                      >= 0.4
+
+  ghc-options:     -Wall
+  hs-source-dirs:  src
+  exposed-modules: Network.Wai.EventSource
+  other-modules:   Network.Wai.EventSource.EventStream
 
 Executable wai-eventsource
   if flag(example)


### PR DESCRIPTION
This adds an exported library interface to wai-eventsource. It should be pretty self-explanatory.

There is one exported module:

```
Network.Wai.EventSource
```

which exports the ServerEvent data type and a function

   eventSourceApp :: Chan ServerEvent -> Application

which waits on the channel for ServerEvents to arrive and sends them out on the event source.

EDIT: Oh, and this is based on my "eventsource-conduits" branch.
