### PR TITLE
Add allow-sendfilefd flag for Debian GNU/kFreeBSD

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -20,6 +20,10 @@ Description:
 Flag network-bytestring
     Default: False
 
+Flag allow-sendfilefd
+    Description: Allow use of sendfileFd (not available on GNU/kFreeBSD)
+    Default:     True
+
 Library
   Build-Depends:     base                      >= 3        && < 5
                    , blaze-builder             >= 0.2.1.4  && < 0.4
@@ -53,7 +57,7 @@ Library
                      Network.Wai.Handler.Warp.Types
                      Paths_warp
   Ghc-Options:       -Wall
-  if os(linux) || os(freebsd) || os(darwin)
+  if (os(linux) || os(freebsd) || os(darwin)) && flag(allow-sendfilefd)
       Cpp-Options:   -DSENDFILEFD
       Build-Depends: hashable
       Other-modules: Network.Wai.Handler.Warp.FdCache
@@ -92,7 +96,7 @@ Test-Suite spec
     -- Yes, this means that the test suite will no longer work on Windows.
     -- Unfortunately there is a bug in older versions of cabal, and this conditional
     -- will therefore break older systems.
-  --if os(linux) || os(freebsd) || os(darwin)
+  --if (os(linux) || os(freebsd) || os(darwin)) && flag(allow-sendfilefd)
     Cpp-Options:   -DSENDFILEFD
     Build-Depends: unix
                    , hashable


### PR DESCRIPTION
On Debian GNU/kFreeBSD (FreeBSD kernel plus glibc), the BSD flavour of
sendfile is not usable, but Cabal treats kfreebsdgnu as os(freebsd) so I
had to add a flag to simple-sendfile.cabal to make it possible to select
the fallback implementation.  See
https://github.com/kazu-yamamoto/simple-sendfile/pull/13 for more
details.

warp.cabal reflects the availability of interfaces from simple-sendfile,
and so I believe it needs a matching flag to make it possible to
forcibly disable the use of -DSENDFILEFD.
