### PR TITLE
warp's bindPort modified to retry after Network.Socket.socket throws an exception

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 ---------------------------------------------------------
 --
 -- Module        : Network.Wai.Handler.Warp
@@ -82,6 +83,7 @@ import Control.Exception
     ( bracket, finally, Exception, SomeException, catch
     , fromException, AsyncException (ThreadKilled)
     , bracketOnError
+    , IOException
     )
 import Control.Concurrent (forkIO)
 import Data.Maybe (fromMaybe, isJust)
@@ -174,17 +176,25 @@ bindPort p s = do
     addrs <- getAddrInfo (Just hints) host port
     -- Choose an IPv6 socket if exists.  This ensures the socket can
     -- handle both IPv4 and IPv6 if v6only is false.
-    let addrs' = filter (\x -> addrFamily x == AF_INET6) addrs
-        addr = if null addrs' then head addrs else head addrs'
-    bracketOnError
-        (Network.Socket.socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
-        sClose
-        (\sock -> do
-            setSocketOption sock ReuseAddr 1
-            bindSocket sock (addrAddress addr)
-            listen sock maxListenQueue
-            return sock
-        )
+    let addrs' = filter (\x -> addrFamily x == AF_INET6) addrs ++ filter (\x -> addrFamily x /= AF_INET6) addrs
+
+        tryAddrs (addr1:rest@(_:_)) = 
+                                      catch
+                                      (theBody addr1) 
+                                      (\(_ :: IOException) -> tryAddrs rest)
+        tryAddrs (addr1:[])         = theBody addr1
+        tryAddrs _                  = error "bindPort: addrs is empty"
+        theBody addr = 
+          bracketOnError
+          (Network.Socket.socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+          (sClose)
+          (\sock -> do
+              setSocketOption sock ReuseAddr 1
+              bindSocket sock (addrAddress addr)
+              listen sock maxListenQueue
+              return sock
+          )
+    tryAddrs addrs'
 
 -- | Run an 'Application' on the given port. This calls 'runSettings' with
 -- 'defaultSettings'.


### PR DESCRIPTION
Hi, 

I had some problems running yesod on IPv4-only system.
The reason is that getAddrInfo returns IPv6 (AF_INET6) addr's even though ipv6 is not available on the system, and bindPort just tries to call socket with the first addr.
Because of this, application crashes saying
 web: socket: unsupported operation (Address family not supported by protocol)

I changed bindPort so that it retries using the rest of the addrs after failing with the first one.

I hope this helps!
