### PR TITLE
Prevent no-longer-"useful" buffers from staying in the BufferPool.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -69,7 +69,7 @@ getBuffer pool = do
 {-# INLINE getBuffer #-}
 
 putBuffer :: BufferPool -> ByteString -> IO ()
-putBuffer pool buffer = when (usefulBuffer buffer) $ writeIORef pool buffer
+putBuffer pool buffer = writeIORef pool buffer
 {-# INLINE putBuffer #-}
 
 withForeignBuffer :: ByteString -> ((Buffer, BufSize) -> IO Int) -> IO Int

--- a/warp/test/BufferPoolSpec.hs
+++ b/warp/test/BufferPoolSpec.hs
@@ -1,0 +1,47 @@
+module BufferPoolSpec where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as B (ByteString(PS))
+import Foreign.ForeignPtr (withForeignPtr)
+import Foreign.Marshal.Utils (copyBytes)
+import Foreign.Ptr (plusPtr)
+
+import Test.Hspec (Spec, hspec, shouldBe, describe, it)
+
+import Network.Wai.Handler.Warp.Buffer
+    ( bufferSize
+    , newBufferPool
+    , withBufferPool
+    )
+import Network.Wai.Handler.Warp.Types (Buffer, BufSize)
+
+main :: IO ()
+main = hspec spec
+
+-- Two ByteStrings each big enough to fill a 'bufferSize' buffer (16K).
+wantData, otherData :: B.ByteString
+wantData = B.replicate bufferSize 0xac
+otherData = B.replicate bufferSize 0x77
+
+spec :: Spec
+spec = describe "withBufferPool" $ do
+    it "does not clobber buffers" $ do
+        pool <- newBufferPool
+        -- 'pool' contains B.empty; prime it to contain a real buffer.
+        _ <- withBufferPool pool $ const $ return 0
+        -- 'pool' contains a 16K buffer; fill it with \xac and keep the result.
+        got <- withBufferPool pool $ blitBuffer wantData
+        got `shouldBe` wantData
+        -- 'pool' should now be empty and reallocate, rather than clobber the
+        -- previous buffer.
+        _ <- withBufferPool pool $ blitBuffer otherData
+        got `shouldBe` wantData
+
+-- Fill the Buffer with the contents of the ByteString and return the number of
+-- bytes written.  To be used with 'withBufferPool'.
+blitBuffer :: B.ByteString -> (Buffer, BufSize) -> IO Int
+blitBuffer (B.PS fp off len) (dst, len') = withForeignPtr fp $ \ptr -> do
+    let src = ptr `plusPtr` off
+        n = min len len'
+    copyBytes dst src n
+    return n

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -122,7 +122,8 @@ Test-Suite doctest
 
 Test-Suite spec
     Main-Is:         Spec.hs
-    Other-modules:   ConduitSpec
+    Other-modules:   BufferPoolSpec
+                     ConduitSpec
                      ExceptionSpec
                      FdCacheSpec
                      MultiMapSpec


### PR DESCRIPTION
Previously, when 'receive' pulled a buffer and filled enough space in it to make it cease to be "useful" (i.e. have less remaining space than a certain threshold), it would be left in the BufferPool IORef and overwritten by the next 'receive' call.  This broke referential transparency of the ByteStrings and caused corruption of request bodies and, less frequently, protocol synchronization data.

Fixes #406.