### PR TITLE
EventSource: Export sourceToSource as a low-level option

### DIFF
--- a/wai-eventsource/src/Network/Wai/EventSource.hs
+++ b/wai-eventsource/src/Network/Wai/EventSource.hs
@@ -3,7 +3,8 @@ module Network.Wai.EventSource (
     ServerEvent(..),
     eventSourceAppChan,
     eventSourceAppSource,
-    eventSourceAppIO
+    eventSourceAppIO,
+    sourceToSource
     ) where
 
 import           Blaze.ByteString.Builder (Builder)
@@ -59,6 +60,8 @@ ioToSource act =
             Just y -> C.StateOpen (Just C.Flush) (C.Chunk y)
     pull (Just x) = return $ C.StateOpen Nothing x
 
+-- | Convert a ServerEvent source into a Builder source of serialized
+-- events.
 sourceToSource :: Monad m => C.Source m ServerEvent -> C.Source m (C.Flush Builder)
 sourceToSource src = src $= CL.concatMap eventToFlushBuilder
   where


### PR DESCRIPTION
Hi guys,

I found a need to get at the "sourceToSource" function in EventSource, so I'd like to have this added to the export list in Wai.Network.EventSource.

This is sufficient for me currently, but if you'd like a cleaner solution, I could probably be convinced to create a brand new "conduit-eventsource" package containing just the "sourceToSource" function (+ ServerEvent->Builder code) and let wai-eventsource depend on that. Any opinions?
