### PR TITLE
broken zlib 0.5.3.2 causes fresh build to fail

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -35,6 +35,8 @@ Library
                    , data-default              >= 0.3      && < 0.4
                    , fast-logger               >= 0.0.2
                    , conduit                   >= 0.2
+                   -- remove hard zlib dependency when zlib > 0.5.3.2 is released
+                   , zlib                      <= 0.5.3.1
                    , zlib-conduit              >= 0.2
                    , blaze-builder-conduit     >= 0.2
 


### PR DESCRIPTION
zlib 0.5.3.2 fails to compile due to a macro expansion
error. WAI has an indirect dependency to zlib though
zlib-bindings and zlib-conduit. This caused the build to
fail. Directly depending on a working version of zlib fixes
this problem.

Reference: http://stackoverflow.com/questions/8961413/zlib-build-error-with-ghc
