### PR TITLE
Shutdown faster.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -467,8 +467,4 @@ setSocketCloseOnExec socket =
 #endif
 
 gracefulShutdown :: Counter -> IO ()
-gracefulShutdown counter = do
-    -- To avoid race condition, we just use threadDelay, not MVar.
-    threadDelay 10000000
-    noConnections <- isZero counter
-    unless noConnections $ gracefulShutdown counter
+gracefulShutdown counter = waitForZero counter

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -46,6 +46,7 @@ Library
                    , text
                    , streaming-commons         >= 0.1.10
                    , vault                     >= 0.3
+                   , stm                       >= 2.3
   if flag(network-bytestring)
       Build-Depends: network                   >= 2.2.1.5  && < 2.2.3
                    , network-bytestring        >= 0.1.3    && < 0.1.4
@@ -143,6 +144,7 @@ Test-Suite spec
                    , streaming-commons         >= 0.1.10
                    , async
                    , vault
+                   , stm                       >= 2.3
   if flag(use-bytestring-builder)
       Build-Depends: bytestring                < 0.10.2.0
                    , bytestring-builder


### PR DESCRIPTION
This replaces the `IORef` in `Counter` with a `TVar`. That way `gracefulShutdown` can just use `retry` to listen on changes to the counter instead of waiting arbitrarily long. 