### PR TITLE
Make sure Timer is tickled in sendfile.

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -222,7 +222,7 @@ httpOverTls TLSSettings{..} s cachedRef params = do
       , connBufferSize       = bufferSize
       }
       where
-        sendfile fp offset len _th headers = do
+        sendfile fp offset len tickle headers = do
             TLS.sendData ctx $ L.fromChunks headers
             IO.withBinaryFile fp IO.ReadMode $ \h -> do
                 IO.hSeek h IO.AbsoluteSeek offset
@@ -234,6 +234,7 @@ httpOverTls TLSSettings{..} s cachedRef params = do
                 unless (B.null bs) $ do
                     let x = B.take remaining bs
                     TLS.sendData ctx $ L.fromChunks [x]
+                    tickle -- This tickles the Timer.  It MUST be called per chunk.
                     loop h $ remaining - B.length x
 
         close = freeBuffer readBuf `finally`


### PR DESCRIPTION
Without this, if it takes longer than 60 seconds to send a file (though it should be 30 seconds...), the connection will be dropped.