### PR TITLE
#290, add a Show instance for Request. Things which can't be shown are shown as their type.

### DIFF
--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 -- | Internal constructors and helper functions. Note that no guarantees are
 -- given for stability of these interfaces.
 module Network.Wai.Internal where
@@ -14,6 +15,7 @@ import Data.Vault.Lazy (Vault)
 import           Data.Word                    (Word64)
 import qualified Network.HTTP.Types           as H
 import           Network.Socket               (SockAddr)
+import           Data.List                    (intercalate)
 
 -- | Information on the request sent by the client. This abstracts away the
 -- details of the underlying implementation.
@@ -71,6 +73,27 @@ data Request = Request {
   }
   deriving (Typeable)
 
+instance Show Request where
+    show Request{..} = "Request {" ++ intercalate ", " [a ++ " = " ++ b | (a,b) <- fields] ++ "}"
+        where
+            fields =
+                [("requestMethod",show requestMethod)
+                ,("httpVersion",show httpVersion)
+                ,("rawPathInfo",show rawPathInfo)
+                ,("rawQueryString",show rawQueryString)
+                ,("requestHeaders",show requestHeaders)
+                ,("isSecure",show isSecure)
+                ,("remoteHost",show remoteHost)
+                ,("pathInfo",show pathInfo)
+                ,("queryString",show queryString)
+                ,("requestBody","<IO ByteString>")
+                ,("vault","<Vault>")
+                ,("requestBodyLength",show requestBodyLength)
+                ,("requestHeaderHost",show requestHeaderHost)
+                ,("requestHeaderRange",show requestHeaderRange)
+                ]
+
+
 data Response
     = ResponseFile H.Status H.ResponseHeaders FilePath (Maybe FilePart)
     | ResponseBuilder H.Status H.ResponseHeaders Builder
@@ -90,7 +113,7 @@ type StreamingBody = (Builder -> IO ()) -> IO () -> IO ()
 -- not be known.
 --
 -- Since 1.4.0
-data RequestBodyLength = ChunkedBody | KnownLength Word64
+data RequestBodyLength = ChunkedBody | KnownLength Word64 deriving Show
 
 -- | Information on which part to be sent.
 --   Sophisticated application handles Range (and If-Range) then


### PR DESCRIPTION
With this change:

```
*Network.Wai> show defaultRequest
"Request {requestMethod = \"GET\", httpVersion = HTTP/1.0, rawPathInfo = \"\", r
awQueryString = \"\", requestHeaders = [], isSecure = False, remoteHost = 0.0.0.
0:0, pathInfo = [], queryString = [], requestBody = <IO ByteString>, vault = <Va
ult>, requestBodyLength = KnownLength 0, requestHeaderHost = Nothing, requestHea
derRange = Nothing}"
```

Note that now determined (and evil) users can pull fields out without going through the accessors. However, that's a real pain, so people probably won't bother, and if they do having their code break seems a reasonable result.
