### PR TITLE
Clean up imports in WaiExtraSpec.hs for GHC 7.10

### DIFF
--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module WaiExtraSpec (spec, toRequest) where
 
 import Test.Hspec
 import Test.HUnit hiding (Test)
-import Data.Monoid (mappend, mempty, (<>))
+#if MIN_VERSION_base(4,8,0)
+import Data.Monoid ((<>))
+#else
+import Data.Monoid (mempty, mappend, (<>))
+#endif
 
 import Network.Wai
 import Network.Wai.Test


### PR DESCRIPTION
Some Monoid functions are in Prelude now.