### PR TITLE
wai-handler-launch cannot be loaded dynamically on 64 bit Windows

### DIFF
--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -25,7 +25,7 @@ Library
     if os(windows)
         c-sources: windows.c
         cpp-options: -DWINDOWS
-        extra-libraries: Shell32
+        extra-libraries: Shell32 msvcrt
     else
         build-depends: process >= 1.0 && < 1.3
         if os(darwin)

--- a/wai-handler-launch/windows.c
+++ b/wai-handler-launch/windows.c
@@ -6,7 +6,7 @@ void launch(int port, char *s)
 {
     int len = 8 + strlen("http://127.0.0.1:") + strlen(s);
     char *buff = malloc(len);
-    snprintf(buff, len, "http://127.0.0.1:%d/%s", port, s);
+    _snprintf(buff, len, "http://127.0.0.1:%d/%s", port, s);
     ShellExecute(NULL, "open", buff, NULL, NULL, SW_SHOWNORMAL);
     free(buff);
 }


### PR DESCRIPTION
Fixes #329.

This is the same issue as [jystic/unix-compat/PR11](https://github.com/jystic/unix-compat/pull/12), as pointed out by @snoyberg, fixed in the same way.

See also the [explanation on the café](https://www.haskell.org/pipermail/haskell-cafe/2014-June/114621.html) by the author of that PR.