### PR TITLE
Made runSettingsSocket call interruptible on Windows.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Recv.hs
+++ b/warp/Network/Wai/Handler/Warp/Recv.hs
@@ -21,6 +21,7 @@ import Network.Wai.Handler.Warp.Buffer
 
 #ifdef mingw32_HOST_OS
 import GHC.IO.FD (FD(..), readRawBufferPtr)
+import Network.Wai.Handler.Warp.Windows
 #endif
 
 ----------------------------------------------------------------
@@ -47,7 +48,7 @@ receiveloop :: CInt -> Ptr CChar -> CSize -> IO CInt
 #endif
 receiveloop sock buf size = do
 #ifdef mingw32_HOST_OS
-    bytes <- fmap fromIntegral $ readRawBufferPtr "recv" (FD sock 1) buf 0 size
+    bytes <- windowsThreadBlockHack $ fmap fromIntegral $ readRawBufferPtr "recv" (FD sock 1) buf 0 size
 #else
     bytes <- c_recv sock buf size 0
 #endif

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -40,8 +40,7 @@ import Network.Wai.Handler.Warp.Types
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 
 #if WINDOWS
-import qualified Control.Concurrent.MVar as MV
-import Control.Concurrent (forkIO)
+import Network.Wai.Handler.Warp.Windows
 #else
 import System.Posix.IO (FdOption(CloseOnExec), setFdOption)
 import Network.Socket (fdSocket)
@@ -83,18 +82,6 @@ runSettings set app = withSocketsDo $
         (\socket -> do
             setSocketCloseOnExec socket
             runSettingsSocket set socket app)
-
-#if WINDOWS
-windowsThreadBlockHack :: IO a -> IO a
-windowsThreadBlockHack act = 
-  do
-    var <- MV.newEmptyMVar :: IO (MV.MVar (Either SomeException a))
-    void . forkIO $ E.try act >>= MV.putMVar var
-    res <- MV.takeMVar var
-    case res of
-      Left  e -> throwIO e
-      Right r -> return r
-#endif
 
 -- | Same as 'runSettings', but uses a user-supplied socket instead of opening
 -- one. This allows the user to provide, for example, Unix named socket, which

--- a/warp/Network/Wai/Handler/Warp/Windows.hs
+++ b/warp/Network/Wai/Handler/Warp/Windows.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE CPP #-}
+module Network.Wai.Handler.Warp.Windows
+  ( windowsThreadBlockHack
+  ) where
+
+#if WINDOWS
+import Control.Exception
+import Control.Concurrent.MVar
+import Control.Concurrent
+import Control.Monad
+
+windowsThreadBlockHack :: IO a -> IO a
+windowsThreadBlockHack act = 
+  do
+    var <- newEmptyMVar :: IO (MVar (Either SomeException a))
+    void . forkIO $ try act >>= putMVar var
+    res <- takeMVar var
+    case res of
+      Left  e -> throwIO e
+      Right r -> return r
+#else
+windowsThreadBlockHack :: IO a -> IO a
+windowsThreadBlockHack = id
+#endif

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -81,6 +81,7 @@ Library
                      Network.Wai.Handler.Warp.Settings
                      Network.Wai.Handler.Warp.Thread
                      Network.Wai.Handler.Warp.Types
+                     Network.Wai.Handler.Warp.Windows
                      Paths_warp
   Ghc-Options:       -Wall
 


### PR DESCRIPTION
This addresses issue #129 regarding runSettings thread becoming uninterruptible. I've used a simple MVar hack to make a runSettingsSocket function interruptible and removed #if WINDOWS block as proposed by joeyadams.
