### PR TITLE
Treat exceeding the concurrency limit as a stream error.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -324,5 +324,7 @@ stream FramePriority header bs Context{outputQ} s Stream{streamNumber} = do
 
 -- this ordering is important
 stream _ _ _ _ (Open Continued{}) _ = E.throwIO $ ConnectionError ProtocolError "an illegal frame follows header/continuation frames"
+-- Ignore frames to streams we have just reset, per section 5.1.
+stream _ _ _ _ st@(Closed (ResetByMe _)) _ = return st
 stream FrameData FrameHeader{streamId} _ _ _ _ = E.throwIO $ StreamError StreamClosed streamId
 stream _ FrameHeader{streamId} _ _ _ _ = E.throwIO $ StreamError ProtocolError streamId


### PR DESCRIPTION
Previously it caused the entire connection to be torn down.  The HTTP2 spec requires servers to treat this as a stream error, not a connection error.

Fixes #404.