### PR TITLE
wai-extra: Expose gzipCheckMime

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -19,6 +19,7 @@ module Network.Wai.Middleware.Gzip
     , GzipSettings
     , gzipFiles
     , GzipFiles (..)
+    , gzipCheckMime
     , def
     , defaultCheckMime
     ) where


### PR DESCRIPTION
It would be useful if `gzipCheckMime` was exposed.

Currently `defaultCheckMime` matches only `text/*`. This means that JSON responses are not compressed by the gzip middleware. This small patch allows us to specify custom `gzipCheckMime` function insetad of the default one.
