### PR TITLE
catching up to fast-logger 0.3.

### DIFF
--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -37,7 +37,7 @@ import System.IO.Unsafe
 
 import Data.Default (Default (def))
 import Network.Wai.Logger.Format (apacheFormat, IPAddrSource (..))
-import System.Log.FastLogger.Date (getDate, dateInit, ZonedDate)
+import System.Date.Cache (ondemandDateCacher)
 
 data OutputFormat = Apache IPAddrSource
                   | Detailed Bool -- ^ use colors?
@@ -79,7 +79,9 @@ mkRequestLogger RequestLoggerSettings{..} = do
             getdate <-
                 case mgetdate of
                     Just x -> return x
-                    Nothing -> fmap getDate dateInit
+                    Nothing -> do
+                        (getter,_) <- ondemandDateCacher zonedDateCacheConf
+                        return getter
             return $ apacheMiddleware callback ipsrc getdate
         Detailed useColors -> detailedMiddleware callback useColors
   where

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -33,8 +33,9 @@ Library
                    , text                      >= 0.7      && < 0.12
                    , case-insensitive          >= 0.2
                    , data-default
-                   , fast-logger               >= 0.2      && < 0.3
-                   , wai-logger                >= 0.2      && < 0.3
+                   , date-cache                >= 0.3      && < 0.4
+                   , fast-logger               >= 0.3      && < 0.4
+                   , wai-logger                >= 0.3      && < 0.4
                    , conduit                   >= 0.5      && < 0.6
                    , zlib-conduit              >= 0.5      && < 0.6
                    , blaze-builder-conduit     >= 0.5      && < 0.6


### PR DESCRIPTION
This patch is to catch up to fast-logger.
I will report why I changed fast-logger to "web-devel".
Since I don't use this package, I could not test it.
