### PR TITLE
Multithreaded SSL/TLS handshaking.

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -38,6 +38,7 @@ module Network.Wai.Handler.Warp (
     -- * Connection
   , Connection (..)
   , runSettingsConnection
+  , runSettingsConnectionMaker
     -- * Datatypes
   , Port
   , InvalidRequest (..)


### PR DESCRIPTION
In warp/warp-tls, SSL/TLS handshaking is executed sequentially. This causes a performance problem.

This patch moves handshaking from TCP accept loop to each individual thread spawned per connection.
