### PR TITLE
Add unix dependency to all non-Windows platforms

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -55,12 +55,13 @@ Library
   Ghc-Options:       -Wall
   if os(linux) || os(freebsd) || os(darwin)
       Cpp-Options:   -DSENDFILEFD
-      Build-Depends: unix
-                   , hashable
+      Build-Depends: hashable
       Other-modules: Network.Wai.Handler.Warp.FdCache
                      Network.Wai.Handler.Warp.MultiMap
   if os(windows)
       Cpp-Options:   -DWINDOWS
+  else
+      Build-Depends: unix
 
 Test-Suite spec
     Main-Is:         Spec.hs


### PR DESCRIPTION
Since commit 543a9c5ae1db55c17c256b04124029957b6cafdf uses System.Posix.IO on non-Windows platform, build on NetBSD, OpenBSD, etc. fails.
