### PR TITLE
Auto-flush in 'Detailed' log format

### DIFF
--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -89,7 +89,9 @@ mkRequestLogger RequestLoggerSettings{..} = do
             getdate <- getDateGetter flusher
             apache <- initLogger ipsrc (LogCallback callback (return ())) getdate
             return $ apacheMiddleware apache
-        Detailed useColors -> detailedMiddleware callback useColors
+        Detailed useColors -> detailedMiddleware
+                                  (\str -> callback str >> flusher)
+                                  useColors
         CustomOutputFormat formatter -> do
             getdate <- getDateGetter flusher
             return $ customMiddleware callback getdate formatter

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             2.0.3.1
+Version:             2.0.3.2
 Synopsis:            Provides some basic WAI handlers and middleware.
 Description:         The goal here is to provide common features without many dependencies.
 License:             MIT


### PR DESCRIPTION
Even with wai-extra-2.0.3.1, the logging in "Detailed" format (eg yesod devel) is not flushed promptly. Not even as promptly as Apache or CustomOutputFormat!  This is about the simplest possible fix to improve it.

The criticism of this fix might be that it is too eager to flush, but I imagine Detailed logging is pretty exclusively used in development, where immediate flushing is desirable.  As far as I can see, anything else would require a configuration parameter to control flushing options.
