### PR TITLE
Add runEnv: like run but uses $PORT

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -20,6 +20,7 @@
 module Network.Wai.Handler.Warp (
     -- * Run a Warp server
     run
+  , runEnv
   , runSettings
   , runSettingsSocket
   , runSettingsConnection

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -35,6 +35,7 @@ import Network.Wai.Handler.Warp.Settings
 import qualified Network.Wai.Handler.Warp.Timeout as T
 import Network.Wai.Handler.Warp.Types
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
+import System.Environment (getEnvironment)
 import System.IO.Error (isFullErrorType, ioeGetErrorType)
 
 #if WINDOWS
@@ -70,6 +71,16 @@ allowInterrupt = unblock $ return ()
 -- 'defaultSettings'.
 run :: Port -> Application -> IO ()
 run p = runSettings defaultSettings { settingsPort = p }
+
+-- | Run an 'Application' on the port present in the @PORT@ environment variable
+--
+-- Uses the 'Port' given when the variable is unset.
+--
+-- Since X.Y.Z
+runEnv :: Port -> Application -> IO ()
+runEnv p app = do
+    mp <- fmap (lookup "PORT") getEnvironment
+    run (maybe p read mp) app
 
 -- | Run an 'Application' with the given 'Settings'.
 runSettings :: Settings -> Application -> IO ()

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -80,7 +80,14 @@ run p = runSettings defaultSettings { settingsPort = p }
 runEnv :: Port -> Application -> IO ()
 runEnv p app = do
     mp <- fmap (lookup "PORT") getEnvironment
-    run (maybe p read mp) app
+
+    maybe (run p app) runReadPort mp
+
+  where
+    runReadPort :: String -> IO ()
+    runReadPort sp = case reads sp of
+        ((p', _):_) -> run p' app
+        _ -> fail $ "Invalid value in $PORT: " ++ sp
 
 -- | Run an 'Application' with the given 'Settings'.
 runSettings :: Settings -> Application -> IO ()


### PR DESCRIPTION
When making smaller Yesod sites not using the scaffold, by far the most common
way I run it is to look at $PORT then fall back. I thought maybe the helper
we've been using for this would be generally useful. It would certainly be nice
not to have to define it again in all our projects.

As usual, I'm not tied to the name.

If this is accepted, and when the version bump happens, please also update the
"Since" comment.