### PR TITLE
Support chain certs

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -18,6 +18,8 @@ module Network.Wai.Handler.WarpTLS (
     , tlsWantClientCert
     , tlsServerHooks
     , defaultTlsSettings
+    , tlsSettings
+    , tlsSettingsMemory
     , tlsSettingsChain
     , tlsSettingsChainMemory
     , OnInsecure (..)

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -17,7 +17,7 @@ Library
   Build-Depends:     base                          >= 4        && < 5
                    , bytestring                    >= 0.9
                    , wai                           >= 3.0      && < 3.1
-                   , warp                          >= 3.0      && < 3.1
+                   , warp                          >= 3.0.8    && < 3.1
                    , data-default-class            >= 0.0.1
                    , tls                           >= 1.2.16
                    , network                       >= 2.2.1


### PR DESCRIPTION
Allow wai-tls to support popular low-cost chain certificates, such as those issued by GoDaddy. This has already been supported by the tls library since version 1.2.15.