### PR TITLE
wai-eventsource: Export EventStream module.

### DIFF
--- a/wai-eventsource/src/Network/Wai/EventSource.hs
+++ b/wai-eventsource/src/Network/Wai/EventSource.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-|
+    A WAI adapter to the HTML5 Server-Sent Events API.
+-}
 module Network.Wai.EventSource (
     ServerEvent(..),
     eventSourceAppChan,

--- a/wai-eventsource/src/Network/Wai/EventSource/EventStream.hs
+++ b/wai-eventsource/src/Network/Wai/EventSource/EventStream.hs
@@ -2,8 +2,7 @@
 {- code adapted by Mathias Billman originaly from Chris Smith https://github.com/cdsmith/gloss-web -}
 
 {-|
-    A WAI adapter to the HTML5 Server-Sent Events API.  Push-mode and
-    pull-mode interfaces are both available.
+    Internal module, usually you don't need to use it.
 -}
 module Network.Wai.EventSource.EventStream (
     ServerEvent(..),

--- a/wai-eventsource/wai-eventsource.cabal
+++ b/wai-eventsource/wai-eventsource.cabal
@@ -25,8 +25,9 @@ Library
 
   ghc-options:     -Wall
   hs-source-dirs:  src
-  exposed-modules: Network.Wai.EventSource
-  other-modules:   Network.Wai.EventSource.EventStream
+  exposed-modules:
+    Network.Wai.EventSource
+    Network.Wai.EventSource.EventStream
 
 source-repository head
   type:     git


### PR DESCRIPTION
Is this ok?  I'd also like to backport it to `wai-eventsource-1.2.*`.  It is needed in order to efficiently send many events at once.
