### PR TITLE
cleaning up the types of Connection.

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -40,15 +40,15 @@ module Network.Wai.Handler.Warp (
   , HostPreference (..)
   , Port
   , InvalidRequest (..)
+  , ConnSendFileOverride (..)
     -- * Connection
   , Connection (..)
   , socketConnection
     -- * Internal
     -- ** Time out manager
   , module Network.Wai.Handler.Warp.Timeout
-    -- ** Cleaner
+    -- ** Data types
   , Cleaner
-  , dummyCleaner
     -- ** Request and response
   , parseRequest
   , sendResponse

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -86,7 +86,7 @@ sendResponse settings cleaner req conn restore (ResponseFile s0 hs0 path mpart0)
     sendResponse' (Right (s, lengthyHeaders, beg, end))
       | hasBody s req = liftIO $ do
           lheader <- composeHeader settings version s lengthyHeaders
-          connSendFile conn path beg end (T.tickle th) [lheader] cleaner
+          connSendFile conn path beg end (T.tickle th) [lheader]
           T.tickle th
           return isPersist
       | otherwise = liftIO $ do

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+
+module Network.Wai.Handler.Warp.SendFile where
+
+import Data.ByteString (ByteString)
+import Network.Sendfile
+import Network.Socket (Socket)
+import qualified Network.Wai.Handler.Warp.FdCache as F
+import Network.Wai.Handler.Warp.Types
+
+defaultSendFile :: Socket -> FilePath -> Integer -> Integer -> IO () -> [ByteString] -> IO ()
+defaultSendFile s path off len act hdr = sendfileWithHeader s path (PartOfFile off len) act hdr
+
+
+#if SENDFILEFD
+setSendFile :: Connection -> Maybe F.MutableFdCache -> Connection
+setSendFile conn Nothing    = conn
+setSendFile conn (Just fdc) = case connSendFileOverride conn of
+    NotOverride -> conn
+    Override s  -> conn { connSendFile = sendFile fdc s }
+
+sendFile :: F.MutableFdCache -> Socket -> FilePath -> Integer -> Integer -> IO () -> [ByteString] -> IO ()
+sendFile fdc s path off len act hdr = do
+    (fd, fresher) <- F.getFd fdc path
+    sendfileFdWithHeader s fd (PartOfFile off len) (act>>fresher) hdr
+#else
+setSendFile :: Connection -> Maybe F.MutableFdCache -> Connection
+setSendFile conn _ = conn
+#endif

--- a/warp/Network/Wai/Handler/Warp/Timeout.hs
+++ b/warp/Network/Wai/Handler/Warp/Timeout.hs
@@ -26,7 +26,6 @@ module Network.Wai.Handler.Warp.Timeout (
     Manager
   , TimeoutAction
   , Handle
-  , dummyHandle
   -- * Manager
   , initialize
   , stopManager
@@ -55,7 +54,6 @@ import Control.Monad (forever, void)
 import Data.IORef (IORef)
 import qualified Data.IORef as I
 import Data.Typeable (Typeable)
-import System.IO.Unsafe (unsafePerformIO)
 import System.Mem.Weak (deRefWeak)
 
 ----------------------------------------------------------------
@@ -73,12 +71,6 @@ data State = Active    -- Manager turns it to Inactive.
            | Inactive  -- Manager removes it with timeout action.
            | Paused    -- Manager does not change it.
            | Canceled  -- Manager removes it without timeout action.
-
-----------------------------------------------------------------
-
--- | A dummy @Handle@.
-dummyHandle :: Handle
-dummyHandle = Handle (return ()) (unsafePerformIO $ I.newIORef Active)
 
 ----------------------------------------------------------------
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -61,6 +61,7 @@ Library
                      Network.Wai.Handler.Warp.Response
                      Network.Wai.Handler.Warp.ResponseHeader
                      Network.Wai.Handler.Warp.Run
+                     Network.Wai.Handler.Warp.SendFile
                      Network.Wai.Handler.Warp.Settings
                      Network.Wai.Handler.Warp.Types
                      Paths_warp


### PR DESCRIPTION
When I was brushing up documentation, I noticed that the signature of `connSendFile` have `Cleaner`, which is internal information. Due to this, we need to prepare `dummyXXX`. It was me who introduced `Cleaner` to `connSendFile` and I admit that it's ugly.

To fix this, I introduce one more field `connSendFileOverride`. This holds `Socket` and suggests `connSendFile` can be overridden. I think this API is cleaner than before.

@snoyberg I would like to ask two things:
- Please review this patch and give a look at haddock documentation.  If you agree with this change, please merge.
- `Cleaner` is not proper name anymore. `InternalInfo`, for instance, is much better. Do you agree with this change. Of course, suggestions on more proper naming would be appreiciated.
