### PR TITLE
Cryptonite and non-deprecated Warp APIs

### DIFF
--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -41,7 +41,7 @@ import qualified Data.Text as T
 
 import Data.Either (rights)
 import Network.HTTP.Date (parseHTTPDate, epochTimeToHTTPDate, formatHTTPDate)
-import Data.Monoid (First (First, getFirst), mconcat)
+import Data.Monoid (First (First, getFirst))
 
 import WaiAppStatic.Types
 import Util
@@ -106,17 +106,19 @@ serveFolder ss@StaticSettings {..} pieces req folder@Folder {..} =
     setLast (a:b) x = a : setLast b x
 
     addTrailingSlash :: W.Request -> Maybe ByteString
-    addTrailingSlash req
+    addTrailingSlash req'
         | S8.null rp = Just "/"
         | S8.last rp == '/' = Nothing
         | otherwise = Just $ S8.snoc rp '/'
       where
-        rp = W.rawPathInfo req
+        rp = W.rawPathInfo req'
 
+    {-
     noTrailingSlash :: Pieces -> Bool
     noTrailingSlash [] = False
     noTrailingSlash [x] = fromPiece x /= ""
     noTrailingSlash (_:xs) = noTrailingSlash xs
+    -}
 
     findIndex :: [File] -> Piece -> First Piece
     findIndex files index
@@ -230,7 +232,7 @@ staticAppPieces ss rawPieces req sendResponse = liftIO $ do
     response :: StaticResponse -> IO W.ResponseReceived
     response (FileResponse file ch) = do
         mimetype <- ssGetMimeType ss file
-        let filesize = fileGetSize file
+        -- let filesize = fileGetSize file
         let headers = ("Content-Type", mimetype)
                     -- Let Warp provide the content-length, since it takes
                     -- range requests into account

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -8,8 +8,7 @@ module WaiAppStatic.CmdLine
 import Network.Wai (Middleware)
 import Network.Wai.Application.Static (staticApp, defaultFileServerSettings)
 import Network.Wai.Handler.Warp
-    ( runSettings, defaultSettings, settingsHost, settingsPort
-    )
+    ( runSettings, defaultSettings, setHost, setPort )
 import Options.Applicative
 import Text.Printf (printf)
 import System.Directory (canonicalizePath)
@@ -100,10 +99,8 @@ runCommandLine middleware = do
     let middle = gzip def { gzipFiles = GzipCompress }
                . (if verbose then logStdout else id)
                . (middleware args)
-    runSettings defaultSettings
-        { settingsPort = port
-        , settingsHost = fromString host
-        } $ middle $ staticApp (defaultFileServerSettings $ fromString docroot)
+    runSettings (setPort port $ setHost (fromString host) $ defaultSettings)
+        $ middle $ staticApp (defaultFileServerSettings $ fromString docroot)
         { ssIndices = if noindex then [] else mapMaybe (toPiece . pack) index
         , ssGetMimeType = return . mimeByExt mimeMap defaultMimeType . fromPiece . fileName
         }

--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -20,6 +20,7 @@ import Data.Byteable (toBytes)
 import qualified Data.ByteString.Base64 as B64
 import WaiAppStatic.Storage.Filesystem (defaultFileServerSettings)
 import System.FilePath (isPathSeparator)
+import qualified Data.ByteArray as DBA
 
 -- | Serve the list of path/content pairs directly from memory.
 embeddedSettings :: [(Prelude.FilePath, ByteString)] -> StaticSettings
@@ -95,4 +96,5 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
-runHash = B64.encode . toBytes . (hash :: S.ByteString -> Digest MD5)
+runHash x = B64.encode $ toBytes $
+      (DBA.copyAndFreeze (hash x :: Digest MD5) (\_ -> return ()) :: ByteString)

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -28,6 +28,7 @@ import Data.Byteable (toBytes)
 import Crypto.Hash (MD5, Digest)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.Text as T
+import qualified Data.ByteArray as DBA
 
 -- | Construct a new path from a root and some @Pieces@.
 pathFromPieces :: FilePath -> Pieces -> FilePath
@@ -117,7 +118,8 @@ webAppLookup hashFunc prefix pieces =
 hashFile :: FilePath -> IO ByteString
 hashFile fp = do
     h <- Crypto.Hash.Conduit.hashFile fp
-    return $ B64.encode $ toBytes (h :: Digest MD5)
+    return $ B64.encode $ toBytes
+      (DBA.copyAndFreeze (h :: Digest MD5) (\_ -> return ()) :: ByteString)
 
 hashFileIfExists :: ETagLookup
 hashFileIfExists fp = do

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -51,7 +51,7 @@ library
                    , filepath
                    , wai-extra                 >= 3.0      && < 3.1
                    , optparse-applicative      >= 0.7
-                   , warp                      >= 3.0.11   && < 3.1
+                   , warp                      >= 3.0.11   && < 3.2
                    , memory                    >= 0.7
                    -- Used exclusively for hashFile function
                    , cryptohash-conduit

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -40,7 +40,7 @@ library
                    , blaze-builder             >= 0.2.1.4
                    , base64-bytestring         >= 0.1
                    , byteable
-                   , cryptohash                >= 0.11
+                   , cryptonite                >= 0.3
                    , http-date
                    , blaze-html                >= 0.5
                    , blaze-markup              >= 0.5.1
@@ -52,6 +52,7 @@ library
                    , wai-extra                 >= 3.0      && < 3.1
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.1
+                   , memory                    >= 0.7
                    -- Used exclusively for hashFile function
                    , cryptohash-conduit
 

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -14,8 +14,8 @@ extra-source-files:  README.md ChangeLog.md
 Library
     Exposed-modules: Network.Wai.Handler.Launch
     build-depends:   base                    >= 4       && < 5
-                   , wai                     >= 3.0     && < 3.1
-                   , warp                    >= 3.0     && < 3.1
+                   , wai                     >= 3.0     && < 3.2
+                   , warp                    >= 3.0     && < 3.2
                    , http-types              >= 0.7
                    , transformers            >= 0.2.2
                    , bytestring              >= 0.9.1.4

--- a/wai-websockets/server.lhs
+++ b/wai-websockets/server.lhs
@@ -76,9 +76,8 @@ actual server.
 > main = do
 >     putStrLn "http://localhost:9160/client.html"
 >     state <- newMVar newServerState
->     Warp.runSettings Warp.defaultSettings
->       { Warp.settingsPort = 9160
->       } $ WaiWS.websocketsOr WS.defaultConnectionOptions (application state) staticApp
+>     Warp.runSettings (Warp.setPort 9160 $ Warp.defaultSettings)
+>       $ WaiWS.websocketsOr WS.defaultConnectionOptions (application state) staticApp
 
 > staticApp :: Network.Wai.Application
 > staticApp = Static.staticApp $ Static.embeddedSettings $(embedDir "static")

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -36,7 +36,6 @@ import Control.Applicative ((<$>))
 #endif
 import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException)
 import Control.Monad (void)
-import qualified Crypto.Random.AESCtr
 import qualified Data.ByteString as B
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
@@ -265,8 +264,7 @@ mkConn tlsset s params = do
 
 httpOverTls :: TLS.TLSParams params => TLSSettings -> Socket -> I.IORef B.ByteString -> params -> IO (Connection, Transport)
 httpOverTls TLSSettings{..} s cachedRef params = do
-    gen <- Crypto.Random.AESCtr.makeSystem
-    ctx <- TLS.contextNew backend params gen
+    ctx <- TLS.contextNew backend params
     TLS.contextHookSetLogging ctx tlsLogging
     TLS.handshake ctx
     writeBuf <- allocateBuffer bufferSize

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -19,9 +19,8 @@ Library
                    , wai                           >= 3.0      && < 3.1
                    , warp                          >= 3.1      && < 3.2
                    , data-default-class            >= 0.0.1
-                   , tls                           >= 1.2.16
+                   , tls                           >= 1.3.0
                    , network                       >= 2.2.1
-                   , cprng-aes                     >= 0.5.0
                    , streaming-commons
   Exposed-modules:   Network.Wai.Handler.WarpTLS
   ghc-options:       -Wall


### PR DESCRIPTION
These patches allow my system to build with cryptonite (and not the packages it replaces) installed.  It was also seemingly necessary to modify packages in this repository to work together after c7072101959982e95745c3898a1e81fede8b4bee.  While here, some warnings were silenced.