### PR TITLE
Fix wai-websockets.cabal

### DIFF
--- a/wai-websockets/wai-websockets.cabal
+++ b/wai-websockets/wai-websockets.cabal
@@ -34,9 +34,7 @@ Library
 Executable           wai-websockets-example
   if flag(example)
     buildable: True
-  else
-    buildable: False
-  Build-Depends:     base               >= 3 && < 5
+    Build-Depends:   base               >= 3 && < 5
                    , conduit
                    , wai-websockets
                    , websockets
@@ -52,6 +50,8 @@ Executable           wai-websockets-example
                    , file-embed
                    , io-streams
                    , http-types
+  else
+    buildable: False
 
   ghc-options:       -Wall -threaded
   main-is:           server.lhs


### PR DESCRIPTION
The build-depends would still be effective if they are not part of the `if`.
