### PR TITLE
WAI middleware that converts a ResponseFile into ResponseStream.

### DIFF
--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -3,16 +3,10 @@
 module Network.Wai.Middleware.StreamFile
     (streamFile) where
 
-import Network.Wai
+import Network.Wai (responseStream)
 import Network.Wai.Internal
 import Network.Wai (Middleware, responseToStream)
-import Network.HTTP.Types (Status, ResponseHeaders)
 import qualified Data.ByteString.Char8 as S8
-import qualified Data.ByteString as S
-import qualified Data.Streaming.Blaze as B
-import qualified Blaze.ByteString.Builder as Blaze
-import Control.Monad (unless)
-import Data.Function (fix)
 import System.Posix
 
 -- |Convert ResponseFile type responses into ResponseStream type

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Network.Wai.Middleware.StreamFile where
+module Network.Wai.Middleware.StreamFile
+    (streamFile) where
 
 import Network.Wai
 import Network.Wai.Internal

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -15,6 +15,17 @@ import Control.Monad (unless)
 import Data.Function (fix)
 import System.Posix
 
+-- |Convert ResponseFile type responses into ResponseStream type
+--
+-- Checks the response type, and if it's a ResponseFile, converts it
+-- into a ResponseStream. Other response types are passed through
+-- unchanged.
+--
+-- Converted responses get a Content-Length header.
+--
+-- Streaming a file will bypass a sendfile system call, and may be
+-- useful to work around systems without working sendfile
+-- implementations.
 streamFile :: Middleware
 streamFile app env sendResponse = app env $ \res ->
     case res of

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Wai.Middleware.StreamFile where
+
+import Network.Wai
+import Network.Wai.Internal
+import Network.Wai (Middleware, responseToStream)
+import Network.HTTP.Types (Status, ResponseHeaders)
+import qualified Data.ByteString.Char8 as S8
+import qualified Data.ByteString as S
+import qualified Data.Streaming.Blaze as B
+import qualified Blaze.ByteString.Builder as Blaze
+import Control.Monad (unless)
+import Data.Function (fix)
+import System.Posix
+
+streamFile :: Middleware
+streamFile app env sendResponse = app env $ \res ->
+    case res of
+      ResponseFile _ _ fp _ -> withBody sendBody
+          where
+            (s, hs, withBody) = responseToStream res
+            sendBody :: StreamingBody -> IO ResponseReceived
+            sendBody body = do
+               len <- getFileSize fp
+               let hs' = ("Content-Length", (S8.pack (show len))) : hs
+               sendResponse $ responseStream s hs' body
+      _ -> sendResponse res
+
+getFileSize :: FilePath -> IO FileOffset
+getFileSize path = do
+    stat <- getFileStatus path
+    return (fileSize stat)

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -59,6 +59,7 @@ spec = do
     it "accept override" caseAcceptOverride
     it "debug request body" caseDebugRequestBody
     it "stream file" caseStreamFile
+    it "stream LBS" caseStreamLBS
 
 toRequest :: S8.ByteString -> S8.ByteString -> SRequest
 toRequest ctype content = SRequest defaultRequest
@@ -434,3 +435,14 @@ caseStreamFile = flip runSession streamFileApp $ do
     assertStatus 200 sres
     assertBodyContains "caseStreamFile" sres
     assertNoHeader "Transfer-Encoding" sres
+
+streamLBSApp :: Application
+streamLBSApp = streamFile $ \_ f -> f $ responseLBS status200
+    [("Content-Type", "text/plain")]
+    "test"
+
+caseStreamLBS :: Assertion
+caseStreamLBS = flip runSession streamLBSApp $ do
+    sres <- request defaultRequest
+    assertStatus 200 sres
+    assertBody "test" sres

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -432,4 +432,5 @@ caseStreamFile :: Assertion
 caseStreamFile = flip runSession streamFileApp $ do
     sres <- request defaultRequest
     assertStatus 200 sres
+    assertBodyContains "caseStreamFile" sres
     assertNoHeader "Transfer-Encoding" sres

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -25,6 +25,7 @@ import Network.Wai.Middleware.MethodOverridePost
 import Network.Wai.Middleware.AcceptOverride
 import Network.Wai.Middleware.RequestLogger
 import Codec.Compression.GZip (decompress)
+import Network.Wai.Middleware.StreamFile
 
 import Control.Monad.IO.Class (liftIO)
 import Data.Maybe (fromMaybe)
@@ -57,6 +58,7 @@ spec = do
     it "method override post" caseMethodOverridePost
     it "accept override" caseAcceptOverride
     it "debug request body" caseDebugRequestBody
+    it "stream file" caseStreamFile
 
 toRequest :: S8.ByteString -> S8.ByteString -> SRequest
 toRequest ctype content = SRequest defaultRequest
@@ -419,3 +421,15 @@ casesUrlMap = [pair1, pair2, pair3, pair4]
   pair4 = makePair "should 404 if none match" $ do
     res4 <- get "/api/v3"
     assertStatus 404 res4
+
+testFile :: FilePath
+testFile = "test/WaiExtraSpec.hs"
+
+streamFileApp :: Application
+streamFileApp = streamFile $ \_ f -> f $ responseFile status200 [] testFile Nothing
+
+caseStreamFile :: Assertion
+caseStreamFile = flip runSession streamFileApp $ do
+    sres <- request defaultRequest
+    assertStatus 200 sres
+    assertNoHeader "Transfer-Encoding" sres

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -66,6 +66,7 @@ Library
                      Network.Wai.Middleware.Rewrite
                      Network.Wai.Middleware.Vhost
                      Network.Wai.Middleware.HttpAuth
+                     Network.Wai.Middleware.StreamFile
                      Network.Wai.Parse
                      Network.Wai.UrlMap
                      Network.Wai.Test


### PR DESCRIPTION
Code and a simple test case.

I had a hard time figuring out a good test case, since the whole point is to make file responses look like file responses despite being a stream internally. I did add a couple to make sure it's not completely broken at least.

In response to issue #315 .