### PR TITLE
Add additional DHE RSA and DSA ciphers to warp-tls default ciphers list.

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.1.4
+
+Add additional Diffie-Hellman RSA and DSA ciphers to warp-tls.
+
 ## 3.0.1.3
 
 [Unable to allow insecure connections with warp-tls #324](https://github.com/yesodweb/wai/issues/324)

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -99,7 +99,15 @@ defaultTlsSettings = TLSSettings {
 -- taken from stunnel example in tls-extra
 ciphers :: [TLS.Cipher]
 ciphers =
-    [ TLSExtra.cipher_AES128_SHA1
+    [
+      TLSExtra.cipher_DHE_RSA_AES256_SHA256
+    , TLSExtra.cipher_DHE_RSA_AES128_SHA256
+    , TLSExtra.cipher_DHE_RSA_AES256_SHA1
+    , TLSExtra.cipher_DHE_RSA_AES128_SHA1
+    , TLSExtra.cipher_DHE_DSS_AES128_SHA1
+    , TLSExtra.cipher_DHE_DSS_AES256_SHA1
+    , TLSExtra.cipher_DHE_DSS_RC4_SHA1
+    , TLSExtra.cipher_AES128_SHA1
     , TLSExtra.cipher_AES256_SHA1
     , TLSExtra.cipher_RC4_128_MD5
     , TLSExtra.cipher_RC4_128_SHA1

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.0.1.3
+Version:             3.0.1.4
 Synopsis:            HTTP over SSL/TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
I was debugging TLS some tls related issues in Keter and noticed some potentially useful ciphers could be added to the `warp-tls` ciphers list.

The ciphers list in the Stunnel example from `hs-tls` has also been updated since the warp function was written: https://github.com/vincenthz/hs-tls/blob/master/debug/src/Stunnel.hs#L33

It might also help to use ciphersuite_all: https://github.com/vincenthz/hs-tls/blob/master/core/Network/TLS/Extra/Cipher.hs#L106.

Any feedback on this one would be greatly appreciated.