### PR TITLE
Internal apis

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -152,7 +152,7 @@ import Network.Wai.Handler.Warp.Types
 -- | Port to listen on. Default value: 3000
 --
 -- Since 2.1.0
-setPort :: Int -> Settings -> Settings
+setPort :: Port -> Settings -> Settings
 setPort x y = y { settingsPort = x }
 
 -- | Interface to bind to. Default value: HostIPv4
@@ -240,7 +240,7 @@ setNoParsePath x y = y { settingsNoParsePath = x }
 -- | Get the listening port.
 --
 -- Since 2.1.1
-getPort :: Settings -> Int
+getPort :: Settings -> Port
 getPort = settingsPort
 
 -- | Get the interface to bind to.

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -39,10 +39,6 @@ module Network.Wai.Handler.Warp (
   , runEnv
   , runSettings
   , runSettingsSocket
-    -- ** Low level run functions
-  , runSettingsConnection
-  , runSettingsConnectionMaker
-  , runSettingsConnectionMakerSecure
     -- * Settings
   , Settings
   , defaultSettings
@@ -88,10 +84,19 @@ module Network.Wai.Handler.Warp (
   , defaultOnExceptionResponse
   , exceptionResponseForDebug
     -- * Data types
-  , Transport (..)
   , HostPreference (..)
   , Port
   , InvalidRequest (..)
+    -- * Per-request utilities
+  , pauseTimeout
+    -- * Internal
+    -- | The following APIs will move to Network.Wai.Handler.Warp.Internal.
+
+    -- ** Low level run functions
+  , runSettingsConnection
+  , runSettingsConnectionMaker
+  , runSettingsConnectionMakerSecure
+  , Transport (..)
     -- * Connection
   , Connection (..)
   , socketConnection
@@ -106,9 +111,6 @@ module Network.Wai.Handler.Warp (
   , SendFile
   , sendFile
   , readSendFile
-    -- * Per-request utilities
-  , pauseTimeout
-    -- * Internal
     -- ** Version
   , warpVersion
     -- ** Data types

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -1,15 +1,64 @@
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
-module Network.Wai.Handler.Warp.Internal
-    ( Settings (..)
-    , getOnOpen
-    , getOnClose
-    , getOnException
-    ) where
 
-import Network.Wai.Handler.Warp.Settings (Settings (..))
+module Network.Wai.Handler.Warp.Internal (
+    -- * Settings
+    Settings (..)
+    -- ** Getters
+  , getOnOpen
+  , getOnClose
+  , getOnException
+    -- * Low level run functions
+  , runSettingsConnection
+  , runSettingsConnectionMaker
+  , runSettingsConnectionMakerSecure
+  , Transport (..)
+    -- * Connection
+  , Connection (..)
+  , socketConnection
+    -- ** Buffer
+  , Buffer
+  , BufSize
+  , bufferSize
+  , allocateBuffer
+  , freeBuffer
+    -- ** Sendfile
+  , FileId (..)
+  , SendFile
+  , sendFile
+  , readSendFile
+    -- * Version
+  , warpVersion
+    -- * Data types
+  , InternalInfo (..)
+  , HeaderValue
+  , IndexedHeader
+  , requestMaxIndex
+    -- * Time out manager
+  , module Network.Wai.Handler.Warp.Timeout
+    -- * File descriptor cache
+  , module Network.Wai.Handler.Warp.FdCache
+    -- * Date
+  , module Network.Wai.Handler.Warp.Date
+    -- * Request and response
+  , Source
+  , recvRequest
+  , sendResponse
+  ) where
+
+import Control.Exception (SomeException)
 import Network.Socket (SockAddr)
 import Network.Wai (Request)
-import Control.Exception (SomeException)
+import Network.Wai.Handler.Warp.Buffer
+import Network.Wai.Handler.Warp.Date
+import Network.Wai.Handler.Warp.FdCache
+import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Request
+import Network.Wai.Handler.Warp.Response
+import Network.Wai.Handler.Warp.Run
+import Network.Wai.Handler.Warp.SendFile
+import Network.Wai.Handler.Warp.Settings
+import Network.Wai.Handler.Warp.Timeout
+import Network.Wai.Handler.Warp.Types
 
 getOnOpen :: Settings -> SockAddr -> IO Bool
 getOnOpen = settingsOnOpen

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -32,7 +32,7 @@ import qualified Paths_warp
 --
 -- > setTimeout 20 defaultSettings
 data Settings = Settings
-    { settingsPort :: Int -- ^ Port to listen on. Default value: 3000
+    { settingsPort :: Port -- ^ Port to listen on. Default value: 3000
     , settingsHost :: HostPreference -- ^ Default value: HostIPv4
     , settingsOnException :: Maybe Request -> SomeException -> IO () -- ^ What to do with exceptions thrown by either the application or server. Default: ignore server-generated exceptions (see 'InvalidRequest') and print application-generated applications to stderr.
     , settingsOnExceptionResponse :: SomeException -> Response

--- a/warp/Network/Wai/Handler/Warp/Timeout.hs
+++ b/warp/Network/Wai/Handler/Warp/Timeout.hs
@@ -5,6 +5,9 @@
 
 -- |
 --
+-- Note that this module will not be exported in the near future.
+-- Please use Network.Wai.Handler.Warp.Internal instead.
+--
 -- In order to provide slowloris protection, Warp provides timeout handlers. We
 -- follow these rules:
 --


### PR DESCRIPTION
For #387. This makes the Internal module richer. But this does not make the old APIs deprecated.