### PR TITLE
Using sendfileWithHeader.

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -162,7 +162,7 @@ allowInterrupt = unblock $ return ()
 data Connection = Connection
     { connSendMany :: [B.ByteString] -> IO ()
     , connSendAll  :: B.ByteString -> IO ()
-    , connSendFile :: FilePath -> Integer -> Integer -> IO () -> IO () -- ^ offset, length
+    , connSendFile :: FilePath -> Integer -> Integer -> IO () -> [ByteString] -> IO () -- ^ offset, length
     , connClose    :: IO ()
     , connRecv     :: IO B.ByteString
     }
@@ -171,7 +171,7 @@ socketConnection :: Socket -> Connection
 socketConnection s = Connection
     { connSendMany = Sock.sendMany s
     , connSendAll = Sock.sendAll s
-    , connSendFile = \fp off len act -> sendfile s fp (PartOfFile off len) act
+    , connSendFile = \fp off len act hdr -> sendfileWithHeader s fp (PartOfFile off len) act hdr
     , connClose = sClose s
     , connRecv = Sock.recv s bytesPerRead
     }
@@ -586,13 +586,12 @@ sendResponse th req conn r = sendResponse' r
                 [("Content-Type", "text/plain")]
                 "File not found"
             Right (lengthyHeaders, cl) -> liftIO $ do
-                let headers' = headers version s lengthyHeaders
-                sendHeader $ headers' False
+                let headers' = L.toChunks . toLazyByteString $ headers version s lengthyHeaders False
                 T.tickle th
                 if hasBody s req then do
                     case mpart of
-                        Nothing   -> connSendFile conn fp 0 cl (T.tickle th)
-                        Just part -> connSendFile conn fp (filePartOffset part) (filePartByteCount part) (T.tickle th)
+                        Nothing   -> connSendFile conn fp 0 cl (T.tickle th) headers'
+                        Just part -> connSendFile conn fp (filePartOffset part) (filePartByteCount part) (T.tickle th) headers'
                     T.tickle th
                     return isPersist
                   else

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -26,7 +26,7 @@ Library
                    , blaze-builder-conduit     >= 0.4      && < 0.5
                    , lifted-base               >= 0.1      && < 0.2
                    , blaze-builder             >= 0.2.1.4  && < 0.4
-                   , simple-sendfile           >= 0.2.2    && < 0.3
+                   , simple-sendfile           >= 0.2.4    && < 0.3
                    , http-types                >= 0.6      && < 0.7
                    , case-insensitive          >= 0.2
                    , unix-compat               >= 0.2


### PR DESCRIPTION
This patch makes ResponseFile drastically faster on Linux and FreeBSD by using sendfileWithHeader newly provided in the simple-sendfile package v0.2.4.

OLD means "without this patch"
NEW means "with this patch"

```
         OLD+pronk  NEW+pronk  OLD+httperf  NEW+httperf
Mac      3678.74    3415.76    6642.5       6891.8
FreeBSD  10.0010    1309.43    10.0     3174.8       # this machine is slow
Linux    24.9875    2558.36    25.0         8284.2
```
