### PR TITLE
add ansi colors to connect a request & response

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -37,6 +37,7 @@ Library
                    , conduit                   >= 0.2
                    , zlib-conduit              >= 0.2
                    , blaze-builder-conduit     >= 0.2
+                   , ansi-terminal
 
   Exposed-modules:   Network.Wai.Handler.CGI
                      Network.Wai.Middleware.AcceptOverride


### PR DESCRIPTION
Opening this as a pull request in case someone doesn't like the idea of depending on ansi-terminal for some reason. However, In the future we should use more terminal colors as we add more things to the log.
Also this should be tested on Windows first. I think it may have no effect there the way it is currently used.

This pull request connects the request & response through terminal colors, in case multiple requests get intermingled (obviously shouldn't happen much in dev mode). The request is logged before the response so that you have that info if your app crashes.
