### PR TITLE
Switch to cryptohash-cryptoapi

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Embedded.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded.hs
@@ -15,7 +15,8 @@ import Data.Function (on)
 import qualified Data.Text as T
 import Data.Ord
 import qualified Data.ByteString as S
-import qualified Crypto.Hash.MD5 as MD5
+import qualified Crypto.Classes as CR
+import Crypto.Hash.CryptoAPI (hash', MD5)
 import qualified Data.ByteString.Base64 as B64
 import WaiAppStatic.Storage.Filesystem (defaultFileServerSettings)
 
@@ -89,4 +90,4 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
-runHash = B64.encode . MD5.hash
+runHash = B64.encode . CR.encode . (hash' :: S.ByteString -> MD5)

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -27,7 +27,7 @@ import System.PosixCompat.Files (fileSize, getFileStatus, modificationTime, isRe
 import Data.Maybe (catMaybes)
 import qualified Crypto.Conduit
 import Data.Serialize (encode)
-import Crypto.Hash.MD5 (MD5)
+import Crypto.Hash.CryptoAPI (MD5)
 import qualified Data.ByteString.Base64 as B64
 
 -- | Construct a new path from a root and some @Pieces@.

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -37,7 +37,8 @@ library
                    , text                      >= 0.7
                    , blaze-builder             >= 0.2.1.4
                    , base64-bytestring         >= 0.1
-                   , cryptohash                >= 0.7
+                   , crypto-api                >= 0.12.2
+                   , cryptohash-cryptoapi      >= 0.1.0
                    , system-filepath           >= 0.4
                    , system-fileio             >= 0.3
                    , http-date


### PR DESCRIPTION
Crypto.Hash.MD5 from cryptohash package  was deprecated for a while and
is now removed. Changed to use Crypto.Hash.CryptoAPI from
cryptohash-cryptoapi.
