### PR TITLE
Fix some warp comment typos

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -122,7 +122,7 @@ setHost x y = y { settingsHost = x }
 
 -- | What to do with exceptions thrown by either the application or server.
 -- Default: ignore server-generated exceptions (see 'InvalidRequest') and print
--- application-generated applications to stderr.
+-- application-generated exceptions to stderr.
 --
 -- Since 2.1.0
 setOnException :: (Maybe Request -> SomeException -> IO ()) -> Settings -> Settings

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -89,7 +89,7 @@ runSettings set app = withSocketsDo $
 -- 'serverPort' record.
 --
 -- When the listen socket in the second argument is closed, all live
--- connections are gracefully shut-downed.
+-- connections are gracefully shut down.
 runSettingsSocket :: Settings -> Socket -> Application -> IO ()
 runSettingsSocket set socket app = do
     settingsInstallShutdownHandler set closeListenSocket
@@ -259,7 +259,7 @@ fork set mkConn addr app dc fc tm counter = settingsFork set $ \ unmask ->
        bracket (onOpen addr) (onClose addr) $ \goingon ->
 
        -- Actually serve this connection.
-       -- onnClose above ensures the termination of the connection.
+       -- bracket with closeConn above ensures the connection is closed.
        when goingon $ serveConnection conn ii addr isSecure' set app
   where
     closeConn (conn, _isSecure) = connClose conn


### PR DESCRIPTION
I found a couple of typos/errors while reading through the source. I think the `connClose/closeConn` code has changed since the comment was written, so I'm not sure what's best, but it's definitely not "onnClose". There's also a user-supplied function called `onClose` which someone might think the comment is referring to.