### PR TITLE
Use bufferIO in place of toBS in Network.Wai.Handler.Warp.IO.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -47,7 +47,7 @@ toBufIOWith buf !size io (Builder build) = loop firstStep
     firstStep = build (buildStep finalStep)
     finalStep (BufRange p _) = return $ Done p ()
     bufRange = BufRange buf (buf `plusPtr` size)
-    runIO ptr = toBS buf (ptr `minusPtr` buf) >>= io
+    runIO ptr = bufferIO buf (ptr `minusPtr` buf) io
     loop step = do
         signal <- runBuildStep step bufRange
         case signal of


### PR DESCRIPTION
When using blaze-builder > 0.4.

Attempt to fix #419.

@snoyberg @kazu-yamamoto  Looking through the history, this should be sufficient to fix the issue. However, the build failes with more errors. Most of my attempts to fix these result in more widespread conflict issues. Any advice?

```
[29 of 33] Compiling Network.Wai.Handler.Warp.HTTP2.Sender ( Network/Wai/Handler/Warp/HTTP2/Sender.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.2.0/build/Network/Wai/Handler/Warp/HTTP2/Sender.o )

Network/Wai/Handler/Warp/HTTP2/Sender.hs:247:35:
    Couldn't match expected type ‘Data.ByteString.Builder.Internal.Builder’
                with actual type ‘Blaze.ByteString.Builder.Internal.Types.Builder’
    NB: ‘Data.ByteString.Builder.Internal.Builder’
          is defined in ‘Data.ByteString.Builder.Internal’
              in package ‘bytestring-0.10.6.0’
        ‘Blaze.ByteString.Builder.Internal.Types.Builder’
          is defined in ‘Blaze.ByteString.Builder.Internal.Types’
              in package ‘blaze-builder-0.3.3.4’
    In the first argument of ‘B.runBuilder’, namely ‘bb’
    In a stmt of a 'do' block:
      (len, signal) <- B.runBuilder bb datBuf room

Network/Wai/Handler/Warp/HTTP2/Sender.hs:342:47:
    Couldn't match expected type ‘Data.ByteString.Builder.Internal.Builder’
                with actual type ‘Blaze.ByteString.Builder.Internal.Types.Builder’
    NB: ‘Data.ByteString.Builder.Internal.Builder’
          is defined in ‘Data.ByteString.Builder.Internal’
              in package ‘bytestring-0.10.6.0’
        ‘Blaze.ByteString.Builder.Internal.Types.Builder’
          is defined in ‘Blaze.ByteString.Builder.Internal.Types’
              in package ‘blaze-builder-0.3.3.4’
    In the first argument of ‘B.runBuilder’, namely ‘builder’
    In a stmt of a 'do' block:
      (len, signal) <- B.runBuilder builder buf room
```



Also, is the mention of `bytestring` necessary here since it's in both the if else for a cabal flag?
https://github.com/yesodweb/wai/blob/master/warp/warp.cabal#L42