### PR TITLE
[Warp] remove dependency *void*

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -42,7 +42,6 @@ Library
                    , iproute                   >= 1.3.1
                    , simple-sendfile           >= 0.2.7    && < 0.3
                    , unix-compat               >= 0.2
-                   , void
                    , wai                       >= 3.0      && < 3.1
                    , text
                    , streaming-commons         >= 0.1.10
@@ -133,7 +132,6 @@ Test-Suite spec
                    , simple-sendfile           >= 0.2.4    && < 0.3
                    , transformers              >= 0.2.2
                    , unix-compat               >= 0.2
-                   , void
                    , wai
                    , network
                    , HUnit


### PR DESCRIPTION
It seems this dependency is not needed by *warp*.