### PR TITLE
Fix Windows build with time-1.5

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Date.hs
+++ b/warp/Network/Wai/Handler/Warp/Date.hs
@@ -12,8 +12,12 @@ import Control.AutoUpdate (defaultUpdateSettings, updateAction, mkAutoUpdate)
 import Data.ByteString.Char8
 
 #if WINDOWS
-import Data.Time
-import System.Locale
+import Data.Time (formatTime, getCurrentTime)
+# if MIN_VERSION_time(1,5,0)
+import Data.Time (defaultTimeLocale)
+# else
+import System.Locale (defaultTimeLocale)
+# endif
 #else
 import Network.HTTP.Date
 import System.Posix (epochTime)


### PR DESCRIPTION
`time-1.5` changed the type signature of `formatTime` and now exports `defaultTimeLocale`, which clashes with `defaultTimeLocale` from `old-locale`. This causes `warp` to fail when building on Windows using `time-1.5`. This commit uses CPP pragmas to fix the issue.