### PR TITLE
Server settings now gives the user the chance to chose the ciphers and tls version

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -71,7 +71,10 @@ data TLSSettings = TLSSettings
       -- ^ The TLS versions this server accepts.
       --
       -- Default: '[TLS.SSL3,TLS.TLS10,TLS.TLS11,TLS.TLS12]'.
+    , tlsCiphers :: [TLS.Cipher]
+      -- ^ The TLS ciphers this server accepts.
       --
+      -- Default: '[TLSExtra.cipher_AES128_SHA1, TLSExtra.cipher_AES256_SHA1, TLSExtra.cipher_RC4_128_MD5, TLSExtra.cipher_RC4_128_SHA1]'
     }
 
 -- | An action when a plain HTTP comes to HTTP over TLS/SSL port.
@@ -95,6 +98,7 @@ defaultTlsSettings = TLSSettings
     , onInsecure = DenyInsecure "This server only accepts secure HTTPS connections."
     , tlsLogging = TLS.defaultLogging
     , tlsAllowedVersions = [TLS.SSL3,TLS.TLS10,TLS.TLS11,TLS.TLS12]
+    , tlsCiphers = ciphers
     }
 
 -- | Running 'Application' with 'TLSSettings' and 'Settings' using
@@ -108,7 +112,7 @@ runTLSSocket TLSSettings {..} set sock app = do
                 (\sp -> sp { TLS.serverWantClientCert = False }) $
             TLS.defaultParamsServer
             { TLS.pAllowedVersions = tlsAllowedVersions
-            , TLS.pCiphers         = ciphers
+            , TLS.pCiphers         = tlsCiphers
             , TLS.pCertificates    = zip certs $ (Just pk):repeat Nothing
             , TLS.pLogging         = tlsLogging
             }


### PR DESCRIPTION
This patch allows a user to specify which TLS versions the warp server allows and the ciphers supported. 
This can be important if either doing an app that specifically targets only the newest browsers with 1.2 support and/or requires the extra security given by the ciphers supported by this version and/or needs to run with specific support for a certain cipher.
