### PR TITLE
auto-update: Fix build failure with GHC 7.4.2

### DIFF
--- a/auto-update/Control/AutoUpdate/Util.hs
+++ b/auto-update/Control/AutoUpdate/Util.hs
@@ -10,7 +10,7 @@ module Control.AutoUpdate.Util
 #if MIN_VERSION_base(4,6,0)
 import           Data.IORef         (atomicModifyIORef')
 #else
-import           Data.IORef         (atomicModifyIORef)
+import           Data.IORef         (IORef, atomicModifyIORef)
 -- | Strict version of 'atomicModifyIORef'.  This forces both the value stored
 -- in the 'IORef' as well as the value returned.
 atomicModifyIORef' :: IORef a -> (a -> (a,b)) -> IO b


### PR DESCRIPTION
The auto-update 0.1.1.0 failed to install with GHC 7.4.2. A build log is as below:

```
Building auto-update-0.1.1.0...
Preprocessing library auto-update-0.1.1.0...
[1 of 3] Compiling Control.AutoUpdate.Util ( Control/AutoUpdate/Util.hs, dist/build/Control/AutoUpdate/Util.o )

Control/AutoUpdate/Util.hs:16:23:
    Not in scope: type constructor or class `IORef'
```
