### PR TITLE
upgrade warp-tls to tls 1.2

### DIFF
--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -12,9 +12,6 @@ Cabal-Version:       >=1.6
 Stability:           Stable
 Description:         HTTP over SSL/TLS support for Warp via the TLS package.
 
-flag tls_1_1_3
-    default: True
-
 Library
   Build-Depends:     base                          >= 4        && < 5
                    , bytestring                    >= 0.9
@@ -23,20 +20,10 @@ Library
                    , transformers                  >= 0.2
                    , conduit                       >= 0.5      && < 1.1
                    , network-conduit               >= 0.6      && < 1.1
-                   , certificate                   >= 1.2
-                   , pem                           >= 0.1
-                   , cryptocipher                  >= 0.3
-                   , tls-extra                     >= 0.6
-                   , tls                           >= 1.1
-                   , crypto-random-api             >= 0.2
+                   , data-default-class            >= 0.0.1
+                   , tls                           >= 1.2
                    , network                       >= 2.2.1
-                   , cprng-aes                     >= 0.3.4
-  if flag(tls_1_1_3)
-      build-depends: tls >= 1.1.3
-                   , cprng-aes >= 0.5.0
-  else
-      build-depends: tls < 1.1.3
-                   , cprng-aes < 0.5.0
+                   , cprng-aes                     >= 0.5.0
   Exposed-modules:   Network.Wai.Handler.WarpTLS
   ghc-options:       -Wall
 


### PR DESCRIPTION
The pull request unconditionally upgrade dependencies to tls 1.2, and at the same time remove quite a bit of direct dependencies.

It's only compiled tested
