### PR TITLE
Reenable testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: haskell
 
+ghc:
+    - 7.6
+    - 7.8
+
 install:
     - ghc --version
     - cabal --version

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -30,10 +30,6 @@ Flag use-bytestring-builder
     description: Use bytestring-builder package
     default: False
 
-Flag run-doctests
-    description: Run the doctests as part of testing
-    default: False
-
 Library
   Build-Depends:     base                      >= 3        && < 5
                    , array
@@ -104,12 +100,8 @@ Test-Suite doctest
   HS-Source-Dirs:       test
   Ghc-Options:          -threaded -Wall
   Main-Is:              doctests.hs
-  if flag(run-doctests)
-    buildable: True
-    Build-Depends:      base
+  Build-Depends:        base
                       , doctest >= 0.9.3
-  else
-    buildable: False
 
 Test-Suite spec
     Main-Is:         Spec.hs


### PR DESCRIPTION
Based off of discussion in #338

This also enables travis CI testing on GHC 7.6 and 7.8, which @kazu-yamamoto and I thought was a good idea. There was a period where the doctests worked on 7.8 but not 7.6 so I wanted to get that in with the PR that reenabled doctests.