### PR TITLE
fixing "cabal sdist"

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -15,9 +15,6 @@ Description:         The premier WAI handler. For more information, see <http://
 Flag network-bytestring
     Default: False
 
-Flag test
-    Default: False
-
 Library
   Build-Depends:     base                      >= 3        && < 5
                    , blaze-builder             >= 0.2.1.4  && < 0.4
@@ -39,21 +36,8 @@ Library
                    , network-bytestring    >= 0.1.3   && < 0.1.4
   else
       Build-Depends: network               >= 2.3     && < 2.4
-  if flag(test)
-    Exposed-modules: Network.Wai.Handler.Warp
-                     Network.Wai.Handler.Warp.Conduit
-                     Network.Wai.Handler.Warp.ReadInt
-                     Network.Wai.Handler.Warp.Request
-                     Network.Wai.Handler.Warp.Response
-                     Network.Wai.Handler.Warp.ResponseHeader
-                     Network.Wai.Handler.Warp.Run
-                     Network.Wai.Handler.Warp.Settings
-                     Network.Wai.Handler.Warp.Timeout
-                     Network.Wai.Handler.Warp.Types
-                     Paths_warp
-  else
-    Exposed-modules: Network.Wai.Handler.Warp
-    Other-modules:   Network.Wai.Handler.Warp.Conduit
+  Exposed-modules:   Network.Wai.Handler.Warp
+  Other-modules:     Network.Wai.Handler.Warp.Conduit
                      Network.Wai.Handler.Warp.ReadInt
                      Network.Wai.Handler.Warp.Request
                      Network.Wai.Handler.Warp.Response
@@ -69,22 +53,29 @@ Library
 
 Test-Suite spec
     Main-Is:         Spec.hs
-    Hs-Source-Dirs:  test
+    Hs-Source-Dirs:  test, .
     Type:            exitcode-stdio-1.0
 
     Ghc-Options:     -Wall
     Build-Depends:   base >= 4 && < 5
+                   , blaze-builder             >= 0.2.1.4  && < 0.4
+                   , blaze-builder-conduit     >= 0.5      && < 0.6
+                   , bytestring                >= 0.9.1.4
+                   , case-insensitive          >= 0.2
+                   , conduit                   >= 0.5      && < 0.6
+                   , ghc-prim
+                   , http-types                >= 0.7      && < 0.8
+                   , lifted-base               >= 0.1      && < 0.2
+                   , network-conduit           >= 0.5      && < 0.6
+                   , simple-sendfile           >= 0.2.4    && < 0.3
+                   , transformers              >= 0.2.2    && < 0.4
+                   , unix-compat               >= 0.2
+                   , void
+                   , wai                       >= 1.3      && < 1.4
+                   , network
                    , HUnit
                    , QuickCheck
-                   , bytestring
-                   , conduit
-                   , ghc-prim
                    , hspec
-                   , http-types
-                   , network
-                   , transformers
-                   , wai
-                   , warp
 
 Source-Repository head
   Type:     git


### PR DESCRIPTION
This fixes the problem of "cabal sdist".

Note that cabal test sometime fails:

```
1) Run - connection termination - ConnectionClosedByPeer FAILED
expected: "Just ConnectionClosedByPeer"
but got: "Just recv: resource vanished (Connection reset by peer)"
```

Please check it out.
