### PR TITLE
Fixing compilation of wai-handler-launch under windows

### DIFF
--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString as S
 import Blaze.ByteString.Builder (fromByteString)
 #if WINDOWS
 import Foreign
-import Foreign.String
+import Foreign.C.String
 #else
 import System.Cmd (rawSystem)
 #endif

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -1,5 +1,5 @@
 Name:                wai-handler-launch
-Version:             1.3.0
+Version:             1.3.1
 Synopsis:            Launch a web app in the default browser.
 Description:         This handles cross-platform launching and inserts Javascript code to ping the server. When the server no longer receives pings, it shuts down.
 License:             MIT


### PR DESCRIPTION
Just a tiny fix and a version bump to be able to compile under windows
