### PR TITLE
Export tlsAllowedVersions and tlsCiphers.

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -13,6 +13,8 @@ module Network.Wai.Handler.WarpTLS (
     , keyFile
     , onInsecure
     , tlsLogging
+    , tlsAllowedVersions
+    , tlsCiphers
     , defaultTlsSettings
     , tlsSettings
     , OnInsecure (..)


### PR DESCRIPTION
In #200,  tlsAllowedVersions and tlsCiphers are added to TLSSettings, but both of them are not expoted from Network.Wai.Handler.WarpTLS module.
This patch exports them.
