### PR TITLE
[wai-app-static] Provide sample.hs for actual wai-app-static

### DIFF
--- a/wai-app-static/sample.hs
+++ b/wai-app-static/sample.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE OverloadedStrings #-}
-import Network.Wai.Application.Static
-import Network.Wai.Handler.Warp (run)
 
+import Data.String
+import Data.Text (pack)
+import Data.Maybe (mapMaybe)
+import WaiAppStatic.Types (ssIndices, toPiece)
+import Network.Wai.Application.Static (staticApp,defaultFileServerSettings)
+import Network.Wai.Handler.Warp (runSettings, settingsPort, defaultSettings)
+  
 main :: IO ()
-main = run 3000 $ staticApp defaultWebAppSettings
-    { ssLookupFile = fileSystemLookup "."
-    , ssMaxAge = MaxAgeForever
-    , ssIndices = []
-    , ssListing = Just defaultListing
+main = runSettings defaultSettings
+    {
+        settingsPort = 3000
+    } $ staticApp (defaultFileServerSettings $ fromString ".")
+    {
+      ssIndices = mapMaybe (toPiece . pack) ["index.html"]
     }


### PR DESCRIPTION
Hello All,

I tried to use example from `wai-app-static` but got some problems with it. Actually there are no `fileSystemLookup` in `Network.Wai.Application.Static`, `ssMaxAge` now is in `WaiAppStatic.Types` and etc...

Here is working version of example with the current wai from master.
