### PR TITLE
Pass the Request to the exception handler

### DIFF
--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -140,7 +140,7 @@ runUrlPort port url app = do
     x <- newIORef True
     _ <- forkIO $ Warp.runSettings Warp.defaultSettings
         { Warp.settingsPort = port
-        , Warp.settingsOnException = const $ return ()
+        , Warp.settingsOnException = (\_ _ -> return ())
         , Warp.settingsHost = "*4"
         } $ ping x app
     launch port url

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -21,7 +21,7 @@ import System.IO.Error (ioeGetErrorType)
 data Settings = Settings
     { settingsPort :: Int -- ^ Port to listen on. Default value: 3000
     , settingsHost :: HostPreference -- ^ Default value: HostIPv4
-    , settingsOnException :: SomeException -> IO () -- ^ What to do with exceptions thrown by either the application or server. Default: ignore server-generated exceptions (see 'InvalidRequest') and print application-generated applications to stderr.
+    , settingsOnException :: Maybe Request -> SomeException -> IO () -- ^ What to do with exceptions thrown by either the application or server. Default: ignore server-generated exceptions (see 'InvalidRequest') and print application-generated applications to stderr.
     , settingsOnOpen :: IO () -- ^ What to do when a connection is open. Default: do nothing.
     , settingsOnClose :: IO ()  -- ^ What to do when a connection is close. Default: do nothing.
     , settingsTimeout :: Int -- ^ Timeout value in seconds. Default value: 30
@@ -67,8 +67,8 @@ defaultSettings = Settings
     , settingsServerName = S8.pack $ "Warp/" ++ warpVersion
     }
 
-defaultExceptionHandler :: SomeException -> IO ()
-defaultExceptionHandler e = throwIO e `catches` handlers
+defaultExceptionHandler :: Maybe Request -> SomeException -> IO ()
+defaultExceptionHandler _ e = throwIO e `catches` handlers
   where
     handlers = [Handler ah, Handler ih, Handler oh, Handler sh]
 

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -118,7 +118,7 @@ runTerminateTest :: InvalidRequest
 runTerminateTest expected input = do
     ref <- I.newIORef Nothing
     withApp defaultSettings
-      { settingsOnException = \e -> I.writeIORef ref $ Just e
+      { settingsOnException = \_ e -> I.writeIORef ref $ Just e
       } dummyApp $ \port -> do
         handle <- connectTo "127.0.0.1" $ PortNumber $ fromIntegral port
         hPutStr handle input


### PR DESCRIPTION
We change the exception handler to take Maybe Request, because some
exceptions will happen before we have managed to parse a Request yet.

Add an exception handler to everything just after the Request is parsed
that does pass the Request through.

This allows the exception handler to give more useful data to the
application developer.

Closes #173
