### PR TITLE
Configurable Slowloris size

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -64,6 +64,7 @@ module Network.Wai.Handler.Warp (
   , setProxyProtocolNone
   , setProxyProtocolRequired
   , setProxyProtocolOptional
+  , setSlowlorisSize
     -- ** Getters
   , getPort
   , getHost
@@ -337,6 +338,12 @@ setProxyProtocolRequired y = y { settingsProxyProtocol = ProxyProtocolRequired }
 -- Since 3.0.5
 setProxyProtocolOptional :: Settings -> Settings
 setProxyProtocolOptional y = y { settingsProxyProtocol = ProxyProtocolOptional }
+
+-- | Size in bytes read to prevent Slowloris protection. Default value: 2048
+--
+-- Since 3.1.2
+setSlowlorisSize :: Int -> Settings -> Settings
+setSlowlorisSize x y = y { settingsSlowlorisSize = x }
 
 -- | Explicitly pause the slowloris timeout.
 --

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -45,8 +45,8 @@ module Network.Wai.Handler.Warp.Internal (
     --
     -- * When all request headers are read, the timeout is tickled.
     --
-    -- * Every time at least 2048 bytes of the request body are read, the timeout
-    --   is tickled.
+    -- * Every time at least the slowloris size settings number of bytes of the request
+    --   body are read, the timeout is tickled.
     --
     -- * The timeout is paused while executing user code. This will apply to both
     --   the application itself, and a ResponseSource response. The timeout is

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -89,6 +89,10 @@ data Settings = Settings
       -- ^ Specify usage of the PROXY protocol.
       --
       -- Since 3.0.5.
+    , settingsSlowlorisSize :: Int
+      -- ^ Size of bytes read to prevent Slowloris protection. Default value: 2048
+      --
+      -- Since 3.1.2.
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -119,6 +123,7 @@ defaultSettings = Settings
     , settingsServerName = S8.pack $ "Warp/" ++ showVersion Paths_warp.version
     , settingsMaximumBodyFlush = Just 8192
     , settingsProxyProtocol = ProxyProtocolNone
+    , settingsSlowlorisSize = 2048
     }
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an


### PR DESCRIPTION
I know there's been a lot of history around the Slowloris protection here and in the mailing list. This change simply seeks to make the hard-coded value configurable by settings, with a continued default value of 2048 bytes.

The current documentation indicates that

```
Every time at least 2048 bytes of the request body are read, the timeout is tickled.
```

which suggests that after 2048 bytes of the request body have been processed, through however many reads, the timeout will be tickled. But the current implementation seems to tickle the timeout only after a [single read](https://github.com/yesodweb/wai/blob/master/warp/Network/Wai/Handler/Warp/Run.hs#L478)  consumed at least 2048 bytes. Sending in at least 2048 bytes across multiple writes without any single write at least 2048 bytes will trigger the Slowloris protection. A stateful counter of bytes here that resets on tickle might be useful.

Our current warp use-case is an IoT application that  POST's low volume telemetry data over long-lived streaming requests. Our devices end up looking a lot like a Slowloris attack :) While in the long run HTTP/2 might be a better fit and its timeout tickling better-suited, we'd still like to be able to use HTTP/1 as well, and configure down the Slowloris prevention value without having to increase the timeout value and lose client responsiveness detection.

I couldn't piece together in `RunSpec.hs` how the Slowloris prevention was being validated, but would be happy to add a test that checks that the new Slowloris size is honored with a little guidance.

And thanks for the great software! We love running on top of warp!