### PR TITLE
Change from deprecated `breakByte` to `break`.

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -42,6 +42,7 @@ import Data.Function (fix)
 import Control.Exception (throwIO)
 import qualified System.IO as IO
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
+import Data.Word8 (_semicolon)
 
 data GzipSettings = GzipSettings
     { gzipFiles :: GzipFiles
@@ -58,7 +59,7 @@ defaultCheckMime :: S.ByteString -> Bool
 defaultCheckMime bs =
     S8.isPrefixOf "text/" bs || bs' `Set.member` toCompress
   where
-    bs' = fst $ S.breakByte 59 bs -- semicolon
+    bs' = fst $ S.break (== _semicolon) bs
     toCompress = Set.fromList
         [ "application/json"
         , "application/javascript"

--- a/wai-extra/Network/Wai/Middleware/HttpAuth.hs
+++ b/wai-extra/Network/Wai/Middleware/HttpAuth.hs
@@ -109,7 +109,7 @@ extractBasicAuth bs =
   where
     extract encoded =
         let raw = decodeLenient encoded
-            (username, password') = S.breakByte _colon raw
+            (username, password') = S.break (== _colon) raw
         in ((username,) . snd) <$> S.uncons password'
 
 -- | Extract bearer authentication data from __Authorization__ header


### PR DESCRIPTION
Small change to avoid deprecated `breakByte` function.