### PR TITLE
Update sample.hs -> handler-webkit

### DIFF
--- a/wai-handler-webkit/sample.hs
+++ b/wai-handler-webkit/sample.hs
@@ -7,4 +7,4 @@ main :: IO ()
 main = run "Sample App" app
 
 app :: Application
-app _ = return $ responseLBS status200 [("Content-Type", "text/html")] "<h1>Hello World!</h1>"
+app _ response = response $ responseLBS status200 [("Content-Type", "text/html")] "<h1>Hello World!</h1>"


### PR DESCRIPTION
I believe `return` was incorrect, it produced a type error:
```
  Couldn't match type `WAI.Response' with `IO WAI.ResponseReceived'
    Expected type: (WAI.Response -> IO WAI.ResponseReceived)
                   -> IO WAI.ResponseReceived
      Actual type: (WAI.Response -> IO WAI.ResponseReceived)
                   -> WAI.Response
```
Passing a response instead of return solved the issue and the webkit browser works.