### PR TITLE
Extend isSecure and remove caveats about reverse proxy

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.0.7
+
+* Add appearsSecure: check if a request appears to be using SSL even in the
+  presence of reverse proxies [#362](https://github.com/yesodweb/wai/pull/362)
+
 ## 3.0.6.1
 
 * Test code: only include a Cookie header if there are cookies. Without this

--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -21,6 +21,8 @@ import qualified Data.ByteString.Char8 as C
 -- @'isSecure'@. This is not always the case though: for example, deciding to
 -- force a non-SSL request to SSL by redirect. One can safely choose not to
 -- redirect when the request /appears/ secure, even if it's actually not.
+--
+-- Since 3.0.7
 appearsSecure :: Request -> Bool
 appearsSecure request = isSecure request || any (uncurry matchHeader)
     [ ("HTTPS"                  , (== "on"))

--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- | Some helpers for interrogating a WAI 'Request'.
+
+module Network.Wai.Request
+    ( appearsSecure
+    ) where
+
+import Data.ByteString (ByteString)
+import Network.HTTP.Types (HeaderName)
+import Network.Wai (Request, isSecure, requestHeaders)
+
+import qualified Data.ByteString.Char8 as C
+
+-- | Does this request appear to have been made over an SSL connection?
+--
+-- This function first checks @'isSecure'@, but also checks for headers that may
+-- indicate a secure connection even in the presence of reverse proxies.
+--
+-- Note: these headers can be easily spoofed, so decisions which require a true
+-- SSL connection (i.e. sending sensitive information) should only use
+-- @'isSecure'@. This is not always the case though: for example, deciding to
+-- force a non-SSL request to SSL by redirect. One can safely choose not to
+-- redirect when the request /appears/ secure, even if it's actually not.
+appearsSecure :: Request -> Bool
+appearsSecure request = isSecure request || any (uncurry matchHeader)
+    [ ("HTTPS"                  , (== "on"))
+    , ("HTTP_X_FORWARDED_SSL"   , (== "on"))
+    , ("HTTP_X_FORWARDED_SCHEME", (== "https"))
+    , ("HTTP_X_FORWARDED_PROTO" , ((== ["https"]) . take 1 . C.split ','))
+    ]
+
+  where
+    matchHeader :: HeaderName -> (ByteString -> Bool) -> Bool
+    matchHeader h f = maybe False f $ lookup h $ requestHeaders request

--- a/wai-extra/test/Network/Wai/RequestSpec.hs
+++ b/wai-extra/test/Network/Wai/RequestSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.Wai.RequestSpec
+    ( main
+    , spec
+    ) where
+
+import Test.Hspec
+
+import Data.ByteString (ByteString)
+import Network.HTTP.Types (HeaderName)
+import Network.Wai (Request(..), defaultRequest)
+
+import Network.Wai.Request
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "appearsSecure" $ do
+    let insecureRequest = defaultRequest
+            { isSecure = False
+            , requestHeaders =
+                [ ("HTTPS", "off")
+                , ("HTTP_X_FORWARDED_SSL", "off")
+                , ("HTTP_X_FORWARDED_SCHEME", "http")
+                , ("HTTP_X_FORWARDED_PROTO", "http,xyz")
+                ]
+            }
+
+    it "returns False for an insecure request" $
+        insecureRequest `shouldSatisfy` not . appearsSecure
+
+    it "checks if the Request is actually secure" $ do
+        let req = insecureRequest { isSecure = True }
+
+        req `shouldSatisfy` appearsSecure
+
+    it "checks for HTTP: on" $ do
+        let req = addHeader "HTTPS" "on" insecureRequest
+
+        req `shouldSatisfy` appearsSecure
+
+    it "checks for HTTP_X_FORWARDED_SSL: on" $ do
+        let req = addHeader "HTTP_X_FORWARDED_SSL" "on" insecureRequest
+
+        req `shouldSatisfy` appearsSecure
+
+    it "checks for HTTP_X_FORWARDED_SCHEME: https" $ do
+        let req = addHeader "HTTP_X_FORWARDED_SCHEME" "https" insecureRequest
+
+        req `shouldSatisfy` appearsSecure
+
+    it "checks for HTTP_X_FORWARDED_PROTO: https,..." $ do
+        let req = addHeader "HTTP_X_FORWARDED_PROTO" "https,xyz" insecureRequest
+
+        req `shouldSatisfy` appearsSecure
+
+addHeader :: HeaderName -> ByteString -> Request -> Request
+addHeader name value req = req
+    { requestHeaders = (name, value) : otherHeaders }
+
+  where
+    otherHeaders = filter ((/= name) . fst) $ requestHeaders req

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.6.1
+Version:             3.0.7
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -132,6 +132,7 @@ Library
                      Network.Wai.Middleware.HttpAuth
                      Network.Wai.Middleware.StreamFile
                      Network.Wai.Parse
+                     Network.Wai.Request
                      Network.Wai.UrlMap
                      Network.Wai.Test
                      Network.Wai.EventSource


### PR DESCRIPTION
This all started because I want to update `sslOnlyMiddleware` to not only add
the HSTS header, but also redirect non-http to https itself. Otherwise, users
still need to get to some https page organically for the header to be respected
and browser redirects to begin at all. This is what the analogous `force_ssl`
setting of Rails (and maybe other frameworks?) does, so I'm assuming it's
reasonable behavior to add to Yesod.

To do this, I first need a robust way to check if the current request is SSL.
Having read the caveats for the current `isSecure`, I decided to <del>update it</del> 
add a new function with slightly more elaborate checks that I believe still work in 
the presence of reverse proxies.

The checks were lifted from [here](https://github.com/rack/rack/blob/d68b93a9922b8bbfd76d5c7bcf5b63f2aec8f36f/lib/rack/request.rb#L72-88).