### PR TITLE
Fix wai-extra dependency to wai-3.0.1

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -22,7 +22,7 @@ extra-source-files:
 Library
   Build-Depends:     base                      >= 4 && < 5
                    , bytestring                >= 0.9.1.4
-                   , wai                       >= 3.0      && < 3.1
+                   , wai                       >= 3.0.1    && < 3.1
                    , old-locale                >= 1.0.0.2  && < 1.1
                    , time                      >= 1.1.4
                    , network                   >= 2.2.1.5


### PR DESCRIPTION
Build of Network.Wai.EventSource would fail on wai-3.0.0?
