### PR TITLE
devel logger: Accept doesn't need its own line

### DIFF
--- a/wai-extra/test/WaiExtraTest.hs
+++ b/wai-extra/test/WaiExtraTest.hs
@@ -541,8 +541,8 @@ caseDebugRequestBody = do
   where
     params = [("foo", "bar"), ("baz", "bin")]
     -- FIXME change back once we include post parameter output in logging postOutput = T.pack $ "POST \nAccept: \nPOST " ++ (show params)
-    postOutput = T.pack $ "POST /\nAccept: \nStatus: 200 OK. /\n"
-    getOutput params' = T.pack $ "GET /location\nAccept: \nGET " ++ show params' ++ "\nStatus: 200 OK. /location\n"
+    postOutput = T.pack $ "POST / | \nStatus: 200 OK. /\n"
+    getOutput params' = T.pack $ "GET /location | \nGET " ++ show params' ++ "\nStatus: 200 OK. /location\n"
 
     debugApp output' req = do
         iactual <- liftIO $ I.newIORef mempty


### PR DESCRIPTION
GET /static/vendor/angularjs/angular-cookies.min.js
Accept: _/_

will now be

GET /static/vendor/angularjs/angular-cookies.min.js | _/_
