### PR TITLE
Restrict optparse-applicative below version 0.10.0

### DIFF
--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -50,7 +50,7 @@ library
                    , zlib                      >= 0.5
                    , filepath
                    , wai-extra                 >= 3.0      && < 3.1
-                   , optparse-applicative      >= 0.7
+                   , optparse-applicative      >= 0.7      && < 0.10.0
                    , warp                      >= 3.0      && < 3.1
                    -- Used exclusively for hashFile function
                    , cryptohash-conduit


### PR DESCRIPTION
optparse-applicative v0.10 (at commit 9091b11) changes the type of
Options.Applicative.Builder.option.
