### PR TITLE
Added a RedirectToIndex setting

### DIFF
--- a/warp-static/warp.hs
+++ b/warp-static/warp.hs
@@ -52,6 +52,7 @@ main = do
         } $ middle $ staticApp defaultFileServerSettings
         { ssFolder = fileSystemLookup $ toFilePath docroot
         , ssIndices = if noindex then [] else map pack index
+        , ssRedirectToIndex = false
         , ssListing = Just defaultListing
         , ssGetMimeType = return . mimeTypeByExt mimeMap defaultMimeType . fileName
         }


### PR DESCRIPTION
When a directory is requested and a request file exists, the previous version would have redirected to the request file. This setting enables the user to set RedirectToIndex which does that. Otherwise, it just serves the index file without any redirect.

```
RedirectToIndex=True: http://example.com/ redirected to http://example.com/index.html
RedirectToIndex=False: http://example.com/ remains same. Index.html is served.
```

This enables for prettier URLs for static sites.

```
http://myblog.com/2012/12/1/sample-blog-post/
vs
http://myblog.com/2012/12/1/sample-blog-post/index.html
```
