### PR TITLE
Replace crypto-conduit, crypto-api by simpler cryptohash and cryptohash-conduit

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -15,8 +15,8 @@ import Data.Function (on)
 import qualified Data.Text as T
 import Data.Ord
 import qualified Data.ByteString as S
-import qualified Crypto.Classes as CR
-import Crypto.Hash.CryptoAPI (hash', MD5)
+import Crypto.Hash (hash, MD5, Digest)
+import Data.Byteable (toBytes)
 import qualified Data.ByteString.Base64 as B64
 import WaiAppStatic.Storage.Filesystem (defaultFileServerSettings)
 import System.FilePath (isPathSeparator)
@@ -95,4 +95,4 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
-runHash = B64.encode . CR.encode . (hash' :: S.ByteString -> MD5)
+runHash = B64.encode . toBytes . (hash :: S.ByteString -> Digest MD5)

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -25,9 +25,9 @@ import WaiAppStatic.Listing
 import Network.Mime
 import System.PosixCompat.Files (fileSize, getFileStatus, modificationTime, isRegularFile)
 import Data.Maybe (catMaybes)
-import qualified Crypto.Conduit
-import Data.Serialize (encode)
-import Crypto.Hash.CryptoAPI (MD5)
+import qualified Crypto.Hash.Conduit (hashFile)
+import Data.Byteable (toBytes)
+import Crypto.Hash (MD5, Digest)
 import qualified Data.ByteString.Base64 as B64
 
 -- | Construct a new path from a root and some @Pieces@.
@@ -117,8 +117,8 @@ webAppLookup hashFunc prefix pieces =
 -- exists.
 hashFile :: FilePath -> IO ByteString
 hashFile fp = do
-    h <- Crypto.Conduit.hashFile (F.encodeString fp)
-    return $ B64.encode $ encode (h :: MD5)
+    h <- Crypto.Hash.Conduit.hashFile (F.encodeString fp)
+    return $ B64.encode $ toBytes (h :: Digest MD5)
 
 hashFileIfExists :: ETagLookup
 hashFileIfExists fp = do

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -37,15 +37,14 @@ library
                    , text                      >= 0.7
                    , blaze-builder             >= 0.2.1.4
                    , base64-bytestring         >= 0.1
-                   , crypto-api                >= 0.12.2
-                   , cryptohash-cryptoapi      >= 0.1.0
+                   , byteable
+                   , cryptohash                >= 0.11
+                   , cryptohash-conduit        >= 0.1.0
                    , system-filepath           >= 0.4
                    , system-fileio             >= 0.3
                    , http-date
                    , blaze-html                >= 0.5
                    , blaze-markup              >= 0.5.1
-                   , crypto-conduit            >= 0.4
-                   , cereal                    >= 0.3.5
                    , mime-types                >= 0.1      && < 0.2
                    , unordered-containers      >= 0.2
                    , template-haskell          >= 2.7


### PR DESCRIPTION
Simplified dependencies of wai-app-static using the new cryptohash-conduit.
