### PR TITLE
wai-extra: Add stripHeader/s Middleware component

### DIFF
--- a/wai-extra/Network/Wai/Middleware/AddHeaders.hs
+++ b/wai-extra/Network/Wai/Middleware/AddHeaders.hs
@@ -3,6 +3,7 @@
 -- Since 3.0.3
 module Network.Wai.Middleware.AddHeaders
     ( addHeaders
+    , mapResponseHeader
     ) where
 
 import Network.HTTP.Types   (ResponseHeaders, Header)
@@ -20,11 +21,14 @@ addHeaders :: [(ByteString, ByteString)] -> Middleware
 
 addHeaders h app req respond = app req $ respond . addHeaders' (map (first CI.mk) h)
 
-mapHeader :: (ResponseHeaders -> ResponseHeaders) -> Response -> Response
-mapHeader f (ResponseFile s h b1 b2) = ResponseFile s (f h) b1 b2
-mapHeader f (ResponseBuilder s h b) = ResponseBuilder s (f h) b
-mapHeader f (ResponseStream s h b) = ResponseStream s (f h) b
-mapHeader _ r@(ResponseRaw _ _) = r
-
 addHeaders' :: [Header] -> Response -> Response
-addHeaders' h = mapHeader (\hs -> h ++ hs)
+addHeaders' h = mapResponseHeader (\hs -> h ++ hs)
+
+
+-- | Apply the provided function to the response header list of the Response.
+mapResponseHeader :: (ResponseHeaders -> ResponseHeaders) -> Response -> Response
+mapResponseHeader f (ResponseFile s h b1 b2) = ResponseFile s (f h) b1 b2
+mapResponseHeader f (ResponseBuilder s h b) = ResponseBuilder s (f h) b
+mapResponseHeader f (ResponseStream s h b) = ResponseStream s (f h) b
+mapResponseHeader _ r@(ResponseRaw _ _) = r
+

--- a/wai-extra/Network/Wai/Middleware/StripHeaders.hs
+++ b/wai-extra/Network/Wai/Middleware/StripHeaders.hs
@@ -1,0 +1,43 @@
+-- This was written for one specific use case and then generalized.
+
+-- The specific use case was a JSON API with a consumer that would choke on the
+-- "Set-Cookie" response header. The solution was to test for the API's
+-- `pathInfo` in the Request and if it matched, filter the response headers.
+
+-- When using this, care should be taken not to strip out headers that are
+-- required for correct operation of the client (eg Content-Type).
+
+module Network.Wai.Middleware.StripHeaders
+    ( stripHeader
+    , stripHeaders
+    ) where
+
+import Network.Wai                       (Middleware, Request)
+import Data.ByteString                   (ByteString)
+import Network.Wai.Middleware.AddHeaders (mapResponseHeader)
+
+import qualified Data.CaseInsensitive as CI
+
+
+-- | If the request satisifes the provided predicate, strip headers matching
+-- the provided header name.
+--
+-- Since 3.0.8
+
+stripHeader :: ByteString -> (Request -> Bool) -> Middleware
+stripHeader h rpred app req respond
+    | rpred req = app req $ respond . mapResponseHeader (filter (\ hdr -> fst hdr /= CI.mk h))
+    | otherwise = app req respond
+
+
+-- | If the request satisifes the provided predicate, strip all headers whose
+-- header name is in the list of provided header names.
+--
+-- Since 3.0.8
+
+stripHeaders :: [ByteString] -> (Request -> Bool) -> Middleware
+stripHeaders hs rpred app req respond
+    | rpred req = do
+        let hnames = map CI.mk hs
+        app req $ respond . mapResponseHeader (filter (\ hdr -> fst hdr `notElem` hnames))
+    | otherwise = app req respond

--- a/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.Wai.Middleware.StripHeadersSpec
+    ( main
+    , spec
+    ) where
+
+import Test.Hspec
+
+import Network.Wai.Middleware.AddHeaders
+import Network.Wai.Middleware.StripHeaders
+
+import Control.Arrow (first)
+import Data.ByteString (ByteString)
+import Data.Monoid ((<>))
+import Network.HTTP.Types (status200)
+import Network.Wai
+import Network.Wai.Test
+
+import qualified Data.CaseInsensitive as CI
+
+
+main :: IO ()
+main = hspec spec
+
+
+spec :: Spec
+spec = describe "stripHeader" $ do
+    let host = "example.com"
+    let ciTestHeaders = map (first CI.mk) testHeaders
+
+    it "strips a specific header" $ do
+        resp1 <- runApp host (addHeaders testHeaders) defaultRequest
+        resp2 <- runApp host (stripHeader "Foo" (const False) . addHeaders testHeaders) defaultRequest
+        resp3 <- runApp host (stripHeader "Foo" (const True) . addHeaders testHeaders) defaultRequest
+
+        simpleHeaders resp1 `shouldBe` ciTestHeaders
+        simpleHeaders resp2 `shouldBe` ciTestHeaders
+        simpleHeaders resp3 `shouldBe` tail ciTestHeaders
+
+    it "strips specific set of headers" $ do
+        resp1 <- runApp host (addHeaders testHeaders) defaultRequest
+        resp2 <- runApp host (stripHeaders ["Bar", "Foo"] (const False) . addHeaders testHeaders) defaultRequest
+        resp3 <- runApp host (stripHeaders ["Bar", "Foo"] (const True) . addHeaders testHeaders) defaultRequest
+
+        simpleHeaders resp1 `shouldBe` ciTestHeaders
+        simpleHeaders resp2 `shouldBe` ciTestHeaders
+        simpleHeaders resp3 `shouldBe` [last ciTestHeaders]
+
+
+testHeaders :: [(ByteString, ByteString)]
+testHeaders = [("Foo", "fooey"), ("Bar", "barbican"), ("Baz", "bazooka")]
+
+
+runApp :: ByteString -> Middleware -> Request -> IO SResponse
+runApp host mw req = runSession
+    (request req { requestHeaderHost = Just $ host <> ":80" }) $ mw app
+  where
+    app _ respond = respond $ responseLBS status200 [] ""

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -130,6 +130,7 @@ Library
                      Network.Wai.Middleware.MethodOverride
                      Network.Wai.Middleware.MethodOverridePost
                      Network.Wai.Middleware.Rewrite
+                     Network.Wai.Middleware.StripHeaders
                      Network.Wai.Middleware.Vhost
                      Network.Wai.Middleware.HttpAuth
                      Network.Wai.Middleware.StreamFile
@@ -152,6 +153,7 @@ test-suite spec
                      Network.Wai.RequestSpec
                      Network.Wai.Middleware.ApprootSpec
                      Network.Wai.Middleware.ForceSSLSpec
+                     Network.Wai.Middleware.StripHeadersSpec
                      WaiExtraSpec
     build-depends:   base                      >= 4        && < 5
                    , wai-extra
@@ -168,6 +170,7 @@ test-suite spec
                    , blaze-builder
                    , cookie
                    , time
+                   , case-insensitive
     ghc-options:     -Wall -Werror
 
 source-repository head


### PR DESCRIPTION
This Middleware component allows specific HTTP response headers
(chosen by header name) to be dropped if the Wai Request matches
a predicate.

Tests included.

I can merge this to master myself, but just want to see if everyone thinks its ok.
