### PR TITLE
Add defaultAuthSettings and export AuthSettings data constructor.

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.2.1
+Version:             3.0.2.2
 Synopsis:            Provides some basic WAI handlers and middleware.
 Description:         The goal here is to provide common features without many dependencies.
 License:             MIT


### PR DESCRIPTION
I didn't want to use the recommended method of creating AuthSettings by using a string literal, but it seemed that was actually the only way.  This PR exports the AuthSettings data constructor and a defaultAuthSettings value so that AuthSettings can be created manually.  

I'm not sure if this is desirable for anyone else, but I don't see any reason to prevent people from doing this.  If I'm missing something, please let me know.  I also wasn't sure what I should do to the wai-extra version number for something like this, let me know if I should have bumped number C instead of D or something else entirely.

Unrelated to this PR, but I wanted to note that I had some trouble realizing an http-basic middleware existed because wai-extra's description is vague on hackage and it's bundled with many other things.  I think it'd be useful to list capabilities in the package description instead of "Provides some basic WAI handlers and middleware" or perhaps break this package up.  Thoughts?