### PR TITLE
Data.Conduit.Lazy disappeared with 1.1.0!

### DIFF
--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -20,7 +20,7 @@ Library
   Build-Depends:     base                      >= 4        && < 5
                    , bytestring                >= 0.9.1.4
                    , blaze-builder             >= 0.2.1.4  && < 0.4
-                   , conduit                   >= 1.0.8    && < 1.2
+                   , conduit                   >= 1.0.8    && < 1.1
                    , conduit-extra
                    , network                   >= 2.2.1.5
                    , http-types                >= 0.7


### PR DESCRIPTION
I haven't looked deeply into your redesign of conduit, however, the build is currently failing without Data.Conduit.Lazy in conduit-1.1.0. Hope you're doing well! Keep kickin' ass, Snoyman!!!
