### PR TITLE
Pass the Request to settingsOnException handlers when available.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -339,6 +339,13 @@ serveConnection conn ii origAddr isSecure' settings app = do
     recvSendLoop addr istatus fromClient = do
         (req', mremainingRef, idxhdr) <- recvRequest settings conn ii addr fromClient
         let req = req' { isSecure = isSecure' }
+        processRequest addr istatus fromClient req mremainingRef idxhdr
+            `catch` \e -> do
+                -- Call the user-supplied exception handlers, passing the request.
+                sendErrorResponse addr istatus e
+                onE settings (Just req) e
+
+    processRequest addr istatus fromClient req mremainingRef idxhdr = do
         -- Let the application run for as long as it wants
         T.pause th
 


### PR DESCRIPTION
This PR tries to address what looks like a regression. At one point the `Maybe Request` argument was added to the `settingsOnException` handler and the `Request` passed along [1]. The related ticket was https://github.com/yesodweb/wai/issues/173. Only a couple of commits later the relevant line of code got lost [2]. As a result, it seems as if the `Maybe Request` argument is actually never passed a request, which is unfortunate.

[1] https://github.com/yesodweb/wai/commit/b2fa01e715b0703676e819f73db7a84ad451c9b7#diff-39726960319491135a952279b66943f2R249
[2] https://github.com/yesodweb/wai/commit/67a0bf58f0aaea3e68a13b05c9fe479352b67ccd#diff-39726960319491135a952279b66943f2L245