### PR TITLE
Exception handling

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -81,9 +81,12 @@ module Network.Wai.Handler.Warp (
   , settingsFdCacheDuration
   , settingsBeforeMainLoop
   , settingsNoParsePath
-    -- ** Debugging
-  , exceptionResponseForDebug
+    -- ** Exception handler
+  , defaultOnException
   , defaultShouldDisplayException
+    -- ** Exception response handler
+  , defaultOnExceptionResponse
+  , exceptionResponseForDebug
     -- * Data types
   , Transport (..)
   , HostPreference (..)
@@ -157,8 +160,7 @@ setHost :: HostPreference -> Settings -> Settings
 setHost x y = y { settingsHost = x }
 
 -- | What to do with exceptions thrown by either the application or server.
--- Default: ignore server-generated exceptions (see 'InvalidRequest') and print
--- application-generated exceptions to stderr.
+-- Default: 'defaultOnException'
 --
 -- Since 2.1.0
 setOnException :: (Maybe Request -> SomeException -> IO ()) -> Settings -> Settings
@@ -166,7 +168,7 @@ setOnException x y = y { settingsOnException = x }
 
 -- | A function to create a `Response` when an exception occurs.
 --
--- Default: 500, text/plain, \"Something went wrong\"
+-- Default: 'defaultOnExceptionResponse'
 --
 -- Since 2.1.0
 setOnExceptionResponse :: (SomeException -> Response) -> Settings -> Settings

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -98,7 +98,7 @@ headerLines :: Source -> IO [ByteString]
 headerLines src = do
     bs <- readSource src
     if S.null bs
-        then throwIO $ NotEnoughLines []
+        then throwIO $ ConnectionClosedByPeer
         else push src (THStatus 0 id id) bs
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -179,9 +179,7 @@ runSettingsConnectionMakerSecure set getConnMaker app = do
                    f
 
 onE :: Settings -> Maybe Request -> SomeException -> IO ()
-onE set mreq e = case fromException e of
-    Just (NotEnoughLines []) -> return ()
-    _                        -> settingsOnException set mreq e
+onE set mreq e = settingsOnException set mreq e
 
 -- Note that there is a thorough discussion of the exception safety of the
 -- following code at: https://github.com/yesodweb/wai/issues/146

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -145,8 +145,8 @@ defaultOnExceptionResponse e
   | Just (_ :: InvalidRequest) <- fromException e = responseLBS H.badRequest400  [(H.hContentType, "text/plain; charset=utf-8")] "Bad Request"
   | otherwise                                     = responseLBS H.internalServerError500 [(H.hContentType, "text/plain; charset=utf-8")] "Something went wrong"
 
--- | Default implementation of 'settingsOnExceptionResponse'
---   for the debugging purpose. 500, text/plain, a showed exception.
+-- | Exception handler for the debugging purpose.
+--   500, text/plain, a showed exception.
 exceptionResponseForDebug :: SomeException -> Response
 exceptionResponseForDebug e = responseLBS H.internalServerError500 [(H.hContentType, "text/plain; charset=utf-8")] (TLE.encodeUtf8 $ TL.pack $ "Exception: " ++ show e)
 


### PR DESCRIPTION
Trying to fix #382.

- EOF is now `ConnectionClosedByPeer` instead of `NotEnoughLines []`
- `onE` does not ignore `NotEnoughLines []`
- `defaultOnException` and `defaultOnExceptionResponse` are exported
- `defaultOnException and defaultOnExceptionResponse` sends 400 or 500
- Documentation is updated

Behavior:

- A single line:

> Incomplete request headers, received: []

and 400 response

- Junk:

> Warp: Invalid first line of request: "junk"

and 400 response

- EOF:

> Warp: Client closed connection prematurely

and no response
