### PR TITLE
Using RNG from cprng-aes in order to be more economic with OS entropy

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -42,7 +42,7 @@ import qualified Data.PEM as PEM
 import Data.Conduit.Network (sourceSocket, sinkSocket, acceptSafe)
 import Data.Maybe (fromMaybe)
 import qualified Data.IORef as I
-import Crypto.Random.API (getSystemRandomGen)
+import Crypto.Random.AESCtr (makeSystem)
 import Control.Exception (Exception, throwIO)
 import Data.Typeable (Typeable)
 import qualified Data.Conduit.Binary as CB
@@ -117,7 +117,7 @@ runTLSSocket TLSSettings {..} set sock app = do
                     return bs
             if maybe False ((== 0x16) . fst) (firstBS >>= B.uncons)
                 then do
-                    gen <- getSystemRandomGen
+                    gen <- makeSystem
                     ctx <- TLS.contextNew
                         TLS.Backend
                             { TLS.backendFlush = return ()

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -27,6 +27,7 @@ Library
                    , tls                           >= 1.1
                    , crypto-random-api             >= 0.2
                    , network                       >= 2.2.1
+                   , cprng-aes                     >= 0.3.4
   Exposed-modules:   Network.Wai.Handler.WarpTLS
   ghc-options:       -Wall
 


### PR DESCRIPTION
This change introduces a new dependency, so I am not sure if it is acceptable.

The benefit is a more efficient usage of operating system entropy and less system calls (for reading from /dev/urandom on UNIX).

`Crypto.Random.API.SystemRandom` obtains all random bits directly from the operating system entropy pool. On UNIX this implies that a handle for `/dev/urandom` is kept open. `Crypto.Random.AESCtr.AESRNG` does so only for seeding the random number generator.
