### PR TITLE
Remove causes of compiler warnings. Use headers from http-types.

### DIFF
--- a/wai-extra/Network/Wai/EventSource.hs
+++ b/wai-extra/Network/Wai/EventSource.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-|
     A WAI adapter to the HTML5 Server-Sent Events API.
 -}
@@ -8,12 +7,11 @@ module Network.Wai.EventSource (
     eventSourceAppIO
     ) where
 
-import           Blaze.ByteString.Builder (Builder)
 import           Data.Function (fix)
 import           Control.Concurrent.Chan (Chan, dupChan, readChan)
 import           Control.Monad.IO.Class (liftIO)
-import           Network.HTTP.Types (status200)
-import           Network.Wai (Application, Response, responseStream)
+import           Network.HTTP.Types (status200, hContentType)
+import           Network.Wai (Application, responseStream)
 
 import Network.Wai.EventSource.EventStream
 
@@ -30,7 +28,7 @@ eventSourceAppIO :: IO ServerEvent -> Application
 eventSourceAppIO src _ sendResponse =
     sendResponse $ responseStream
         status200
-        [("Content-Type", "text/event-stream")]
+        [(hContentType, "text/event-stream")]
         $ \sendChunk flush -> fix $ \loop -> do
             se <- src
             case eventToBuilder se of

--- a/wai-extra/Network/Wai/EventSource/EventStream.hs
+++ b/wai-extra/Network/Wai/EventSource/EventStream.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 {- code adapted by Mathias Billman originaly from Chris Smith https://github.com/cdsmith/gloss-web -}
 
 {-|
@@ -11,7 +11,9 @@ module Network.Wai.EventSource.EventStream (
 
 import Blaze.ByteString.Builder
 import Blaze.ByteString.Builder.Char8
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
+#endif
 
 {-|
     Type representing a communication over an event stream.  This can be an

--- a/wai-extra/Network/Wai/Middleware/AcceptOverride.hs
+++ b/wai-extra/Network/Wai/Middleware/AcceptOverride.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Network.Wai.Middleware.AcceptOverride
     ( acceptOverride
     ) where

--- a/wai-extra/Network/Wai/Middleware/AddHeaders.hs
+++ b/wai-extra/Network/Wai/Middleware/AddHeaders.hs
@@ -5,7 +5,7 @@ module Network.Wai.Middleware.AddHeaders
     ( addHeaders
     ) where
 
-import Network.HTTP.Types   (ResponseHeaders, Header)
+import Network.HTTP.Types   (Header)
 import Network.Wai          (Middleware, modifyResponse, mapResponseHeaders)
 import Network.Wai.Internal (Response(..))
 import Data.ByteString      (ByteString)

--- a/wai-extra/Network/Wai/Middleware/Approot.hs
+++ b/wai-extra/Network/Wai/Middleware/Approot.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- | Middleware for establishing the root of the application.
 --
 -- Many application need the ability to create URLs referring back to the
@@ -29,13 +28,12 @@ module Network.Wai.Middleware.Approot
 
 import           Control.Exception     (Exception, throw)
 import           Data.ByteString       (ByteString)
-import qualified Data.ByteString       as S
 import qualified Data.ByteString.Char8 as S8
 import           Data.Maybe            (fromMaybe)
 import           Data.Typeable         (Typeable)
 import qualified Data.Vault.Lazy       as V
-import           Network.Wai (Request, vault, Middleware, requestHeaderHost)
-import           Network.Wai.Request   (appearsSecure, guessApproot)
+import           Network.Wai (Request, vault, Middleware)
+import           Network.Wai.Request   (guessApproot)
 import           System.Environment    (getEnvironment)
 import           System.IO.Unsafe      (unsafePerformIO)
 

--- a/wai-extra/Network/Wai/Middleware/Autohead.hs
+++ b/wai-extra/Network/Wai/Middleware/Autohead.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 -- | Automatically produce responses to HEAD requests based on the underlying
 -- applications GET response.
 module Network.Wai.Middleware.Autohead (autohead) where
 
 import Network.Wai
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mempty)
+#endif
 
 autohead :: Middleware
 autohead app req sendResponse

--- a/wai-extra/Network/Wai/Middleware/CleanPath.hs
+++ b/wai-extra/Network/Wai/Middleware/CleanPath.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Network.Wai.Middleware.CleanPath
     ( cleanPath
     ) where
@@ -6,9 +6,11 @@ module Network.Wai.Middleware.CleanPath
 import Network.Wai
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as L
-import Network.HTTP.Types (status301)
+import Network.HTTP.Types (status301, hLocation)
 import Data.Text (Text)
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mconcat)
+#endif
 
 cleanPath :: ([Text] -> Either B.ByteString [Text])
           -> B.ByteString
@@ -19,7 +21,7 @@ cleanPath splitter prefix app env sendResponse =
         Right pieces -> app pieces env sendResponse
         Left p -> sendResponse
                 $ responseLBS status301
-                  [("Location", mconcat [prefix, p, suffix])]
+                  [(hLocation, mconcat [prefix, p, suffix])]
                 $ L.empty
     where
         -- include the query string if present

--- a/wai-extra/Network/Wai/Middleware/ForceSSL.hs
+++ b/wai-extra/Network/Wai/Middleware/ForceSSL.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- | Redirect non-SSL requests to https
 --
 -- Since 3.0.7

--- a/wai-extra/Network/Wai/Middleware/Local.hs
+++ b/wai-extra/Network/Wai/Middleware/Local.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE CPP #-}
 -- | Only allow local connections.
 --
 module Network.Wai.Middleware.Local

--- a/wai-extra/Network/Wai/Middleware/MethodOverride.hs
+++ b/wai-extra/Network/Wai/Middleware/MethodOverride.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.MethodOverride
     ( methodOverride
     ) where

--- a/wai-extra/Network/Wai/Middleware/MethodOverridePost.hs
+++ b/wai-extra/Network/Wai/Middleware/MethodOverridePost.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------
 -- | Module : Network.Wai.Middleware.MethodOverridePost
 --
@@ -9,8 +9,11 @@ module Network.Wai.Middleware.MethodOverridePost
   ) where
 
 import Network.Wai
-import Network.HTTP.Types           (parseQuery)
+import Network.HTTP.Types           (parseQuery, hContentType)
+
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid                  (mconcat, mempty)
+#endif
 import Data.IORef
 import Data.ByteString.Lazy (toChunks)
 
@@ -27,7 +30,7 @@ import Data.ByteString.Lazy (toChunks)
 --
 methodOverridePost :: Middleware
 methodOverridePost app req send =
-    case (requestMethod req, lookup "Content-Type" (requestHeaders req)) of
+    case (requestMethod req, lookup hContentType (requestHeaders req)) of
       ("POST", Just "application/x-www-form-urlencoded") -> setPost req >>= flip app send
       _                                                  -> app req send
 

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-
 -- NOTE: Due to https://github.com/yesodweb/wai/issues/192, this module should
 -- not use CPP.
 module Network.Wai.Middleware.RequestLogger
@@ -30,17 +28,14 @@ import Network.HTTP.Types as H
 import Data.Maybe (fromMaybe)
 import Data.Monoid (mconcat, (<>))
 import Data.Time (getCurrentTime, diffUTCTime)
-
-import Network.Wai.Parse (sinkRequestBody, lbsBackEnd, fileName, Param, File, getRequestBodyType)
+import Network.Wai.Parse (sinkRequestBody, lbsBackEnd, fileName, Param, File
+                         , getRequestBodyType)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Char8 as S8
-
 import System.Console.ANSI
 import Data.IORef.Lifted
 import System.IO.Unsafe
-import Control.Monad (unless)
 import Network.Wai.Internal (Response (ResponseRaw))
-
 import Data.Default.Class (Default (def))
 import Network.Wai.Logger
 import Network.Wai.Middleware.RequestLogger.Internal
@@ -103,7 +98,7 @@ mkRequestLogger RequestLoggerSettings{..} = do
 
 apacheMiddleware :: ApacheLoggerActions -> Middleware
 apacheMiddleware ala app req sendResponse = app req $ \res -> do
-    let msize = lookup "content-length" (responseHeaders res) >>= readInt'
+    let msize = lookup H.hContentLength (responseHeaders res) >>= readInt'
         readInt' bs =
             case S8.readInteger bs of
                 Just (i, "") -> Just i
@@ -193,7 +188,7 @@ detailedMiddleware' :: Callback
                     -> (BS.ByteString -> BS.ByteString -> [BS.ByteString])
                     -> Middleware
 detailedMiddleware' cb ansiColor ansiMethod ansiStatusCode app req sendResponse = do
-    let mlen = lookup "content-length" (requestHeaders req) >>= readInt
+    let mlen = lookup H.hContentLength (requestHeaders req) >>= readInt
     (req', body) <-
         case mlen of
             -- log the request body if it is small
@@ -231,7 +226,7 @@ detailedMiddleware' cb ansiColor ansiMethod ansiStatusCode app req sendResponse 
                 return $ collectPostParams postParams
 
     let getParams = map emptyGetParam $ queryString req
-        accept = fromMaybe "" $ lookup "Accept" $ requestHeaders req
+        accept = fromMaybe "" $ lookup H.hAccept $ requestHeaders req
         params = let par | not $ null postParams = [pack (show postParams)]
                          | not $ null getParams  = [pack (show getParams)]
                          | otherwise             = []

--- a/wai-extra/Network/Wai/Middleware/RequestLogger/Internal.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/Internal.hs
@@ -8,9 +8,10 @@ module Network.Wai.Middleware.RequestLogger.Internal
 
 import Data.ByteString (ByteString)
 import Network.Wai.Logger (clockDateCacher)
+#if !MIN_VERSION_wai_logger(2, 2, 0)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Monad (forever)
-
+#endif
 import System.Log.FastLogger (LogStr, fromLogStr)
 
 logToByteString :: LogStr -> ByteString
@@ -18,12 +19,15 @@ logToByteString = fromLogStr
 
 getDateGetter :: IO () -- ^ flusher
               -> IO (IO ByteString)
+#if !MIN_VERSION_wai_logger(2, 2, 0)
 getDateGetter flusher = do
     (getter, updater) <- clockDateCacher
-#if !MIN_VERSION_wai_logger(2, 2, 0)
     _ <- forkIO $ forever $ do
         threadDelay 1000000
         updater
         flusher
+#else
+getDateGetter _ = do
+    (getter, _) <- clockDateCacher
 #endif
     return getter

--- a/wai-extra/Network/Wai/Middleware/Rewrite.hs
+++ b/wai-extra/Network/Wai/Middleware/Rewrite.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.Rewrite
     ( rewrite, rewritePure
     ) where

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- |
 --
 -- Since 3.0.4
@@ -11,6 +9,7 @@ import Network.Wai.Internal
 import Network.Wai (Middleware, responseToStream)
 import qualified Data.ByteString.Char8 as S8
 import System.PosixCompat (getFileStatus, fileSize, FileOffset)
+import Network.HTTP.Types (hContentLength)
 
 -- |Convert ResponseFile type responses into ResponseStream type
 --
@@ -34,7 +33,7 @@ streamFile app env sendResponse = app env $ \res ->
             sendBody :: StreamingBody -> IO ResponseReceived
             sendBody body = do
                len <- getFileSize fp
-               let hs' = ("Content-Length", (S8.pack (show len))) : hs
+               let hs' = (hContentLength, (S8.pack (show len))) : hs
                sendResponse $ responseStream s hs' body
       _ -> sendResponse res
 

--- a/wai-extra/Network/Wai/Middleware/Vhost.hs
+++ b/wai-extra/Network/Wai/Middleware/Vhost.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
-module Network.Wai.Middleware.Vhost (vhost, redirectWWW, redirectTo, redirectToLogged) where
+{-# LANGUAGE CPP #-}
+ module Network.Wai.Middleware.Vhost (vhost, redirectWWW, redirectTo, redirectToLogged) where
 
 import Network.Wai
 
@@ -7,7 +7,9 @@ import Network.HTTP.Types as H
 import qualified Data.Text.Encoding as TE
 import Data.Text (Text)
 import qualified Data.ByteString as BS
+#if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mappend)
+#endif
 
 vhost :: [(Request -> Bool, Application)] -> Application -> Application
 vhost vhosts def req =
@@ -27,7 +29,7 @@ redirectIf home cond app req sendResponse =
 
 redirectTo :: BS.ByteString -> Response
 redirectTo location = responseLBS H.status301
-    [ ("Content-Type", "text/plain") , ("Location", location) ] "Redirect"
+    [ (H.hContentType, "text/plain") , (H.hLocation, location) ] "Redirect"
 
 redirectToLogged :: (Text -> IO ()) -> BS.ByteString -> IO Response
 redirectToLogged logger loc = do

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -45,6 +44,7 @@ import qualified Network.HTTP.Types as H
 import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (allocate, release, register, InternalState, runInternalState)
 import Data.IORef
+import Network.HTTP.Types (hContentType)
 
 breakDiscard :: Word8 -> S.ByteString -> (S.ByteString, S.ByteString)
 breakDiscard w s =
@@ -140,7 +140,7 @@ data RequestBodyType = UrlEncoded | Multipart S.ByteString
 
 getRequestBodyType :: Request -> Maybe RequestBodyType
 getRequestBodyType req = do
-    ctype' <- lookup "Content-Type" $ requestHeaders req
+    ctype' <- lookup hContentType $ requestHeaders req
     let (ctype, attrs) = parseContentType ctype'
     case ctype of
         "application/x-www-form-urlencoded" -> return UrlEncoded

--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 -- | Some helpers for interrogating a WAI 'Request'.
 
 module Network.Wai.Request

--- a/wai-extra/Network/Wai/UrlMap.hs
+++ b/wai-extra/Network/Wai/UrlMap.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {- | This module gives you a way to mount applications under sub-URIs.
 For example:
@@ -93,7 +93,7 @@ instance ToApplication UrlMap where
             Nothing ->
                 sendResponse $ responseLBS
                     status404
-                    [("content-type", "text/plain")]
+                    [(hContentType, "text/plain")]
                     "Not found\n"
 
         where

--- a/wai-extra/test/Network/Wai/Middleware/RoutedSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/RoutedSpec.hs
@@ -9,7 +9,7 @@ import Test.Hspec
 import Network.Wai.Middleware.Routed
 import Network.Wai.Middleware.ForceSSL (forceSSL)
 
-import Network.HTTP.Types (methodPost, status200, status301, status307)
+import Network.HTTP.Types (hContentType, status200)
 import Network.Wai
 import Network.Wai.Test
 import Data.ByteString (ByteString)
@@ -39,7 +39,7 @@ spec = describe "forceSSL" $ do
 
 jsonApp :: Application
 jsonApp _req cps = cps $ responseLBS status200
-   [("Content-Type", "application/json")]
+   [(hContentType, "application/json")]
       "{\"foo\":\"bar\"}"
 
 testDPath :: ByteString -> Session SResponse

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -116,6 +116,8 @@ Library
   else
       build-depends: unix
 
+  extensions:        OverloadedStrings
+
   Exposed-modules:   Network.Wai.Handler.CGI
                      Network.Wai.Handler.SCGI
                      Network.Wai.Middleware.AcceptOverride


### PR DESCRIPTION
A lot of small changes to remove causes to compiler warnings.
- Use CPP to only import Monoid and Applicative when less than GHC 7.10
- Rename shadowing variables
- Remove unnecessary imports

Also use header functions from the http-types package where possible and moved OverloadedStrings extension to cabal file, since used in almost every module.

Have compiled and tests passing with both GHC 7.8 and GHC 7.10.