### PR TITLE
Support additional cipher suites for forward secrecy on older clients.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tarballs/
 /.shelly
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,8 +11,17 @@ packages:
 - ./wai-conduit
 - ./mime-types
 - ./auto-update
+- location:
+    git: git@github.com:aaronfriel/hs-tls
+    commit: d0f163cac4b1b908b759a7b1a878481699e3ad80
+  subdirs:
+  - core
 extra-deps:
 - doctest-0.10.1
 - http2-1.0.2
 - hex-0.1.2
-- tls-1.3.2
+- cryptonite-0.6
+- x509-1.6.0
+- x509-store-1.6.0
+- x509-validation-1.6.0
+- x509-system-1.6.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,8 +12,8 @@ packages:
 - ./mime-types
 - ./auto-update
 - location:
-    git: git@github.com:aaronfriel/hs-tls
-    commit: d0f163cac4b1b908b759a7b1a878481699e3ad80
+    git: git@github.com:vincenthz/hs-tls
+    commit: 7baaef9657b2154c935565767a01c166f6f4c77d
   subdirs:
   - core
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,3 +15,4 @@ extra-deps:
 - doctest-0.10.1
 - http2-1.0.2
 - hex-0.1.2
+- tls-1.3.2

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -140,6 +140,8 @@ defaultTlsSettings = TLSSettings {
 ciphers :: [TLS.Cipher]
 ciphers =
     [ TLSExtra.cipher_ECDHE_RSA_AES128GCM_SHA256
+    , TLSExtra.cipher_ECDHE_RSA_AES128CBC_SHA256
+    , TLSExtra.cipher_ECDHE_RSA_AES128CBC_SHA
     , TLSExtra.cipher_DHE_RSA_AES128GCM_SHA256
     , TLSExtra.cipher_DHE_RSA_AES256_SHA256
     , TLSExtra.cipher_DHE_RSA_AES128_SHA256

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.1.0
+Version:             3.1.1
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE
@@ -22,7 +22,7 @@ Library
                    , wai                           >= 3.0      && < 3.1
                    , warp                          >= 3.1      && < 3.2
                    , data-default-class            >= 0.0.1
-                   , tls                           >= 1.2.16
+                   , tls                           >= 1.3.2
                    , network                       >= 2.2.1
                    , cprng-aes                     >= 0.5.0
                    , streaming-commons

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -22,7 +22,7 @@ Library
                    , wai                           >= 3.0      && < 3.1
                    , warp                          >= 3.1      && < 3.2
                    , data-default-class            >= 0.0.1
-                   , tls                           >= 1.3.2
+                   , tls                           >= 1.3.1
                    , network                       >= 2.2.1
                    , cprng-aes                     >= 0.5.0
                    , streaming-commons


### PR DESCRIPTION
These changes require vincenthz/hs-tls#113 to build, and should not be merged until `tls` supports the additional cipher suites.

These changes ensure that `warp-tls` builds with a `tls` library that supports secure renegotiation and forward secrecy on a broad set of clients.