### PR TITLE
Fix the ghc-7.4 compile issue

### DIFF
--- a/warp/ReadInt.hs
+++ b/warp/ReadInt.hs
@@ -34,7 +34,7 @@ data Table = Table !Addr#
 
 {- NOINLINE mhDigitToInt #-}
 mhDigitToInt :: Char -> Int
-mhDigitToInt (C# i) = I# (word2Int# $ indexWord8OffAddr# addr (ord# i))
+mhDigitToInt (C# i) = I# (word2Int# (indexWord8OffAddr# addr (ord# i)))
   where
     !(Table addr) = table
     table :: Table


### PR DESCRIPTION
According to Igloo in #ghc, this failed because of changes to Kind inference.
The fix was as simple as replacing a '$' with parentheses.
