### PR TITLE
Add interceptWith to wai-websockets

### DIFF
--- a/wai-websockets/Network/Wai/Handler/WebSockets.hs
+++ b/wai-websockets/Network/Wai/Handler/WebSockets.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Handler.WebSockets
     ( intercept
+    , interceptWith
     ) where
 
 import Control.Monad.IO.Class (liftIO)
@@ -19,9 +20,17 @@ intercept :: WS.Protocol p
           => (WS.Request -> WS.WebSockets p ())
           -> Request
           -> Maybe (C.BufferedSource IO ByteString -> Socket -> C.ResourceT IO ())
-intercept app req = case lookup "upgrade" $ requestHeaders req of
+intercept = interceptWith WS.defaultWebSocketsOptions
+
+-- | Variation of 'intercept' which allows custom options.
+interceptWith :: WS.Protocol p
+              => WS.WebSocketsOptions
+              -> (WS.Request -> WS.WebSockets p ())
+              -> Request
+              -> Maybe (C.BufferedSource IO ByteString -> Socket -> C.ResourceT IO ())
+interceptWith opts app req = case lookup "upgrade" $ requestHeaders req of
     Just s
-        | S.map toLower s == "websocket" -> Just $ runWebSockets req' app
+        | S.map toLower s == "websocket" -> Just $ runWebSockets opts req' app
         | otherwise                      -> Nothing
     _                                    -> Nothing
   where
@@ -29,13 +38,14 @@ intercept app req = case lookup "upgrade" $ requestHeaders req of
 
 -- | Internal function to run the WebSocket iteratee using the conduit library
 runWebSockets :: WS.Protocol p
-              => WS.RequestHttpPart
+              => WS.WebSocketsOptions
+              -> WS.RequestHttpPart
               -> (WS.Request -> WS.WebSockets p ())
               -> C.BufferedSource IO ByteString
               -> Socket
               -> C.ResourceT IO ()
-runWebSockets req app source sock = do
-    step <- liftIO $ E.runIteratee $ WS.runWebSockets req app send
+runWebSockets opts req app source sock = do
+    step <- liftIO $ E.runIteratee $ WS.runWebSocketsWith opts req app send
     source C.$$ C.sinkState (E.returnI step) push close
   where
     send  = WS.iterSocket sock

--- a/wai-websockets/wai-websockets.cabal
+++ b/wai-websockets/wai-websockets.cabal
@@ -1,9 +1,9 @@
 Name:                wai-websockets
-Version:             1.1.0
+Version:             1.1.1
 Synopsis:            Provide a bridge betweeen WAI and the websockets package.
 License:             BSD3
 License-file:        LICENSE
-Author:              Michael Snoyman
+Author:              Michael Snoyman, Jasper Van der Jeugt
 Maintainer:          michael@snoyman.com
 Homepage:            http://github.com/yesodweb/wai
 Category:            Web, Yesod


### PR DESCRIPTION
This is a variation of `intercept` which allows the user to pass in options for the `websockets` library. I also took the liberty of adding my name to the author field of the `wai-websockets` package.
