### PR TITLE
Add X-Forwarded-Proto to appearsSecure.

### DIFF
--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -32,6 +32,7 @@ appearsSecure request = isSecure request || any (uncurry matchHeader)
     , ("HTTP_X_FORWARDED_SSL"   , (== "on"))
     , ("HTTP_X_FORWARDED_SCHEME", (== "https"))
     , ("HTTP_X_FORWARDED_PROTO" , ((== ["https"]) . take 1 . C.split ','))
+    , ("X-Forwarded-Proto"      , (== "https")) -- Used by Nginx and AWS ELB.
     ]
 
   where


### PR DESCRIPTION
The X-Forwarded-Proto header is the default for Nginx[1] and is also used by Amazon's Elastic Load-Balancers (which run Nginx)[2].

I've left the other "X_FORWARDED_" headers although I'm not aware in which settings they would be used and suspect they never would.

[1] http://wiki.nginx.org/SSL-Offloader
[2] http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/x-forwarded-headers.html