### PR TITLE
wai-extra: Add NOINLINE pragmas as needed

### DIFF
--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -119,6 +119,7 @@ customMiddleware cb getdate formatter app req sendResponse = app req $ \res -> d
 
 -- | Production request logger middleware.
 -- Implemented on top of "logCallback", but prints to 'stdout'
+{-# NOINLINE logStdout #-}
 logStdout :: Middleware
 logStdout = unsafePerformIO $ mkRequestLogger def { outputFormat = Apache FromSocket }
 
@@ -127,6 +128,7 @@ logStdout = unsafePerformIO $ mkRequestLogger def { outputFormat = Apache FromSo
 --
 -- Flushes 'stdout' on each request, which would be inefficient in production use.
 -- Use "logStdout" in production.
+{-# NOINLINE logStdoutDev #-}
 logStdoutDev :: Middleware
 logStdoutDev = unsafePerformIO $ mkRequestLogger def
 


### PR DESCRIPTION
The docs for `unsafePerformIO` say:

    Use {-# NOINLINE foo #-} as a pragma on any function foo that
    calls unsafePerformIO. If the call is inlined, the I/O may be
    performed more than once.