### PR TITLE
Input buffer

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -102,11 +102,13 @@ toBlazeBuffer ptr size = do
     fptr <- newForeignPtr_ ptr
     return $ B.Buffer fptr ptr ptr (ptr `plusPtr` size)
 
-{-# INLINE copy #-}
+-- | Copying the bytestring to the buffer.
+--   This function returns the point where the next copy should start.
 copy :: Buffer -> ByteString -> IO Buffer
 copy !ptr (PS fp o l) = withForeignPtr fp $ \p -> do
     memcpy ptr (p `plusPtr` o) (fromIntegral l)
     return $! ptr `plusPtr` l
+{-# INLINE copy #-}
 
 {-# INLINE toBS #-}
 toBS :: Buffer -> Int -> IO ByteString

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -12,12 +12,17 @@ module Network.Wai.Handler.Warp.Internal (
     -- * Connection
   , Connection (..)
   , socketConnection
+    -- ** Receive
+  , Recv
+  , RecvBuf
+  , makePlainReceiveN
     -- ** Buffer
   , Buffer
   , BufSize
   , bufferSize
   , allocateBuffer
   , freeBuffer
+  , copy
     -- ** Sendfile
   , FileId (..)
   , SendFile
@@ -63,6 +68,7 @@ import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Date
 import Network.Wai.Handler.Warp.FdCache
 import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Recv
 import Network.Wai.Handler.Warp.Request
 import Network.Wai.Handler.Warp.Response
 import Network.Wai.Handler.Warp.Run

--- a/warp/Network/Wai/Handler/Warp/Recv.hs
+++ b/warp/Network/Wai/Handler/Warp/Recv.hs
@@ -1,22 +1,29 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ForeignFunctionInterface, OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module Network.Wai.Handler.Warp.Recv (
     receive
+  , receiveBuf
+  , makeReceiveN
+  , makePlainReceiveN
+  , spell
   ) where
 
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative ((<$>))
 #endif
-import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.ByteString.Internal (ByteString(..))
 import Data.Word (Word8)
 import Foreign.C.Error (eAGAIN, getErrno, throwErrno)
 import Foreign.C.Types
-import Foreign.Ptr (Ptr, castPtr)
+import Foreign.ForeignPtr (withForeignPtr)
+import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import GHC.Conc (threadWaitRead)
 import Network.Socket (Socket, fdSocket)
-import Network.Wai.Handler.Warp.Types
 import Network.Wai.Handler.Warp.Buffer
+import Network.Wai.Handler.Warp.IORef
+import Network.Wai.Handler.Warp.Types
 import System.Posix.Types (Fd(..))
 
 #ifdef mingw32_HOST_OS
@@ -26,11 +33,66 @@ import Network.Wai.Handler.Warp.Windows
 
 ----------------------------------------------------------------
 
-receive :: Socket -> BufferPool -> IO ByteString
+makeReceiveN :: ByteString -> Recv -> RecvBuf -> IO (BufSize -> IO ByteString)
+makeReceiveN bs0 recv recvBuf = do
+    ref <- newIORef bs0
+    return $ receiveN ref recv recvBuf
+
+makePlainReceiveN :: Socket -> ByteString -> IO (BufSize -> IO ByteString)
+makePlainReceiveN s bs0 = do
+    ref <- newIORef bs0
+    pool <- newBufferPool
+    return $ receiveN ref (receive s pool) (receiveBuf s)
+
+receiveN :: IORef ByteString -> Recv -> RecvBuf -> BufSize -> IO ByteString
+receiveN ref recv recvBuf size = do
+    cached <- readIORef ref
+    (bs, leftover) <- spell cached size recv recvBuf
+    writeIORef ref leftover
+    return bs
+
+----------------------------------------------------------------
+
+spell :: ByteString -> BufSize -> IO ByteString -> RecvBuf -> IO (ByteString, ByteString)
+spell initial siz recv recvBuf
+  | siz <= len0 = return $ BS.splitAt siz initial
+  | siz <= 4096 = do
+      bs <- recv
+      if bs == "" then
+          return ("", "")
+        else do
+          let (bs1, leftover) = BS.splitAt (siz - len0) bs
+          return (BS.append initial bs1, leftover)
+  | otherwise = do
+      bs@(PS fptr _ _) <- mallocByteString siz
+      withForeignPtr fptr $ \ptr -> do
+          ptr' <- copy ptr initial
+          full <- recvBuf ptr' (siz - len0)
+          if full then
+              return (bs, "")
+             else
+              return ("", "") -- fixme
+  where
+    len0 = BS.length initial
+
+receive :: Socket -> BufferPool -> Recv
 receive sock pool = withBufferPool pool $ \ (ptr, size) -> do
     let sock' = fdSocket sock
         size' = fromIntegral size
     fromIntegral <$> receiveloop sock' ptr size'
+
+receiveBuf :: Socket -> RecvBuf
+receiveBuf sock buf0 siz0 = loop buf0 siz0
+  where
+    loop _   0   = return True
+    loop buf siz = do
+        n <- fromIntegral <$> receiveloop fd buf (fromIntegral siz)
+        -- fixme: what should we do in the case of n == 0
+        if n == 0 then
+            return False
+          else
+            loop (buf `plusPtr` n) (siz - n)
+    fd = fdSocket sock
 
 receiveloop :: CInt -> Ptr Word8 -> CSize -> IO CInt
 receiveloop sock ptr size = do

--- a/warp/Network/Wai/Handler/Warp/Recv.hs
+++ b/warp/Network/Wai/Handler/Warp/Recv.hs
@@ -38,6 +38,11 @@ makeReceiveN bs0 recv recvBuf = do
     ref <- newIORef bs0
     return $ receiveN ref recv recvBuf
 
+-- | This function returns a receiving function
+--   based on two receiving functions.
+--   The returned function efficiently manages received data
+--   which is initialized by the first argument.
+--   The returned function may allocate a byte string with malloc().
 makePlainReceiveN :: Socket -> ByteString -> IO (BufSize -> IO ByteString)
 makePlainReceiveN s bs0 = do
     ref <- newIORef bs0

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -95,7 +95,11 @@ type Buffer = Ptr Word8
 -- | Type for buffer size
 type BufSize = Int
 
+-- | Type for the action to receive input data
 type Recv = IO ByteString
+
+-- | Type for the action to receive input data with a buffer.
+--   The result boolean indicates whether or not the buffer is fully filled.
 type RecvBuf = Buffer -> BufSize -> IO Bool
 
 -- | Data type to manipulate IO actions for connections.

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -95,6 +95,9 @@ type Buffer = Ptr Word8
 -- | Type for buffer size
 type BufSize = Int
 
+type Recv = IO ByteString
+type RecvBuf = Buffer -> BufSize -> IO Bool
+
 -- | Data type to manipulate IO actions for connections.
 --   This is used to abstract IO actions for plain HTTP and HTTP over TLS.
 data Connection = Connection {
@@ -106,8 +109,8 @@ data Connection = Connection {
     , connSendFile    :: SendFile
     -- | The connection closing function.
     , connClose       :: IO ()
-    -- | The connection receiving function.
-    , connRecv        :: IO ByteString
+    -- | The connection receiving function. This returns "" for EOF.
+    , connRecv        :: Recv
     -- | The write buffer.
     , connWriteBuffer :: Buffer
     -- | The size of the write buffer.


### PR DESCRIPTION
This is the second step to improve the performance of WarpTLS. Since TLS record tells the length of the body, we can make use of the length to read input data. This code is a little bit redundant because some APIs are also used in my HTTP/2 implementation. Note that HTTP/2 frames also tell payload length. I designed APIs very carefully and hope that they are clean enough.

The current bottleneck is cryptonite. This patch does not improve the file upload performance in HTTP/1.1 over TLS because cyptonite consumes 40+ percent of CPU powers. But I believe that this is worth merging.

@snoyberg Please review this.