### PR TITLE
supporting HTTP/2.

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -239,12 +239,26 @@ runTLSSocket' tlsset@TLSSettings{..} set credential sock app =
       , TLS.serverSupported = def {
           TLS.supportedVersions = tlsAllowedVersions
         , TLS.supportedCiphers  = tlsCiphers
+        , TLS.supportedHashSignatures = [
+            (TLS.HashSHA256, TLS.SignatureRSA)
+          , (TLS.HashSHA1, TLS.SignatureRSA)
+          ]
         }
       , TLS.serverShared = def {
           TLS.sharedCredentials = TLS.Credentials [credential]
         }
-      , TLS.serverHooks = tlsServerHooks
+      , TLS.serverHooks = tlsServerHooks {
+          TLS.onALPNClientSuggest = Just alpn
+        }
       }
+
+alpn :: [S.ByteString] -> IO S.ByteString
+alpn xs
+  | "h2"    `elem` xs = return "h2"
+  | "h2-16" `elem` xs = return "h2-16"
+  | "h2-15" `elem` xs = return "h2-15"
+  | "h2-14" `elem` xs = return "h2-14"
+  | otherwise         = return "http/1.1"
 
 ----------------------------------------------------------------
 
@@ -275,8 +289,9 @@ httpOverTls TLSSettings{..} s bs0 params = do
     TLS.contextHookSetLogging ctx tlsLogging
     TLS.handshake ctx
     writeBuf <- allocateBuffer bufferSize
+    ref <- I.newIORef ""
     tls <- getTLSinfo ctx
-    return (conn ctx writeBuf, tls)
+    return (conn ctx writeBuf ref, tls)
   where
     backend recvN = TLS.Backend {
         TLS.backendFlush = return ()
@@ -284,12 +299,13 @@ httpOverTls TLSSettings{..} s bs0 params = do
       , TLS.backendSend  = sendAll s
       , TLS.backendRecv  = recvN
       }
-    conn ctx writeBuf = Connection {
+    conn ctx writeBuf ref = Connection {
         connSendMany         = TLS.sendData ctx . L.fromChunks
       , connSendAll          = sendall
       , connSendFile         = sendfile
       , connClose            = close
-      , connRecv             = recv
+      , connRecv             = recv ref
+      , connRecvBuf          = recvBuf ref
       , connWriteBuffer      = writeBuf
       , connBufferSize       = bufferSize
       }
@@ -302,7 +318,15 @@ httpOverTls TLSSettings{..} s bs0 params = do
                 void (tryIO $ TLS.bye ctx) `finally`
                 TLS.contextClose ctx
 
-        recv = handle onEOF go
+        recv cref = do
+            cached <- I.readIORef cref
+            if cached /= "" then do
+                I.writeIORef cref ""
+                return cached
+              else
+                recv'
+
+        recv' = handle onEOF go
           where
             onEOF e
               | Just TLS.Error_EOF <- fromException e       = return S.empty
@@ -313,6 +337,36 @@ httpOverTls TLSSettings{..} s bs0 params = do
                     go
                   else
                     return x
+
+        recvBuf cref buf siz = do
+            cached <- I.readIORef cref
+            (ret, leftover) <- fill cached buf siz recv'
+            I.writeIORef cref leftover
+            return ret
+
+fill :: S.ByteString -> Buffer -> BufSize -> Recv -> IO (Bool,S.ByteString)
+fill bs0 buf0 siz0 recv
+  | siz0 <= len0 = do
+      let (bs, leftover) = S.splitAt siz0 bs0
+      void $ copy buf0 bs
+      return (True, leftover)
+  | otherwise = do
+      buf <- copy buf0 bs0
+      loop buf (siz0 - len0)
+  where
+    len0 = S.length bs0
+    loop _   0   = return (True, "")
+    loop buf siz = do
+      bs <- recv
+      let len = S.length bs
+      if len == 0 then return (False, "")
+        else if (len <= siz) then do
+          buf' <- copy buf bs
+          loop buf' (siz - len)
+        else do
+          let (bs1,bs2) = S.splitAt siz bs
+          void $ copy buf bs1
+          return (True, bs2)
 
 getTLSinfo :: TLS.Context -> IO Transport
 getTLSinfo ctx = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Network.Wai.Handler.Warp.HTTP2 (isHTTP2, http2) where
+
+import Control.Concurrent (forkIO, killThread)
+import qualified Control.Exception as E
+import Control.Monad (when, unless, replicateM)
+import Data.ByteString (ByteString)
+import Network.HTTP2
+import Network.Socket (SockAddr)
+import Network.Wai
+import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
+import Network.Wai.Handler.Warp.HTTP2.Receiver
+import Network.Wai.Handler.Warp.HTTP2.Request
+import Network.Wai.Handler.Warp.HTTP2.Sender
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.HTTP2.Worker
+import qualified Network.Wai.Handler.Warp.Settings as S (Settings)
+import Network.Wai.Handler.Warp.Types
+
+----------------------------------------------------------------
+
+http2 :: Connection -> InternalInfo -> SockAddr -> Transport -> S.Settings -> (BufSize -> IO ByteString) -> Application -> IO ()
+http2 conn ii addr transport settings readN app = do
+    checkTLS
+    ok <- checkPreface
+    when ok $ do
+        ctx <- newContext
+        let responder = response ctx
+            mkreq = mkRequest settings addr
+        tid <- forkIO $ frameReceiver ctx mkreq readN
+        -- fixme: 10 is hard-coded
+        -- To prevent thread-leak, we executed the fixed number of threads
+        -- statically at this moment. But ResponseStream occupies one
+        -- worker thread. So, this should be dynamic.
+        tids <- replicateM 10 $ forkIO $ worker ctx settings tm app responder
+        -- frameSender is the main thread because it ensures to send
+        -- a goway frame.
+        frameSender ctx conn ii settings `E.finally` do
+            clearContext ctx
+            mapM_ killThread (tid:tids)
+  where
+    tm = timeoutManager ii
+    checkTLS = case transport of
+        TCP -> return () -- direct
+        tls -> unless (tls12orLater tls) $ goaway conn InadequateSecurity "Weak TLS"
+    tls12orLater tls = tlsMajorVersion tls == 3 && tlsMinorVersion tls >= 3
+    checkPreface = do
+        preface <- readN connectionPrefaceLength
+        if connectionPreface /= preface then do
+            goaway conn ProtocolError "Preface mismatch"
+            return False
+          else
+            return True
+
+-- connClose must not be called here since Run:fork calls it
+goaway :: Connection -> ErrorCodeId -> ByteString -> IO ()
+goaway Connection{..} etype debugmsg = connSendAll bytestream
+  where
+    bytestream = goawayFrame 0 etype debugmsg

--- a/warp/Network/Wai/Handler/Warp/HTTP2/EncodeFrame.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/EncodeFrame.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Wai.Handler.Warp.HTTP2.EncodeFrame where
+
+import Data.ByteString (ByteString)
+import Network.HTTP2
+
+----------------------------------------------------------------
+
+goawayFrame :: StreamId -> ErrorCodeId -> ByteString -> ByteString
+goawayFrame sid etype debugmsg = encodeFrame einfo frame
+  where
+    einfo = encodeInfo id 0
+    frame = GoAwayFrame sid etype debugmsg
+
+resetFrame :: ErrorCodeId -> StreamId -> ByteString
+resetFrame etype sid = encodeFrame einfo frame
+  where
+    einfo = encodeInfo id sid
+    frame = RSTStreamFrame etype
+
+settingsFrame :: (FrameFlags -> FrameFlags) -> SettingsList -> ByteString
+settingsFrame func alist = encodeFrame einfo $ SettingsFrame alist
+  where
+    einfo = encodeInfo func 0
+
+pingFrame :: ByteString -> ByteString
+pingFrame bs = encodeFrame einfo $ PingFrame bs
+  where
+    einfo = encodeInfo setAck 0
+
+windowUpdateFrame :: StreamId -> WindowSize -> ByteString
+windowUpdateFrame sid winsiz = encodeFrame einfo $ WindowUpdateFrame winsiz
+  where
+    einfo = encodeInfo id sid

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE RecordWildCards, OverloadedStrings #-}
+
+module Network.Wai.Handler.Warp.HTTP2.HPACK where
+
+import Control.Arrow (first)
+import qualified Control.Exception as E
+import Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Char8 as B8
+import Data.CaseInsensitive (foldedCase)
+import Data.IORef (readIORef, writeIORef)
+import Network.HPACK
+import qualified Network.HTTP.Types as H
+import Network.HTTP2
+import Network.Wai
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Response
+import qualified Network.Wai.Handler.Warp.Settings as S
+import Network.Wai.Handler.Warp.Types
+
+hpackEncodeHeader :: Context -> InternalInfo -> S.Settings -> Response
+                  -> IO Builder
+hpackEncodeHeader Context{..} ii settings rsp = do
+    hdr1 <- addServerAndDate hdr0
+    let hdr2 = (":status", status) : map (first foldedCase) hdr1
+    ehdrtbl <- readIORef encodeDynamicTable
+    (ehdrtbl', builder) <- encodeHeaderBuilder defaultEncodeStrategy ehdrtbl hdr2
+    writeIORef encodeDynamicTable ehdrtbl'
+    return builder
+  where
+    hdr0 = responseHeaders rsp
+    status = B8.pack $ show $ H.statusCode $ responseStatus rsp
+    dc = dateCacher ii
+    rspidxhdr = indexResponseHeader hdr0
+    defServer = S.settingsServerName settings
+    addServerAndDate = addDate dc rspidxhdr . addServer defServer rspidxhdr
+
+
+----------------------------------------------------------------
+
+hpackDecodeHeader :: HeaderBlockFragment -> Context -> IO HeaderList
+hpackDecodeHeader hdrblk Context{..} = do
+    hdrtbl <- readIORef decodeDynamicTable
+    (hdrtbl', hdr) <- decodeHeader hdrtbl hdrblk `E.onException` cleanup
+    writeIORef decodeDynamicTable hdrtbl'
+    return hdr
+  where
+    cleanup = E.throwIO $ ConnectionError CompressionError "cannot decompress the header"

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE RecordWildCards, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
 
 module Network.Wai.Handler.Warp.HTTP2.HPACK where
 
@@ -20,7 +21,7 @@ import Network.Wai.Handler.Warp.Types
 
 hpackEncodeHeader :: Context -> InternalInfo -> S.Settings -> Response
                   -> IO Builder
-hpackEncodeHeader Context{..} ii settings rsp = do
+hpackEncodeHeader Context{encodeDynamicTable} ii settings rsp = do
     hdr1 <- addServerAndDate hdr0
     let hdr2 = (":status", status) : map (first foldedCase) hdr1
     ehdrtbl <- readIORef encodeDynamicTable
@@ -39,7 +40,7 @@ hpackEncodeHeader Context{..} ii settings rsp = do
 ----------------------------------------------------------------
 
 hpackDecodeHeader :: HeaderBlockFragment -> Context -> IO HeaderList
-hpackDecodeHeader hdrblk Context{..} = do
+hpackDecodeHeader hdrblk Context{decodeDynamicTable} = do
     hdrtbl <- readIORef decodeDynamicTable
     (hdrtbl', hdr) <- decodeHeader hdrtbl hdrblk `E.onException` cleanup
     writeIORef decodeDynamicTable hdrtbl'

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -1,0 +1,307 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+module Network.Wai.Handler.Warp.HTTP2.Receiver (frameReceiver) where
+
+#if __GLASGOW_HASKELL__ < 709
+import Control.Applicative
+#endif
+import Control.Concurrent (takeMVar)
+import Control.Concurrent.STM
+import qualified Control.Exception as E
+import Control.Monad (when, unless, void)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Maybe (isJust)
+import Network.HTTP2
+import Network.HTTP2.Priority
+import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
+import Network.Wai.Handler.Warp.HTTP2.HPACK
+import Network.Wai.Handler.Warp.HTTP2.Request
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.IORef
+import Network.Wai.Handler.Warp.Types
+
+----------------------------------------------------------------
+
+frameReceiver :: Context -> MkReq -> (BufSize -> IO ByteString) -> IO ()
+frameReceiver ctx@Context{..} mkreq recvN =
+    E.handle sendGoaway loop `E.finally` takeMVar wait
+  where
+    sendGoaway (ConnectionError err msg) = do
+        csid <- readIORef currentStreamId
+        let frame = goawayFrame csid err msg
+        enqueue outputQ (OGoaway frame) highestPriority
+    sendGoaway _                         = return ()
+
+    sendReset err sid = do
+        let frame = resetFrame err sid
+        enqueue outputQ (OFrame frame) highestPriority
+
+    loop = do
+        hd <- recvN frameHeaderLength
+        if BS.null hd then
+            enqueue outputQ OFinish highestPriority
+          else do
+            cont <- processStreamGuardingError $ decodeFrameHeader hd
+            when cont loop
+
+    processStreamGuardingError (_, FrameHeader{..})
+      | isResponse streamId = E.throwIO $ ConnectionError ProtocolError "stream id should be odd"
+    processStreamGuardingError (FrameUnknown _, FrameHeader{..}) = do
+        mx <- readIORef continued
+        case mx of
+            Nothing -> do
+                -- ignoring unknown frame
+                consume payloadLength
+                return True
+            Just _  -> E.throwIO $ ConnectionError ProtocolError "unknown frame"
+    processStreamGuardingError (FramePushPromise, _) =
+        E.throwIO $ ConnectionError ProtocolError "push promise is not allowed"
+    processStreamGuardingError typhdr@(ftyp, header@FrameHeader{..}) = do
+        settings <- readIORef http2settings
+        case checkFrameHeader settings typhdr of
+            Left h2err -> case h2err of
+                StreamError err sid -> do
+                    sendReset err sid
+                    consume payloadLength
+                    return True
+                connErr -> E.throwIO connErr
+            Right _ -> do
+                ex <- E.try $ controlOrStream ftyp header
+                case ex of
+                    Left (StreamError err sid) -> do
+                        sendReset err sid
+                        return True
+                    Left connErr -> E.throw connErr
+                    Right cont -> return cont
+
+    controlOrStream ftyp header@FrameHeader{..}
+      | isControl streamId = do
+          pl <- recvN payloadLength
+          control ftyp header pl ctx
+      | otherwise = do
+          checkContinued
+          strm@Stream{..} <- getStream
+          pl <- recvN payloadLength
+          state <- readIORef streamState
+          state' <- stream ftyp header pl ctx state strm
+          case state' of
+              Open (NoBody hdr pri) -> do
+                  resetContinued
+                  case validateHeaders hdr of
+                      Just vh -> do
+                          when (isJust (vhCL vh) && vhCL vh /= Just 0) $
+                              E.throwIO $ StreamError ProtocolError streamId
+                          writeIORef streamState HalfClosed
+                          let req = mkreq vh (return "")
+                          atomically $ writeTQueue inputQ $ Input strm req pri
+                      Nothing -> E.throwIO $ StreamError ProtocolError streamId
+              Open (HasBody hdr pri) -> do
+                  resetContinued
+                  case validateHeaders hdr of
+                      Just vh -> do
+                          q <- newTQueueIO
+                          writeIORef streamState (Open (Body q))
+                          writeIORef streamContentLength $ vhCL vh
+                          readQ <- newReadBody q
+                          bodySource <- mkSource readQ
+                          let req = mkreq vh (readSource bodySource)
+                          atomically $ writeTQueue inputQ $ Input strm req pri
+                      Nothing -> E.throwIO $ StreamError ProtocolError streamId
+              s@(Open Continued{}) -> do
+                  setContinued
+                  writeIORef streamState s
+              s -> do -- Idle, Open Body, HalfClosed, Closed
+                  resetContinued
+                  writeIORef streamState s
+          return True
+       where
+         setContinued = writeIORef continued (Just streamId)
+         resetContinued = writeIORef continued Nothing
+         checkContinued = do
+             mx <- readIORef continued
+             case mx of
+                 Nothing  -> return ()
+                 Just sid
+                   | sid == streamId && ftyp == FrameContinuation -> return ()
+                   | otherwise -> E.throwIO $ ConnectionError ProtocolError "continuation frame must follow"
+         getStream = do
+             mstrm0 <- search streamTable streamId
+             case mstrm0 of
+                 Just strm0 -> do
+                     when (ftyp == FrameHeaders) $ do
+                         st <- readIORef $ streamState strm0
+                         when (isHalfClosed st) $ E.throwIO $ ConnectionError ProtocolError "header must not be sent to half closed"
+                     return strm0
+                 Nothing    -> do
+                     when (ftyp `notElem` [FrameHeaders,FramePriority]) $
+                         E.throwIO $ ConnectionError ProtocolError "this frame is not allowed in an idel stream"
+                     when (ftyp == FrameHeaders) $ do
+                         csid <- readIORef currentStreamId
+                         if streamId <= csid then
+                             E.throwIO $ ConnectionError ProtocolError "stream identifier must not decrease"
+                           else
+                             writeIORef currentStreamId streamId
+                         cnt <- readIORef concurrency
+                         when (cnt >= recommendedConcurrency) $
+                             E.throwIO $ ConnectionError RefusedStream "over max concurrency"
+                     ws <- initialWindowSize <$> readIORef http2settings
+                     newstrm <- newStream streamId (fromIntegral ws)
+                     when (ftyp == FrameHeaders) $ opened ctx newstrm
+                     insert streamTable streamId newstrm
+                     return newstrm
+
+    consume = void . recvN
+
+----------------------------------------------------------------
+
+control :: FrameTypeId -> FrameHeader -> ByteString -> Context -> IO Bool
+control FrameSettings header@FrameHeader{..} bs Context{..} = do
+    SettingsFrame alist <- guardIt $ decodeSettingsFrame header bs
+    case checkSettingsList alist of
+        Just x  -> E.throwIO x
+        Nothing -> return ()
+    unless (testAck flags) $ do
+        modifyIORef http2settings $ \old -> updateSettings old alist
+        let frame = settingsFrame setAck []
+        enqueue outputQ (OFrame frame) highestPriority
+    return True
+
+control FramePing FrameHeader{..} bs Context{..} =
+    if testAck flags then
+        E.throwIO $ ConnectionError ProtocolError "the ack flag of this ping frame must not be set"
+      else do
+        let frame = pingFrame bs
+        enqueue outputQ (OFrame frame) defaultPriority
+        return True
+
+control FrameGoAway _ _ Context{..} = do
+    enqueue outputQ OFinish highestPriority
+    return False
+
+control FrameWindowUpdate header@FrameHeader{..} bs Context{..} = do
+    WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
+    w <- (n +) <$> atomically (readTVar connectionWindow)
+    when (isWindowOverflow w) $ E.throwIO $ ConnectionError FlowControlError "control window should be less than 2^31"
+    atomically $ writeTVar connectionWindow w
+    return True
+
+control _ _ _ _ =
+    -- must not reach here
+    return False
+
+----------------------------------------------------------------
+
+guardIt :: Either HTTP2Error a -> IO a
+guardIt x = case x of
+    Left err    -> E.throwIO err
+    Right frame -> return frame
+
+checkPriority :: Priority -> StreamId -> IO ()
+checkPriority p me
+  | dep == me = E.throwIO $ StreamError ProtocolError me
+  | otherwise = return ()
+  where
+    dep = streamDependency p
+
+stream :: FrameTypeId -> FrameHeader -> ByteString -> Context -> StreamState -> Stream -> IO StreamState
+stream FrameHeaders header@FrameHeader{..} bs ctx (Open JustOpened) Stream{..} = do
+    HeadersFrame mp frag <- guardIt $ decodeHeadersFrame header bs
+    pri <- case mp of
+        Nothing -> return defaultPriority
+        Just p  -> do
+            checkPriority p streamNumber
+            return p
+    let endOfStream = testEndStream flags
+        endOfHeader = testEndHeader flags
+    if endOfHeader then do
+        hdr <- hpackDecodeHeader frag ctx
+        return $ if endOfStream then
+                    Open (NoBody hdr pri)
+                   else
+                    Open (HasBody hdr pri)
+      else do
+        let !siz = BS.length frag
+        return $ Open $ Continued [frag] siz 1 endOfStream pri
+
+stream FrameHeaders header@FrameHeader{..} bs _ s@(Open (Body q)) Stream{..} = do
+    -- trailer is not supported.
+    -- let's read and ignore it.
+    HeadersFrame _ _ <- guardIt $ decodeHeadersFrame header bs
+    let endOfStream = testEndStream flags
+    if endOfStream then do
+        atomically $ writeTQueue q ""
+        return HalfClosed
+      else
+        return s
+
+stream FrameData header@FrameHeader{..} bs Context{..} s@(Open (Body q)) Stream{..} = do
+    DataFrame body <- guardIt $ decodeDataFrame header bs
+    let endOfStream = testEndStream flags
+    len0 <- readIORef streamBodyLength
+    let !len = len0 + payloadLength
+    writeIORef streamBodyLength len
+    when (payloadLength /= 0) $ do
+        let frame1 = windowUpdateFrame 0 payloadLength
+            frame2 = windowUpdateFrame streamNumber payloadLength
+            frame = frame1 `BS.append` frame2
+        enqueue outputQ (OFrame frame) highestPriority
+    atomically $ writeTQueue q body
+    if endOfStream then do
+        mcl <- readIORef streamContentLength
+        case mcl of
+            Nothing -> return ()
+            Just cl -> when (cl /= len) $ E.throwIO $ StreamError ProtocolError streamId
+        atomically $ writeTQueue q ""
+        return HalfClosed
+      else
+        return s
+
+stream FrameContinuation FrameHeader{..} frag ctx (Open (Continued rfrags siz n endOfStream pri)) _ = do
+    let endOfHeader = testEndHeader flags
+        rfrags' = frag : rfrags
+        siz' = siz + BS.length frag
+        n' = n + 1
+    when (siz' > 51200) $ -- fixme: hard coding: 50K
+      E.throwIO $ ConnectionError EnhanceYourCalm "Header is too big"
+    when (n' > 10) $ -- fixme: hard coding
+      E.throwIO $ ConnectionError EnhanceYourCalm "Header is too fragmented"
+    if endOfHeader then do
+        let hdrblk = BS.concat $ reverse rfrags'
+        hdr <- hpackDecodeHeader hdrblk ctx
+        return $ if endOfStream then
+                    Open (NoBody hdr pri)
+                   else
+                    Open (HasBody hdr pri)
+      else
+        return $ Open $ Continued rfrags' siz' n' endOfStream pri
+
+stream FrameContinuation _ _ _ _ _ = E.throwIO $ ConnectionError ProtocolError "continue frame cannot come here"
+
+stream FrameWindowUpdate header@FrameHeader{..} bs Context{..} s Stream{..} = do
+    WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
+    w <- (n +) <$> atomically (readTVar streamWindow)
+    when (isWindowOverflow w) $
+        E.throwIO $ StreamError FlowControlError streamId
+    atomically $ writeTVar streamWindow w
+    return s
+
+stream FrameRSTStream header bs ctx _ strm = do
+    RSTStreamFrame e <- guardIt $ decoderstStreamFrame header bs
+    let cc = Reset e
+    closed ctx strm cc
+    return $ Closed cc -- will be written to streamState again
+
+stream FramePriority header bs Context{..} s Stream{..} = do
+    PriorityFrame p <- guardIt $ decodePriorityFrame header bs
+    checkPriority p streamNumber
+    prepare outputQ streamNumber p
+    return s
+
+-- this ordering is important
+stream _ _ _ _ (Open Continued{}) _ = E.throwIO $ ConnectionError ProtocolError "an illegal frame follows header/continuation frames"
+stream FrameData FrameHeader{..} _ _ _ _ = E.throwIO $ StreamError StreamClosed streamId
+stream _ FrameHeader{..} _ _ _ _ = E.throwIO $ StreamError ProtocolError streamId

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -28,7 +28,15 @@ import Network.Wai.Handler.Warp.Types
 ----------------------------------------------------------------
 
 frameReceiver :: Context -> MkReq -> (BufSize -> IO ByteString) -> IO ()
-frameReceiver ctx@Context{..} mkreq recvN =
+frameReceiver ctx@Context{ http2settings
+                         , streamTable
+                         , concurrency
+                         , continued
+                         , currentStreamId
+                         , inputQ
+                         , outputQ
+                         , wait}
+              mkreq recvN =
     E.handle sendGoaway loop `E.finally` takeMVar wait
   where
     sendGoaway (ConnectionError err msg) = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE NamedFieldPuns #-}
 
 module Network.Wai.Handler.Warp.HTTP2.Receiver (frameReceiver) where
 
@@ -28,17 +27,17 @@ import Network.Wai.Handler.Warp.Types
 ----------------------------------------------------------------
 
 frameReceiver :: Context -> MkReq -> (BufSize -> IO ByteString) -> IO ()
-frameReceiver ctx@Context{ http2settings
-                         , streamTable
-                         , concurrency
-                         , continued
-                         , currentStreamId
-                         , inputQ
-                         , outputQ
-                         , wait}
-              mkreq recvN =
+frameReceiver ctx mkreq recvN =
     E.handle sendGoaway loop `E.finally` takeMVar wait
   where
+    Context{ http2settings
+           , streamTable
+           , concurrency
+           , continued
+           , currentStreamId
+           , inputQ
+           , outputQ
+           , wait} = ctx
     sendGoaway (ConnectionError err msg) = do
         csid <- readIORef currentStreamId
         let frame = goawayFrame csid err msg

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings, CPP #-}
+
+module Network.Wai.Handler.Warp.HTTP2.Request (
+    mkRequest
+  , newReadBody
+  , MkReq
+  , ValidHeaders(..)
+  , validateHeaders
+  ) where
+
+#if __GLASGOW_HASKELL__ < 709
+import Control.Applicative ((<$>))
+#endif
+import Control.Concurrent.STM
+import Control.Monad (when)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import Data.CaseInsensitive (mk)
+import Data.IORef (IORef, readIORef, newIORef, writeIORef)
+import Data.Maybe (isJust)
+#if __GLASGOW_HASKELL__ < 709
+import Data.Monoid (mempty)
+#endif
+import Data.Word8 (isUpper,_colon)
+import Network.HPACK
+import Network.HTTP.Types (RequestHeaders,hRange)
+import qualified Network.HTTP.Types as H
+import Network.Socket (SockAddr)
+import Network.Wai
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.ReadInt
+import qualified Network.Wai.Handler.Warp.Settings as S (Settings, settingsNoParsePath)
+import Network.Wai.Internal (Request(..))
+
+data ValidHeaders = ValidHeaders {
+    vhMethod :: ByteString
+  , vhPath   :: ByteString
+  , vhAuth   :: Maybe ByteString
+  , vhCL     :: Maybe Int
+  , vhHeader :: RequestHeaders
+  }
+
+type MkReq = ValidHeaders -> IO ByteString -> Request
+
+mkRequest :: S.Settings -> SockAddr -> MkReq
+mkRequest settings addr (ValidHeaders m p ma _ hdr) body = req
+  where
+    (unparsedPath,query) = B8.break (=='?') p
+    path = H.extractPath unparsedPath
+    req = Request {
+        requestMethod = m
+      , httpVersion = http2ver
+      , rawPathInfo = if S.settingsNoParsePath settings then unparsedPath else path
+      , pathInfo = H.decodePathSegments path
+      , rawQueryString = query
+      , queryString = H.parseQuery query
+      , requestHeaders = hdr
+      , isSecure = True
+      , remoteHost = addr
+      , requestBody = body
+      , vault = mempty
+      , requestBodyLength = ChunkedBody -- fixme
+      , requestHeaderHost = ma
+      , requestHeaderRange = lookup hRange hdr
+      }
+
+----------------------------------------------------------------
+
+data Pseudo = Pseudo {
+    colonMethod :: !(Maybe ByteString)
+  , colonPath   :: !(Maybe ByteString)
+  , colonAuth   :: !(Maybe ByteString)
+  , contentLen  :: !(Maybe ByteString)
+  }
+
+emptyPseudo :: Pseudo
+emptyPseudo = Pseudo Nothing Nothing Nothing Nothing
+
+validateHeaders :: HeaderList -> Maybe ValidHeaders
+validateHeaders hs = case pseudo hs (emptyPseudo,id) of
+    Just (Pseudo (Just m) (Just p) ma mcl, h)
+        -> Just $ ValidHeaders m p ma (readInt <$> mcl) h
+    _   -> Nothing
+  where
+    pseudo [] (p,b)       = Just (p,b [])
+    pseudo h@((k,v):kvs) (p,b)
+      | k == ":method"    = if isJust (colonMethod p) then
+                                Nothing
+                              else
+                                pseudo kvs (p { colonMethod = Just v },b)
+      | k == ":path"      = if isJust (colonPath p) then
+                                Nothing
+                              else
+                                pseudo kvs (p { colonPath   = Just v },b)
+      | k == ":authority" = if isJust (colonAuth p) then
+                                Nothing
+                              else
+                                pseudo kvs (p { colonAuth   = Just v },b)
+      | k == ":scheme"    = pseudo kvs (p,b) -- fixme: how to store :scheme?
+      | isPseudo k        = Nothing
+      | otherwise         = normal h (p,b)
+
+    normal [] (p,b)       = Just (p,b [])
+    normal ((k,v):kvs) (p,b)
+      | isPseudo k        = Nothing
+      | k == "connection" = Nothing
+      | k == "te"         = if v == "trailers" then
+                                normal kvs (p, b . ((mk k,v) :))
+                              else
+                                Nothing
+      | k == "content-length"
+                          = normal kvs (p { contentLen = Just v },b)
+      | k == "host"       = if isJust (colonAuth p) then
+                                normal kvs (p,b)
+                              else
+                                normal kvs (p { colonAuth = Just v },b)
+      | otherwise         = case BS.find isUpper k of
+                                 Nothing -> normal kvs (p, b . ((mk k,v) :))
+                                 Just _  -> Nothing
+
+    isPseudo "" = False
+    isPseudo k  = BS.head k == _colon
+
+
+----------------------------------------------------------------
+
+newReadBody :: TQueue ByteString -> IO (IO ByteString)
+newReadBody q = do
+    ref <- newIORef False
+    return $ readBody q ref
+
+readBody :: TQueue ByteString -> IORef Bool -> IO ByteString
+readBody q ref = do
+    eof <- readIORef ref
+    if eof then
+        return ""
+      else do
+        bs <- atomically $ readTQueue q
+        when (bs == "") $ writeIORef ref True
+        return bs

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -1,0 +1,358 @@
+{-# LANGUAGE RecordWildCards, OverloadedStrings #-}
+{-# LANGUAGE BangPatterns, CPP #-}
+
+module Network.Wai.Handler.Warp.HTTP2.Sender (frameSender) where
+
+#if __GLASGOW_HASKELL__ < 709
+import Control.Applicative
+#endif
+import Control.Concurrent (putMVar, forkIO)
+import Control.Concurrent.STM
+import qualified Control.Exception as E
+import Control.Monad (void, unless)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder.Extra as B
+import Foreign.Ptr
+import Network.HTTP2
+import Network.HTTP2.Priority
+import Network.Wai
+import Network.Wai.Handler.Warp.Buffer
+import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
+import Network.Wai.Handler.Warp.HTTP2.HPACK
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.IORef
+import qualified Network.Wai.Handler.Warp.Settings as S
+import Network.Wai.Handler.Warp.Types
+import Network.Wai.Internal (Response(..))
+import qualified System.PosixCompat.Files as P
+
+#ifdef WINDOWS
+import qualified System.IO as IO
+#else
+import Network.Wai.Handler.Warp.FdCache
+import Network.Wai.Handler.Warp.SendFile (positionRead)
+import System.Posix.Types
+#endif
+
+----------------------------------------------------------------
+
+unlessClosed :: Context -> Connection -> Stream -> IO () -> IO ()
+unlessClosed ctx Connection{..} strm@Stream{..} body = E.handle resetStream $ do
+    state <- readIORef streamState
+    unless (isClosed state) body
+  where
+    resetStream e = do
+        let rst = resetFrame InternalError streamNumber
+        connSendAll rst
+        closed ctx strm (ResetByMe e)
+
+checkWindowSize :: TVar WindowSize -> TVar WindowSize -> PriorityTree Output -> Output -> Priority -> (WindowSize -> IO ()) -> IO ()
+checkWindowSize connWindow strmWindow outQ out pri body = do
+   cw <- atomically $ do
+       w <- readTVar connWindow
+       check (w > 0)
+       return w
+   sw <- atomically $ readTVar strmWindow
+   if sw == 0 then
+       void $ forkIO $ do
+           -- checkme: if connection is closed? GC throws dead lock error?
+           atomically $ do
+               x <- readTVar strmWindow
+               check (x > 0)
+           enqueue outQ out pri
+     else
+       body (min cw sw)
+
+frameSender :: Context -> Connection -> InternalInfo -> S.Settings -> IO ()
+frameSender ctx@Context{..} conn@Connection{..} ii settings = do
+    connSendAll initialFrame
+    loop `E.finally` putMVar wait ()
+  where
+    initialSettings = [(SettingsMaxConcurrentStreams,recommendedConcurrency)]
+    initialFrame = settingsFrame id initialSettings
+    bufHeaderPayload = connWriteBuffer `plusPtr` frameHeaderLength
+    headerPayloadLim = connBufferSize - frameHeaderLength
+
+    loop = dequeue outputQ >>= \(out, pri) -> switch out pri
+
+    switch OFinish         _ = return ()
+    switch (OGoaway frame) _ = connSendAll frame
+    switch (OFrame frame)  _ = do
+        connSendAll frame
+        loop
+    switch out@(OResponse strm rsp aux) pri = unlessClosed ctx conn strm $ do
+        checkWindowSize connectionWindow (streamWindow strm) outputQ out pri $ \lim -> do
+            -- Header frame and Continuation frame
+            let sid = streamNumber strm
+                endOfStream = case aux of
+                    Persist{}  -> False
+                    Oneshot hb -> not hb
+            len <- headerContinue sid rsp endOfStream
+            let total = len + frameHeaderLength
+            case aux of
+                Oneshot hasBody -> if hasBody then do
+                    -- Data frame payload
+                    let datPayloadOff = total + frameHeaderLength
+                    Next datPayloadLen mnext <- fillResponseBodyGetNext conn ii datPayloadOff lim rsp
+                    fillDataHeaderSend strm total datPayloadLen mnext pri
+                  else do
+                    bufferIO connWriteBuffer total connSendAll
+                    closed ctx strm Finished
+                Persist sq tvar -> do
+                    let datPayloadOff = total + frameHeaderLength
+                    Next datPayloadLen mnext <- fillStreamBodyGetNext conn datPayloadOff lim sq tvar
+                    fillDataHeaderSend strm total datPayloadLen mnext pri
+        loop
+    switch out@(ONext strm curr) pri = unlessClosed ctx conn strm $ do
+        checkWindowSize connectionWindow (streamWindow strm) outputQ out pri $ \lim -> do
+            -- Data frame payload
+            Next datPayloadLen mnext <- curr lim
+            fillDataHeaderSend strm 0 datPayloadLen mnext pri
+        loop
+
+    headerContinue sid rsp endOfStream = do
+        builder <- hpackEncodeHeader ctx ii settings rsp
+        (len, signal) <- B.runBuilder builder bufHeaderPayload headerPayloadLim
+        let flag0 = case signal of
+                B.Done -> setEndHeader defaultFlags
+                _      -> defaultFlags
+            flag = if endOfStream then setEndStream flag0 else flag0
+        fillFrameHeader FrameHeaders len sid flag connWriteBuffer
+        continue sid len signal
+
+    continue _   len B.Done = return len
+    continue sid len (B.More _ writer) = do
+        bufferIO connWriteBuffer (len + frameHeaderLength) connSendAll
+        (len', signal') <- writer bufHeaderPayload headerPayloadLim
+        let flag = case signal' of
+                B.Done -> setEndHeader defaultFlags
+                _      -> defaultFlags
+        fillFrameHeader FrameContinuation len' sid flag connWriteBuffer
+        continue sid len' signal'
+    continue sid len (B.Chunk bs writer) = do
+        bufferIO connWriteBuffer (len + frameHeaderLength) connSendAll
+        let (bs1,bs2) = BS.splitAt headerPayloadLim bs
+            len' = BS.length bs1
+        void $ copy bufHeaderPayload bs1
+        fillFrameHeader FrameContinuation len' sid defaultFlags connWriteBuffer
+        if bs2 == "" then
+            continue sid len' (B.More 0 writer)
+          else
+            continue sid len' (B.Chunk bs2 writer)
+
+    fillDataHeaderSend strm otherLen datPayloadLen mnext pri = do
+        -- Data frame header
+        let sid = streamNumber strm
+            buf = connWriteBuffer `plusPtr` otherLen
+            total = otherLen + frameHeaderLength + datPayloadLen
+            flag = case mnext of
+                CFinish -> setEndStream defaultFlags
+                _       -> defaultFlags
+        fillFrameHeader FrameData datPayloadLen sid flag buf
+        bufferIO connWriteBuffer total connSendAll
+        atomically $ do
+           modifyTVar' connectionWindow (subtract datPayloadLen)
+           modifyTVar' (streamWindow strm) (subtract datPayloadLen)
+        case mnext of
+            CFinish    -> closed ctx strm Finished
+            CNext next -> enqueue outputQ (ONext strm next) pri
+            CNone      -> return ()
+
+    fillFrameHeader ftyp len sid flag buf = encodeFrameHeaderBuf ftyp hinfo buf
+      where
+        hinfo = FrameHeader len flag sid
+
+----------------------------------------------------------------
+
+{-
+ResponseFile Status ResponseHeaders FilePath (Maybe FilePart)
+ResponseBuilder Status ResponseHeaders Builder
+ResponseStream Status ResponseHeaders StreamingBody
+ResponseRaw (IO ByteString -> (ByteString -> IO ()) -> IO ()) Response
+-}
+
+fillResponseBodyGetNext :: Connection -> InternalInfo -> Int -> WindowSize -> Response -> IO Next
+fillResponseBodyGetNext Connection{..} _ off lim (ResponseBuilder _ _ bb) = do
+    let datBuf = connWriteBuffer `plusPtr` off
+        room = min (connBufferSize - off) lim
+    (len, signal) <- B.runBuilder bb datBuf room
+    return $ nextForBuilder connWriteBuffer connBufferSize len signal
+
+#ifdef WINDOWS
+fillResponseBodyGetNext Connection{..} _ off lim (ResponseFile _ _ path mpart) = do
+    let datBuf = connWriteBuffer `plusPtr` off
+        room = min (connBufferSize - off) lim
+    (start, bytes) <- fileStartEnd path mpart
+    -- fixme: how to close Handle? GC does it at this moment.
+    h <- IO.openBinaryFile path IO.ReadMode
+    IO.hSeek h IO.AbsoluteSeek start
+    len <- IO.hGetBufSome h datBuf (mini room bytes)
+    let bytes' = bytes - fromIntegral len
+    return $ nextForFile len connWriteBuffer connBufferSize h bytes' (return ())
+#else
+fillResponseBodyGetNext Connection{..} ii off lim (ResponseFile _ _ path mpart) = do
+    let Just fdcache = fdCacher ii
+    (fd, refresh) <- getFd fdcache path
+    let datBuf = connWriteBuffer `plusPtr` off
+        room = min (connBufferSize - off) lim
+    (start, bytes) <- fileStartEnd path mpart
+    len <- positionRead fd datBuf (mini room bytes) start
+    refresh
+    let len' = fromIntegral len
+    return $ nextForFile len connWriteBuffer connBufferSize fd (start + len') (bytes - len') refresh
+#endif
+
+fillResponseBodyGetNext _ _ _ _ _ = error "fillResponseBodyGetNext"
+
+fileStartEnd :: FilePath -> Maybe FilePart -> IO (Integer, Integer)
+fileStartEnd path Nothing = do
+    end <- fromIntegral . P.fileSize <$> P.getFileStatus path
+    return (0, end)
+fileStartEnd _ (Just part) =
+    return (filePartOffset part, filePartByteCount part)
+
+----------------------------------------------------------------
+
+fillStreamBodyGetNext :: Connection -> Int -> WindowSize -> TBQueue Sequence -> TVar Sync -> IO Next
+fillStreamBodyGetNext Connection{..} off lim sq tvar = do
+    let datBuf = connWriteBuffer `plusPtr` off
+        room = min (connBufferSize - off) lim
+    (leftover, cont, len) <- runStreamBuilder datBuf room sq
+    nextForStream connWriteBuffer connBufferSize sq tvar leftover cont len
+
+----------------------------------------------------------------
+
+fillBufBuilder :: Buffer -> BufSize -> Leftover -> DynaNext
+fillBufBuilder buf0 siz0 leftover lim = do
+    let payloadBuf = buf0 `plusPtr` frameHeaderLength
+        room = min (siz0 - frameHeaderLength) lim
+    case leftover of
+        LZero -> error "fillBufBuilder: LZero"
+        LOne writer -> do
+            (len, signal) <- writer payloadBuf room
+            getNext len signal
+        LTwo bs writer
+          | BS.length bs <= room -> do
+              buf1 <- copy payloadBuf bs
+              let len1 = BS.length bs
+              (len2, signal) <- writer buf1 (room - len1)
+              getNext (len1 + len2) signal
+          | otherwise -> do
+              let (bs1,bs2) = BS.splitAt room bs
+              void $ copy payloadBuf bs1
+              getNext room (B.Chunk bs2 writer)
+  where
+    getNext l s = return $ nextForBuilder buf0 siz0 l s
+
+nextForBuilder :: Buffer -> BufSize -> BytesFilled -> B.Next -> Next
+nextForBuilder _   _   len B.Done
+    = Next len CFinish
+nextForBuilder buf siz len (B.More _ writer)
+    = Next len (CNext (fillBufBuilder buf siz (LOne writer)))
+nextForBuilder buf siz len (B.Chunk bs writer)
+    = Next len (CNext (fillBufBuilder buf siz (LTwo bs writer)))
+
+----------------------------------------------------------------
+
+runStreamBuilder :: Buffer -> BufSize -> TBQueue Sequence
+                 -> IO (Leftover, Bool, BytesFilled)
+runStreamBuilder buf0 room0 sq = loop buf0 room0 0
+  where
+    loop !buf !room !total = do
+        mbuilder <- atomically $ tryReadTBQueue sq
+        case mbuilder of
+            Nothing      -> return (LZero, True, total)
+            Just (SBuilder builder) -> do
+                (len, signal) <- B.runBuilder builder buf room
+                let !total' = total + len
+                case signal of
+                    B.Done -> loop (buf `plusPtr` len) (room - len) total'
+                    B.More  _ writer  -> return (LOne writer, True, total')
+                    B.Chunk bs writer -> return (LTwo bs writer, True, total')
+            Just SFlush  -> return (LZero, True, total)
+            Just SFinish -> return (LZero, False, total)
+
+fillBufStream :: Buffer -> BufSize -> Leftover -> TBQueue Sequence -> TVar Sync -> DynaNext
+fillBufStream buf0 siz0 leftover0 sq tvar lim0 = do
+    let payloadBuf = buf0 `plusPtr` frameHeaderLength
+        room0 = min (siz0 - frameHeaderLength) lim0
+    case leftover0 of
+        LZero -> do
+            (leftover, cont, len) <- runStreamBuilder payloadBuf room0 sq
+            getNext leftover cont len
+        LOne writer -> write writer payloadBuf room0 0
+        LTwo bs writer
+          | BS.length bs <= room0 -> do
+              buf1 <- copy payloadBuf bs
+              let len = BS.length bs
+              write writer buf1 (room0 - len) len
+          | otherwise -> do
+              let (bs1,bs2) = BS.splitAt room0 bs
+              void $ copy payloadBuf bs1
+              getNext (LTwo bs2 writer) True room0
+  where
+    getNext = nextForStream buf0 siz0 sq tvar
+    write writer1 buf room sofar = do
+        (len, signal) <- writer1 buf room
+        case signal of
+            B.Done -> do
+                (leftover, cont, extra) <- runStreamBuilder (buf `plusPtr` len) (room - len) sq
+                let !total = sofar + len + extra
+                getNext leftover cont total
+            B.More  _ writer -> do
+                let !total = sofar + len
+                getNext (LOne writer) True total
+            B.Chunk bs writer -> do
+                let !total = sofar + len
+                getNext (LTwo bs writer) True total
+
+nextForStream :: Buffer -> BufSize -> TBQueue Sequence -> TVar Sync
+              -> Leftover -> Bool -> BytesFilled
+              -> IO Next
+nextForStream _  _ _  tvar _ False len = do
+    atomically $ writeTVar tvar SyncFinish
+    return $ Next len CFinish
+nextForStream buf siz sq tvar LZero True len = do
+    atomically $ writeTVar tvar $ SyncNext (fillBufStream buf siz LZero sq tvar)
+    return $ Next len CNone
+nextForStream buf siz sq tvar leftover True len =
+    return $ Next len (CNext (fillBufStream buf siz leftover sq tvar))
+
+----------------------------------------------------------------
+
+#ifdef WINDOWS
+fillBufFile :: Buffer -> BufSize -> IO.Handle -> Integer -> IO () -> DynaNext
+fillBufFile buf siz h bytes refresh lim = do
+    let payloadBuf = buf `plusPtr` frameHeaderLength
+        room = min (siz - frameHeaderLength) lim
+    len <- IO.hGetBufSome h payloadBuf room
+    refresh
+    let bytes' = bytes - fromIntegral len
+    return $ nextForFile len buf siz h bytes' refresh
+
+nextForFile :: BytesFilled -> Buffer -> BufSize -> IO.Handle -> Integer -> IO () -> Next
+nextForFile 0   _   _   _  _    _       = Next 0 CFinish
+nextForFile len _   _   _  0    _       = Next len CFinish
+nextForFile len buf siz h bytes refresh =
+    Next len (CNext (fillBufFile buf siz h bytes refresh))
+#else
+fillBufFile :: Buffer -> BufSize -> Fd -> Integer -> Integer -> IO () -> DynaNext
+fillBufFile buf siz fd start bytes refresh lim = do
+    let payloadBuf = buf `plusPtr` frameHeaderLength
+        room = min (siz - frameHeaderLength) lim
+    len <- positionRead fd payloadBuf (mini room bytes) start
+    let len' = fromIntegral len
+    refresh
+    return $ nextForFile len buf siz fd (start + len') (bytes - len') refresh
+
+nextForFile :: BytesFilled -> Buffer -> BufSize -> Fd -> Integer -> Integer -> IO () -> Next
+nextForFile 0   _   _   _  _     _     _       = Next 0 CFinish
+nextForFile len _   _   _  _     0     _       = Next len CFinish
+nextForFile len buf siz fd start bytes refresh =
+    Next len (CNext (fillBufFile buf siz fd start bytes refresh))
+#endif
+
+mini :: Int -> Integer -> Int
+mini i n
+  | fromIntegral i < n = i
+  | otherwise          = fromIntegral n

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedStrings, RecordWildCards, CPP #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
 
 module Network.Wai.Handler.Warp.HTTP2.Types where
 
@@ -193,12 +194,12 @@ newStream sid win = Stream sid <$> newIORef Idle
 ----------------------------------------------------------------
 
 opened :: Context -> Stream -> IO ()
-opened Context{..} Stream{..} = do
+opened Context{concurrency} Stream{streamState} = do
     atomicModifyIORef' concurrency (\x -> ((x+1),()))
     writeIORef streamState (Open JustOpened)
 
 closed :: Context -> Stream -> ClosedCode -> IO ()
-closed Context{..} Stream{..} cc = do
+closed Context{concurrency} Stream{streamState} cc = do
     atomicModifyIORef' concurrency (\x -> ((x-1),()))
     writeIORef streamState (Closed cc)
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -84,16 +84,23 @@ data Leftover = LZero
 
 ----------------------------------------------------------------
 
+-- | The context for HTTP/2 connection.
 data Context = Context {
     http2settings      :: IORef Settings
   , streamTable        :: StreamTable
   , concurrency        :: IORef Int
+  -- | RFC 7540 says "Other frames (from any stream) MUST NOT
+  --   occur between the HEADERS frame and any CONTINUATION
+  --   frames that might follow". This field is used to implement
+  --   this requirement.
   , continued          :: IORef (Maybe StreamId)
   , currentStreamId    :: IORef StreamId
   , inputQ             :: TQueue Input
   , outputQ            :: PriorityTree Output
   , encodeDynamicTable :: IORef DynamicTable
   , decodeDynamicTable :: IORef DynamicTable
+  -- | This is used to synchronization of sender and receiver
+  --   when the HTTP/2 connection is terminated.
   , wait               :: MVar ()
   , connectionWindow   :: TVar WindowSize
   }

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE OverloadedStrings, RecordWildCards, CPP #-}
+
+module Network.Wai.Handler.Warp.HTTP2.Types where
+
+import Blaze.ByteString.Builder (Builder)
+#if __GLASGOW_HASKELL__ < 709
+import Control.Applicative ((<$>),(<*>))
+#endif
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Exception (SomeException)
+import Control.Monad (void)
+import Control.Reaper
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder.Extra as B
+import Data.IntMap.Strict (IntMap, IntMap)
+import qualified Data.IntMap.Strict as M
+import qualified Network.HTTP.Types as H
+import Network.Wai (Request, Response)
+import Network.Wai.Handler.Warp.IORef
+import Network.Wai.Handler.Warp.Types
+
+import Network.HTTP2
+import Network.HTTP2.Priority
+import Network.HPACK
+
+----------------------------------------------------------------
+
+http2ver :: H.HttpVersion
+http2ver = H.HttpVersion 2 0
+
+isHTTP2 :: Transport -> Bool
+isHTTP2 TCP = False
+isHTTP2 tls = useHTTP2
+  where
+    useHTTP2 = case tlsNegotiatedProtocol tls of
+        Nothing    -> False
+        Just proto -> "h2-" `BS.isPrefixOf` proto
+
+----------------------------------------------------------------
+
+data Input = Input Stream Request Priority
+
+----------------------------------------------------------------
+
+data Control a = CFinish
+               | CNext a
+               | CNone
+
+instance Show (Control a) where
+    show CFinish   = "CFinish"
+    show (CNext _) = "CNext"
+    show CNone     = "CNone"
+
+type DynaNext = WindowSize -> IO Next
+
+type BytesFilled = Int
+
+data Next = Next BytesFilled (Control DynaNext)
+
+data Output = OFinish
+            | OGoaway ByteString
+            | OFrame  ByteString
+            | OResponse Stream Response Aux
+            | ONext Stream DynaNext
+
+----------------------------------------------------------------
+
+data Sequence = SFinish
+              | SFlush
+              | SBuilder Builder
+
+data Sync = SyncNone
+          | SyncFinish
+          | SyncNext DynaNext
+
+data Aux = Oneshot Bool
+         | Persist (TBQueue Sequence) (TVar Sync)
+
+data Leftover = LZero
+              | LOne B.BufferWriter
+              | LTwo ByteString B.BufferWriter
+
+----------------------------------------------------------------
+
+data Context = Context {
+    http2settings      :: IORef Settings
+  , streamTable        :: StreamTable
+  , concurrency        :: IORef Int
+  , continued          :: IORef (Maybe StreamId)
+  , currentStreamId    :: IORef StreamId
+  , inputQ             :: TQueue Input
+  , outputQ            :: PriorityTree Output
+  , encodeDynamicTable :: IORef DynamicTable
+  , decodeDynamicTable :: IORef DynamicTable
+  , wait               :: MVar ()
+  , connectionWindow   :: TVar WindowSize
+  }
+
+----------------------------------------------------------------
+
+newContext :: IO Context
+newContext = Context <$> newIORef defaultSettings
+                     <*> initialize 10 -- fixme: hard coding: 10
+                     <*> newIORef 0
+                     <*> newIORef Nothing
+                     <*> newIORef 0
+                     <*> newTQueueIO
+                     <*> newPriorityTree
+                     <*> (newDynamicTableForEncoding defaultDynamicTableSize >>= newIORef)
+                     <*> (newDynamicTableForDecoding defaultDynamicTableSize >>= newIORef)
+                     <*> newEmptyMVar
+                     <*> newTVarIO defaultInitialWindowSize
+
+clearContext :: Context -> IO ()
+clearContext ctx = stop $ streamTable ctx
+
+----------------------------------------------------------------
+
+data OpenState =
+    JustOpened
+  | Continued [HeaderBlockFragment]
+              Int  -- Total size
+              Int  -- The number of continuation frames
+              Bool -- End of stream
+              Priority
+  | NoBody HeaderList Priority
+  | HasBody HeaderList Priority
+  | Body (TQueue ByteString)
+
+data ClosedCode = Finished
+                | Killed
+                | Reset ErrorCodeId
+                | ResetByMe SomeException
+                deriving Show
+
+data StreamState =
+    Idle
+  | Open OpenState
+  | HalfClosed
+  | Closed ClosedCode
+
+isIdle :: StreamState -> Bool
+isIdle Idle = True
+isIdle _    = False
+
+isOpen :: StreamState -> Bool
+isOpen Open{} = True
+isOpen _      = False
+
+isHalfClosed :: StreamState -> Bool
+isHalfClosed HalfClosed = True
+isHalfClosed _          = False
+
+isClosed :: StreamState -> Bool
+isClosed Closed{} = True
+isClosed _        = False
+
+instance Show StreamState where
+    show Idle        = "Idle"
+    show Open{}      = "Open"
+    show HalfClosed  = "HalfClosed"
+    show (Closed e)  = "Closed: " ++ show e
+
+----------------------------------------------------------------
+
+data Stream = Stream {
+    streamNumber        :: StreamId
+  , streamState         :: IORef StreamState
+  -- Next two fields are for error checking.
+  , streamContentLength :: IORef (Maybe Int)
+  , streamBodyLength    :: IORef Int
+  , streamWindow        :: TVar WindowSize
+  }
+
+instance Show Stream where
+  show s = show (streamNumber s)
+
+newStream :: StreamId -> WindowSize -> IO Stream
+newStream sid win = Stream sid <$> newIORef Idle
+                               <*> newIORef Nothing
+                               <*> newIORef 0
+                               <*> newTVarIO win
+
+----------------------------------------------------------------
+
+opened :: Context -> Stream -> IO ()
+opened Context{..} Stream{..} = do
+    atomicModifyIORef' concurrency (\x -> ((x+1),()))
+    writeIORef streamState (Open JustOpened)
+
+closed :: Context -> Stream -> ClosedCode -> IO ()
+closed Context{..} Stream{..} cc = do
+    atomicModifyIORef' concurrency (\x -> ((x-1),()))
+    writeIORef streamState (Closed cc)
+
+----------------------------------------------------------------
+
+type StreamTable = Reaper (IntMap Stream) (M.Key, Stream)
+
+initialize :: Int -> IO StreamTable
+initialize duration = mkReaper settings
+  where
+    settings = defaultReaperSettings {
+          reaperAction = clean
+        , reaperDelay  = duration * 1000000
+        , reaperCons   = uncurry M.insert
+        , reaperNull   = M.null
+        , reaperEmpty  = M.empty
+        }
+
+clean :: IntMap Stream -> IO (IntMap Stream -> IntMap Stream)
+clean old = do
+    new <- M.fromAscList <$> prune oldlist []
+    return $ M.union new
+  where
+    oldlist = M.toDescList old
+    prune []     lst = return lst
+    prune (x@(_,s):xs) lst = do
+        st <- readIORef (streamState s)
+        if isClosed st then
+            prune xs lst
+          else
+            prune xs (x:lst)
+
+insert :: StreamTable -> M.Key -> Stream -> IO ()
+insert strmtbl k v = reaperAdd strmtbl (k,v)
+
+search :: StreamTable -> M.Key -> IO (Maybe Stream)
+search strmtbl k = M.lookup k <$> reaperRead strmtbl
+
+stop :: StreamTable -> IO ()
+stop strmtbl = void $ reaperStop strmtbl
+

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Network.Wai.Handler.Warp.HTTP2.Worker where
+
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Exception as E
+import Control.Monad (void, forever, when)
+import Data.Typeable
+import qualified Network.HTTP.Types as H
+import Network.HTTP2
+import Network.HTTP2.Priority
+import Network.Wai
+import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
+import Network.Wai.Handler.Warp.HTTP2.Types
+import Network.Wai.Handler.Warp.IORef
+import qualified Network.Wai.Handler.Warp.Response as R
+import qualified Network.Wai.Handler.Warp.Settings as S
+import qualified Network.Wai.Handler.Warp.Timeout as T
+import Network.Wai.Internal (Response(..), ResponseReceived(..))
+
+----------------------------------------------------------------
+
+type Responder = Stream -> Priority -> Request -> Response -> IO ResponseReceived
+
+response :: Context -> Responder
+response Context{..} strm pri req rsp = do
+    case rsp of
+        ResponseStream _ _ strmbdy -> do
+            -- fixme: spawn a new worker thread.
+            --
+            -- We must not exit this WAI application.
+            -- If the application exits, streaming would be also closed.
+            -- Since 'StreamingBody' is loop, we cannot control it.
+            -- So, let's serialize 'Builder' with a designated queue.
+            sq <- newTBQueueIO 10
+            tvar <- newTVarIO SyncNone
+            enqueue outputQ (OResponse strm rsp (Persist sq tvar)) pri
+            let push b = atomically $ writeTBQueue sq (SBuilder b)
+                flush  = atomically $ writeTBQueue sq SFlush
+            -- Since we must not enqueue an empty queue to the priority
+            -- queue, we spawn a thread to ensure that the designated
+            -- queue is not empty.
+            void $ forkIO $ waiter tvar sq (enqueue outputQ) strm pri
+            -- fixme: tickle?
+            strmbdy push flush
+            atomically $ writeTBQueue sq SFinish
+        _ -> do
+            let hasBody = requestMethod req /= H.methodHead
+                       || R.hasBody (responseStatus rsp)
+            enqueue outputQ (OResponse strm rsp (Oneshot hasBody)) pri
+    return ResponseReceived
+
+data Break = Break deriving (Show, Typeable)
+
+instance Exception Break
+
+worker :: Context -> S.Settings -> T.Manager -> Application -> Responder -> IO ()
+worker ctx@Context{..} set tm app responder = do
+    tid <- myThreadId
+    ref <- newIORef Nothing
+    bracket (T.register tm (E.throwTo tid Break)) T.cancel $ \th ->
+        go th ref `E.catch` gonext th ref
+  where
+    go th ref = forever $ do
+        Input strm req pri <- atomically $ readTQueue inputQ
+        T.tickle th
+        writeIORef ref (Just strm)
+        -- catching IO errors.
+        E.handle (S.settingsOnException set Nothing)
+                 (void $ app req $ responder strm pri req)
+    gonext th ref Break = handleErrorAndGo `E.catch` gonext th ref
+      where
+        handleErrorAndGo = do
+            m <- readIORef ref
+            case m of
+                Nothing   -> return ()
+                Just strm -> do
+                    let frame = resetFrame InternalError (streamNumber strm)
+                    enqueue outputQ (OFrame frame) highestPriority
+                    closed ctx strm Killed
+                    writeIORef ref Nothing
+                    go th ref
+
+waiter :: TVar Sync -> TBQueue Sequence
+       -> (Output -> Priority -> IO ()) -> Stream -> Priority
+       -> IO ()
+waiter tvar sq enq strm pri = do
+    mx <- atomically $ do
+        mout <- readTVar tvar
+        case mout of
+            SyncNone     -> retry
+            SyncNext nxt -> do
+                writeTVar tvar SyncNone
+                return $ Just nxt
+            SyncFinish   -> return Nothing
+    case mx of
+        Nothing -> return ()
+        Just next -> do
+            atomically $ do
+                isEmpty <- isEmptyTBQueue sq
+                when isEmpty retry
+            enq (ONext strm next) pri
+            waiter tvar sq enq strm pri
+

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -9,6 +9,9 @@ module Network.Wai.Handler.Warp.Response (
   , fileRange -- for testing
   , warpVersion
   , defaultServerValue
+  , addDate
+  , addServer
+  , hasBody
   ) where
 
 #ifndef MIN_VERSION_base

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -4,6 +4,9 @@ module Network.Wai.Handler.Warp.SendFile (
     sendFile
   , readSendFile
   , packHeader -- for testing
+#ifndef WINDOWS
+  , positionRead
+#endif
   ) where
 
 import Control.Monad (void)
@@ -23,7 +26,6 @@ import qualified System.IO as IO
 # if __GLASGOW_HASKELL__ < 709
 import Control.Applicative ((<$>))
 # endif
-import Data.Word (Word8)
 import Control.Exception
 import Foreign.C.Types
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
@@ -140,10 +142,10 @@ readSendFile buf siz send fid off0 len0 hook headers =
           hook
           loop fd (len - n') (off + n')
 
-positionRead :: Fd -> Ptr Word8 -> Int -> Integer -> IO Int
-positionRead (Fd fd) buf siz off =
+positionRead :: Fd -> Buffer -> BufSize -> Integer -> IO Int
+positionRead fd buf siz off =
     fromIntegral <$> c_pread fd (castPtr buf) (fromIntegral siz) (fromIntegral off)
 
 foreign import ccall unsafe "pread"
-  c_pread :: CInt -> Ptr CChar -> ByteCount -> FileOffset -> IO ByteCount -- fixme
+  c_pread :: Fd -> Ptr CChar -> ByteCount -> FileOffset -> IO CSsize
 #endif

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -115,6 +115,9 @@ data Connection = Connection {
     , connClose       :: IO ()
     -- | The connection receiving function. This returns "" for EOF.
     , connRecv        :: Recv
+    -- | The connection receiving function. This tries to fill the buffer.
+    --   This returns when the buffer is filled or reaches EOF.
+    , connRecvBuf     :: RecvBuf
     -- | The write buffer.
     , connWriteBuffer :: Buffer
     -- | The size of the write buffer.
@@ -126,6 +129,7 @@ data Connection = Connection {
 -- | Internal information.
 data InternalInfo = InternalInfo {
     threadHandle :: T.Handle
+  , timeoutManager :: T.Manager
   , fdCacher :: Maybe F.MutableFdCache
   , dateCacher :: D.DateCache
   }

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -37,9 +37,11 @@ Library
                    , blaze-builder             >= 0.3.3    && < 0.5
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2
+                   , containers
                    , ghc-prim
                    , http-types                >= 0.8.5
                    , iproute                   >= 1.3.1
+                   , http2
                    , simple-sendfile           >= 0.2.7    && < 0.3
                    , unix-compat               >= 0.2
                    , wai                       >= 3.0      && < 3.1
@@ -47,6 +49,7 @@ Library
                    , streaming-commons         >= 0.1.10
                    , vault                     >= 0.3
                    , stm                       >= 2.3
+                   , word8
   if flag(network-bytestring)
       Build-Depends: network                   >= 2.2.1.5  && < 2.2.3
                    , network-bytestring        >= 0.1.3    && < 0.1.4
@@ -64,6 +67,14 @@ Library
                      Network.Wai.Handler.Warp.Counter
                      Network.Wai.Handler.Warp.Date
                      Network.Wai.Handler.Warp.FdCache
+                     Network.Wai.Handler.Warp.HTTP2
+                     Network.Wai.Handler.Warp.HTTP2.EncodeFrame
+                     Network.Wai.Handler.Warp.HTTP2.HPACK
+                     Network.Wai.Handler.Warp.HTTP2.Receiver
+                     Network.Wai.Handler.Warp.HTTP2.Request
+                     Network.Wai.Handler.Warp.HTTP2.Sender
+                     Network.Wai.Handler.Warp.HTTP2.Types
+                     Network.Wai.Handler.Warp.HTTP2.Worker
                      Network.Wai.Handler.Warp.Header
                      Network.Wai.Handler.Warp.IO
                      Network.Wai.Handler.Warp.IORef
@@ -148,6 +159,9 @@ Test-Suite spec
                    , stm                       >= 2.3
                    , directory
                    , process
+                   , containers
+                   , http2
+                   , word8
   if flag(use-bytestring-builder)
       Build-Depends: bytestring                < 0.10.2.0
                    , bytestring-builder

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -41,7 +41,7 @@ Library
                    , ghc-prim
                    , http-types                >= 0.8.5
                    , iproute                   >= 1.3.1
-                   , http2
+                   , http2                     >= 1.0.2
                    , simple-sendfile           >= 0.2.7    && < 0.3
                    , unix-compat               >= 0.2
                    , wai                       >= 3.0      && < 3.1
@@ -160,7 +160,7 @@ Test-Suite spec
                    , directory
                    , process
                    , containers
-                   , http2
+                   , http2                     >= 1.0.2
                    , word8
   if flag(use-bytestring-builder)
       Build-Depends: bytestring                < 0.10.2.0


### PR DESCRIPTION
This patch implements HTTP/2 ([RFC 7540](https://tools.ietf.org/html/rfc7540)). 

This code passes the following three tests:

-- All test cases provided by [h2spec](https://github.com/summerwind/h2spec)
-- Test cases provided by [nghttp](https://nghttp2.org/documentation/nghttp.1.html)
-- Field test in the real web world

Recent Firefox and Chrome supports HTTP/2 over TLS. With this patch, WarpTLS automatically communicates with Firefox and Chrome in HTTP/2. There is no settings to disable HTTP/2 at this moment. We should implement them if necessary.

The following picture illustrates rough architecture:

```

         Input queue                          Output queue
Receiver ----------> Thread pool for WAI apps -----------> Sender
```

In HTTP/2, multiple streams are asynchronously sent over a TCP connection.

- The receiver receives HTTP/2 frames, decodes them and enqueues WAI requests to the input queue. The logic of the input buffer is highly tuned.
- A worker thread in the thread pool dequeues a WAI request, gives it to a WAI application, takes its response and enqueues the response to the output priority queue.
- The sender packs a response in the output buffer and send it.

One concern: the number of worker threads in the worker pool is now hard coded -- 10. Unlike ResponseFile and ResponseBuilder, ResponseStream occupies the worker thread. So, if 10 streamings are served, no worker is available. We should fix this if necessary.

@snoyberg Please review and merge this if you think OK.
