### PR TITLE
Using a connection buffer to send RspBuilder.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -7,9 +7,10 @@ import Foreign.Marshal.Alloc (mallocBytes, free)
 import Foreign.Ptr (Ptr, plusPtr)
 
 type Buffer = Ptr Word8
+type BufSize = Int
 
 -- FIXME come up with good values here
-bufferSize :: Int
+bufferSize :: BufSize
 bufferSize = 4096
 
 allocateBuffer :: Int -> IO Buffer
@@ -18,7 +19,7 @@ allocateBuffer = mallocBytes
 freeBuffer :: Buffer -> IO ()
 freeBuffer = free
 
-toBlazeBuffer :: Buffer -> Int -> IO B.Buffer
+toBlazeBuffer :: Buffer -> BufSize -> IO B.Buffer
 toBlazeBuffer ptr size = do
     fptr <- newForeignPtr_ ptr
     return $ B.Buffer fptr ptr ptr (ptr `plusPtr` size)

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Network.Wai.Handler.Warp.IO where
+
+import Blaze.ByteString.Builder.Internal.Types (Builder(..), BuildSignal(..), BufRange(..), runBuildStep, buildStep)
+import Data.ByteString.Internal (ByteString(..))
+import Foreign.ForeignPtr (newForeignPtr_)
+import Foreign.Ptr (plusPtr, minusPtr)
+import Network.Wai.Handler.Warp.Buffer
+
+toBufIOWith :: Buffer -> BufSize -> (ByteString -> IO ()) -> Builder -> IO ()
+toBufIOWith buf !size io (Builder build) = loop firstStep
+  where
+    firstStep = build (buildStep finalStep)
+    finalStep (BufRange p _) = return $ Done p ()
+    bufRange = BufRange buf (buf `plusPtr` size)
+    runIO ptr = toBS buf (ptr `minusPtr` buf) >>= io
+    loop step = do
+        signal <- runBuildStep step bufRange
+        case signal of
+             Done ptr _ -> runIO ptr
+             BufferFull minSize ptr next
+               | size < minSize -> error "toBufIOWith: BufferFull: minSize"
+               | otherwise      -> do
+                   runIO ptr
+                   loop next
+             InsertByteString ptr bs next -> do
+                 runIO ptr
+                 io bs
+                 loop next
+
+toBS :: Buffer -> Int -> IO ByteString
+toBS ptr siz = do
+    fptr <- newForeignPtr_ ptr
+    return $ PS fptr 0 siz

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -45,14 +45,14 @@ import Network.Socket (fdSocket)
 socketConnection :: Socket -> IO Connection
 socketConnection s = do
     buf <- allocateBuffer bufferSize
-    blazeBuf <- toBlazeBuffer buf bufferSize
     return Connection {
         connSendMany = Sock.sendMany s
       , connSendAll = Sock.sendAll s
       , connSendFile = defaultSendFile s
       , connClose = sClose s >> freeBuffer buf
       , connRecv = receive s buf bufferSize
-      , connBuffer = blazeBuf
+      , connBuffer = buf
+      , connBufferSize = bufferSize
       , connSendFileOverride = Override s
       }
 

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -9,10 +9,10 @@ import Data.ByteString (ByteString)
 import Data.Typeable (Typeable)
 import Network.HTTP.Types.Header
 import Network.Socket (Socket)
-import qualified Blaze.ByteString.Builder.Internal.Buffer as B (Buffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
 import qualified Network.Wai.Handler.Warp.Timeout as T
+import Network.Wai.Handler.Warp.Buffer (Buffer,BufSize)
 
 ----------------------------------------------------------------
 
@@ -66,7 +66,8 @@ data Connection = Connection
     , connSendFile :: FilePath -> Integer -> Integer -> IO () -> [ByteString] -> IO () -- ^ filepath, offset, length, hook action, HTTP headers
     , connClose    :: IO ()
     , connRecv     :: IO ByteString
-    , connBuffer   :: B.Buffer
+    , connBuffer           :: Buffer
+    , connBufferSize       :: BufSize
     , connSendFileOverride :: ConnSendFileOverride
     }
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -59,6 +59,7 @@ Library
                      Network.Wai.Handler.Warp.Date
                      Network.Wai.Handler.Warp.FdCache
                      Network.Wai.Handler.Warp.Header
+                     Network.Wai.Handler.Warp.IO
                      Network.Wai.Handler.Warp.IORef
                      Network.Wai.Handler.Warp.ReadInt
                      Network.Wai.Handler.Warp.Recv


### PR DESCRIPTION
This implements #206.

The type of `connBuffer` is now `Buffer.Buffer` (not blaze-builder's `Buffer`). I made this change because `RspBuilder` needs `Buffer.Buffer`.

Blaze-Builder's `Buffer` is created in `RspSource` on demand. It is possible to contain blaze-builder's `Buffer` to avoid the overhead of creation. But I think it is wise to make `Connection` independent from blaze-builder.

@snoyberg please review this.
