### PR TITLE
Fix version constraint on warp to avoid compilation errors.

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -26,7 +26,7 @@ Library
                    , http-types                >= 0.7      && < 0.8
                    , lifted-base               >= 0.1      && < 0.2
                    , network-conduit           >= 0.5      && < 0.6
-                   , simple-sendfile           >= 0.2.4    && < 0.3
+                   , simple-sendfile           >= 0.2.7    && < 0.3
                    , transformers              >= 0.2.2    && < 0.4
                    , unix-compat               >= 0.2
                    , void


### PR DESCRIPTION
The function sendfileFdWithHeader gets introduced in commit ee70e16ff, the first version bump after that is to 0.2.7. Warp needs that function on Linux, so it makes sense to bump the version requirement.
