### PR TITLE
Add an HTTP/2-aware application type supporting trailers and pushed streams.

### DIFF
--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -35,23 +35,42 @@ data PushPromise = PushPromise
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
 type HTTP2Application = Request -> PushFunc -> Responder
 
+-- | Part of a streaming response -- either a 'Builder' or a range of a file.
 data Chunk = FileChunk FilePath (Maybe FilePart) | BuilderChunk Builder
 
+-- TODO send -> write
+-- | Given the write function of a stream body, write the given 'Builder'.
 sendBuilder :: (Chunk -> IO ()) -> Builder -> IO ()
 sendBuilder = (. BuilderChunk)
 
+-- | Given the write function of a stream body, write part or all of the given
+-- file.
 sendFilePart :: (Chunk -> IO ()) -> FilePath -> Maybe FilePart -> IO ()
 sendFilePart = (.: FileChunk)
   where f .: g = curry $ f . uncurry g
 
+-- | The streaming body of a response.  Equivalent to
+-- 'Network.Wai.StreamingBody' except that it can also write file ranges and
+-- return a result of type @a@.
 type Body a = (Chunk -> IO ()) -> IO () -> IO a
 
+-- | A function given to an 'HTTP2Application' used to send the response.  This
+-- is similar to the respond function in 'Network.Wai.Application', but the
+-- status and headers are curried, and it passes on any result value from the
+-- stream body.
 type RespondFunc = forall a. H.Status -> H.ResponseHeaders -> Body a -> IO a
 
+-- | A continuation-passing style function that provides a response by calling
+-- the 'RespondFunc', then returns the request's 'Trailers'.
 type Responder = RespondFunc -> IO Trailers
 
+-- | A function given to an 'HTTP2Application' to initiate a server-pushed
+-- stream.  Its argument is the same as the result of an 'HTTP2Application', so
+-- you can either implement the response inline, or call your own application
+-- to create the response.
 type PushFunc = PushPromise -> Responder -> IO Bool
 
+-- | Create the 'H.RequestHeaders' corresponding to the given 'PushPromise'.
 promiseHeaders :: PushPromise -> H.RequestHeaders
 promiseHeaders p =
   [ (":method", promisedMethod p)

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -14,13 +14,17 @@ module Network.Wai.HTTP2
     , streamSimple
     ) where
 
+import           Blaze.ByteString.Builder (Builder)
 import           Data.ByteString (ByteString)
-
-import           Data.ByteString.Builder (Builder)
 import qualified Network.HTTP.Types as H
 
-import Network.Wai (Application)
-import Network.Wai.Internal (FilePart, Request, Response(..), ResponseReceived(..))
+import           Network.Wai (Application)
+import           Network.Wai.Internal
+    ( FilePart
+    , Request
+    , Response(..)
+    , ResponseReceived(..)
+    )
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,11 +1,16 @@
 module Network.Wai.HTTP2
     ( Http2Application
+    , Response(..)
     , Trailers
+    , responseStatus
+    , responseHeaders
     ) where
 
+import           Blaze.ByteString.Builder     (Builder)
+import qualified Data.ByteString              as B
 import qualified Network.HTTP.Types as H
 
-import Network.Wai.Internal (Request, Response)
+import Network.Wai.Internal (Request, FilePart)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
@@ -13,3 +18,21 @@ type Trailers = H.ResponseHeaders
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
 type Http2Application = Request -> (Response -> IO ()) -> IO Trailers
+
+type StreamingBody = (Builder -> IO ()) -> IO () -> IO ()
+
+data Response
+    = ResponseFile H.Status H.ResponseHeaders FilePath (Maybe FilePart)
+    | ResponseBuilder H.Status H.ResponseHeaders Builder
+    | ResponseStream H.Status H.ResponseHeaders StreamingBody
+    | ResponseRaw (IO B.ByteString -> (B.ByteString -> IO ()) -> IO ()) Response
+
+responseStatus :: Response -> H.Status
+responseStatus (ResponseFile s _ _ _) = s
+responseStatus (ResponseBuilder s _ _) = s
+responseStatus (ResponseStream s _ _) = s
+responseStatus (ResponseRaw _ res) = responseStatus res
+
+responseHeaders :: Response -> H.ResponseHeaders
+responseHeaders _ = []
+

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -7,7 +7,6 @@ module Network.Wai.HTTP2
     ) where
 
 import           Blaze.ByteString.Builder     (Builder)
-import qualified Data.ByteString              as B
 import qualified Network.HTTP.Types as H
 
 import Network.Wai.Internal (Request, FilePart)
@@ -25,14 +24,14 @@ data Response
     = ResponseFile H.Status H.ResponseHeaders FilePath (Maybe FilePart)
     | ResponseBuilder H.Status H.ResponseHeaders Builder
     | ResponseStream H.Status H.ResponseHeaders StreamingBody
-    | ResponseRaw (IO B.ByteString -> (B.ByteString -> IO ()) -> IO ()) Response
 
 responseStatus :: Response -> H.Status
 responseStatus (ResponseFile s _ _ _) = s
 responseStatus (ResponseBuilder s _ _) = s
 responseStatus (ResponseStream s _ _) = s
-responseStatus (ResponseRaw _ res) = responseStatus res
 
 responseHeaders :: Response -> H.ResponseHeaders
-responseHeaders _ = []
+responseHeaders (ResponseFile _ h _ _) = h
+responseHeaders (ResponseBuilder _ h _) = h
+responseHeaders (ResponseStream _ h _) = h
 

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString.Lazy as L
 import           Data.ByteString.Builder (Builder)
 import qualified Network.HTTP.Types as H
 
-import qualified Network.Wai.Internal as H1 (Request)
+import Network.Wai.Internal (Request)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
@@ -29,18 +29,16 @@ data PushPromise = PushPromise
     , promisedHeader :: H.RequestHeaders
     }
 
--- | The type of an HTTP\/2 request: a normal HTTP request and an action to
--- push streams associated with this request.
-type Request = (H1.Request, PushPromise -> Responder -> IO Bool)
-
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
-type Http2Application = Request -> Responder
+type Http2Application = Request -> PushFunc -> Responder
 
 type Body a = (Builder -> IO ()) -> IO () -> IO a
 
 type RespondFunc = forall a. H.Status -> H.ResponseHeaders -> Body a -> IO a
 
 type Responder = RespondFunc -> IO Trailers
+
+type PushFunc = PushPromise -> Responder -> IO Bool
 
 promiseHeaders :: PushPromise -> H.RequestHeaders
 promiseHeaders p =

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -2,12 +2,9 @@
 module Network.Wai.HTTP2
     ( Http2Application
     , PushPromise(..)
+    , RespondFunc
     , Responder
-    , Response
     , Trailers
-    , responseStatus
-    , responseStream
-    , responseHeaders
     , promiseHeaders
     ) where
 
@@ -41,18 +38,9 @@ type Http2Application = Request -> Responder
 
 type Body a = (Builder -> IO ()) -> IO () -> IO a
 
-type Response a = (H.Status, H.ResponseHeaders, Body a)
+type RespondFunc = forall a. H.Status -> H.ResponseHeaders -> Body a -> IO a
 
-type Responder = (forall a. Response a -> IO a) -> IO Trailers
-
-responseStatus :: Response a -> H.Status
-responseStatus (s, _, _) = s
-
-responseHeaders :: Response a -> H.ResponseHeaders
-responseHeaders (_, h, _) = h
-
-responseStream :: H.Status -> H.ResponseHeaders -> Body a -> Response a
-responseStream = (,,)
+type Responder = RespondFunc -> IO Trailers
 
 promiseHeaders :: PushPromise -> H.RequestHeaders
 promiseHeaders p =

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -11,18 +11,24 @@ module Network.Wai.HTTP2
 import           Blaze.ByteString.Builder     (Builder)
 import qualified Network.HTTP.Types as H
 
-import Network.Wai.Internal (Request)
+import qualified Network.Wai.Internal as H1 (Request)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
 type Trailers = H.ResponseHeaders
 
+-- | The type of an HTTP\/2 request.
+-- TODO(awpr): specialize this for HTTP\/2.
+type Request = H1.Request
+
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
-type Http2Application = Request -> (forall a. Response a -> IO a) -> IO Trailers
+type Http2Application = Request -> Responder
 
 type Body a = (Builder -> IO ()) -> IO () -> IO a
 
 type Response a = (H.Status, H.ResponseHeaders, Body a)
+
+type Responder = (forall a. Response a -> IO a) -> IO Trailers
 
 responseStatus :: Response a -> H.Status
 responseStatus (s, _, _) = s

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE EmptyCase, EmptyDataDecls, RankNTypes #-}
 module Network.Wai.HTTP2
     ( Http2Application
+    , PushPromise
     , Response
     , Trailers
     , absurd

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -34,7 +34,7 @@ data PushPromise = PushPromise
 
 -- | The type of an HTTP\/2 request: a normal HTTP request and an action to
 -- push streams associated with this request.
-type Request = (H1.Request, PushPromise -> Responder -> IO ())
+type Request = (H1.Request, PushPromise -> Responder -> IO Bool)
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
 type Http2Application = Request -> Responder

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -7,8 +7,8 @@ module Network.Wai.HTTP2
     , Responder
     , Trailers
     , promiseHeaders
-    , sendBuilder
-    , sendFilePart
+    , writeBuilder
+    , writeFilePart
     ) where
 
 import           Data.ByteString (ByteString)
@@ -38,15 +38,14 @@ type HTTP2Application = Request -> PushFunc -> Responder
 -- | Part of a streaming response -- either a 'Builder' or a range of a file.
 data Chunk = FileChunk FilePath (Maybe FilePart) | BuilderChunk Builder
 
--- TODO send -> write
 -- | Given the write function of a stream body, write the given 'Builder'.
-sendBuilder :: (Chunk -> IO ()) -> Builder -> IO ()
-sendBuilder = (. BuilderChunk)
+writeBuilder :: (Chunk -> IO ()) -> Builder -> IO ()
+writeBuilder = (. BuilderChunk)
 
 -- | Given the write function of a stream body, write part or all of the given
 -- file.
-sendFilePart :: (Chunk -> IO ()) -> FilePath -> Maybe FilePart -> IO ()
-sendFilePart = (.: FileChunk)
+writeFilePart :: (Chunk -> IO ()) -> FilePath -> Maybe FilePart -> IO ()
+writeFilePart = (.: FileChunk)
   where f .: g = curry $ f . uncurry g
 
 -- | The streaming body of a response.  Equivalent to

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,5 +1,27 @@
 {-# LANGUAGE OverloadedStrings, RankNTypes #-}
 {-# LANGUAGE CPP #-}
+
+-- | An HTTP\/2-aware variant of the 'Network.Wai.Application' type.  Compared
+-- to the original, this exposes the new functionality of server push and
+-- trailers, allows stream fragments to be sent in the form of file ranges, and
+-- allows the stream body to produce a value to be used in constructing the
+-- trailers.  Existing @Applications@ can be faithfully upgraded to HTTP\/2
+-- with 'promoteApplication' or served transparently over both protocols with
+-- the normal Warp 'Network.Wai.Handler.Warp.run' family of functions.
+--
+-- An 'HTTP2Application' takes a 'Request' and a 'PushFunc' and produces a
+-- 'Responder' that will push any associated resources and send the response
+-- body.  The response is always a stream of 'Builder's and file chunks.
+-- Equivalents of the 'Network.Wai.responseBuilder' family of functions are
+-- provided for creating 'Responder's conveniently.
+--
+-- Pushed streams are handled by an IO action that triggers a server push.  It
+-- returns @True@ if the @PUSH_PROMISE@ frame was sent, @False@ if not.  Note
+-- this means it will still return @True@ if the client reset or ignored the
+-- stream.  This gives handlers the freedom to implement their own heuristics
+-- for whether to actually push a resource, while also allowing middleware and
+-- frameworks to trigger server pushes automatically.
+
 module Network.Wai.HTTP2
     (
     -- * Applications

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -92,8 +92,9 @@ data Chunk = FileChunk FilePath FilePart | BuilderChunk Builder
 -- return a result of type @a@.
 type Body a = BodyOf Chunk a
 
--- | Generalization of 'Body' to arbitrary chunk types; this unifies with
--- 'Network.Wai.StreamingBody' with @c ~ Builder@ and @a ~ ()@.
+-- | Generalization of 'Body' to arbitrary chunk types.
+--
+-- 'Network.Wai.StreamingBody' is identical to @BodyOf Builder ()@.
 type BodyOf c a = (c -> IO ()) -> IO () -> IO a
 
 -- | The result of an 'HTTP2Application'; or, alternately, an application
@@ -175,7 +176,7 @@ streamBuilder builder write _ = write $ BuilderChunk builder
 
 -- | Equivalent to 'Body' but only streaming 'Builder's.
 --
--- @'Network.Wai.StreamingBody' ~ SimpleBody ()@.
+-- 'Network.Wai.StreamingBody' is identical to @SimpleBody ()@.
 type SimpleBody a = BodyOf Builder a
 
 -- | Create a response body of a stream of 'Builder's.

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -5,11 +5,11 @@ module Network.Wai.HTTP2
 
 import qualified Network.HTTP.Types as H
 
-import Network.Wai.Internal (Request, Response, ResponseReceived)
+import Network.Wai.Internal (Request, Response)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
 type Trailers = H.ResponseHeaders
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
-type Http2Application = Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
+type Http2Application = Request -> (Response -> IO ()) -> IO Trailers

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -20,9 +20,9 @@ type Trailers = H.ResponseHeaders
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
 type Http2Application = Request -> (forall a. Response a -> IO a) -> IO Trailers
 
-type StreamingBody a = (Builder -> IO ()) -> IO () -> IO a
+type Body a = (Builder -> IO ()) -> IO () -> IO a
 
-type Response a = (H.Status, H.ResponseHeaders, StreamingBody a)
+type Response a = (H.Status, H.ResponseHeaders, Body a)
 
 responseStatus :: Response a -> H.Status
 responseStatus (s, _, _) = s
@@ -30,5 +30,5 @@ responseStatus (s, _, _) = s
 responseHeaders :: Response a -> H.ResponseHeaders
 responseHeaders (_, h, _) = h
 
-responseStream :: H.Status -> H.ResponseHeaders -> StreamingBody a -> Response a
+responseStream :: H.Status -> H.ResponseHeaders -> Body a -> Response a
 responseStream = (,,)

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Network.Wai.HTTP2
     ( Http2Application
     , Response
@@ -17,17 +18,17 @@ import Network.Wai.Internal (Request)
 type Trailers = H.ResponseHeaders
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
-type Http2Application = Request -> (Response -> IO ()) -> IO Trailers
+type Http2Application = Request -> (forall a. Response a -> IO a) -> IO Trailers
 
-type StreamingBody = (Builder -> IO ()) -> IO () -> IO ()
+type StreamingBody a = (Builder -> IO ()) -> IO () -> IO a
 
-type Response = (H.Status, H.ResponseHeaders, StreamingBody)
+type Response a = (H.Status, H.ResponseHeaders, StreamingBody a)
 
-responseStatus :: Response -> H.Status
+responseStatus :: Response a -> H.Status
 responseStatus (s, _, _) = s
 
-responseHeaders :: Response -> H.ResponseHeaders
+responseHeaders :: Response a -> H.ResponseHeaders
 responseHeaders (_, h, _) = h
 
-responseStream :: H.Status -> H.ResponseHeaders -> StreamingBody -> Response
+responseStream :: H.Status -> H.ResponseHeaders -> StreamingBody a -> Response a
 responseStream = (,,)

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE EmptyCase, EmptyDataDecls, RankNTypes #-}
 module Network.Wai.HTTP2
     ( Http2Application
     , Response
     , Trailers
+    , absurd
     , responseStatus
     , responseStream
     , responseHeaders
@@ -17,9 +18,19 @@ import qualified Network.Wai.Internal as H1 (Request)
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
 type Trailers = H.ResponseHeaders
 
--- | The type of an HTTP\/2 request.
--- TODO(awpr): specialize this for HTTP\/2.
-type Request = H1.Request
+-- | The synthesized request and headers of a pushed stream.
+-- TODO(awpr): implement for real.
+data PushPromise
+
+-- 'PushPromise' is currently uninhabited, which proves the caller cannot use
+-- 'pushPromise'.  This discharges the obligation to implement any function
+-- taking a 'PushPromise'.
+absurd :: PushPromise -> a
+absurd p = case p of {}
+
+-- | The type of an HTTP\/2 request: a normal HTTP request and an action to
+-- push streams associated with this request.
+type Request = (H1.Request, PushPromise -> Responder -> IO ())
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
 type Http2Application = Request -> Responder

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,0 +1,15 @@
+module Network.Wai.HTTP2
+    ( Http2Application
+    , Trailers
+    ) where
+
+import qualified Network.HTTP.Types as H
+
+import Network.Wai.Internal (Request, Response, ResponseReceived)
+
+-- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
+-- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
+type Trailers = H.ResponseHeaders
+
+-- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
+type Http2Application = Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, RankNTypes #-}
 module Network.Wai.HTTP2
-    ( Http2Application
+    ( HTTP2Application
     , PushPromise(..)
     , RespondFunc
     , Responder
@@ -30,7 +30,7 @@ data PushPromise = PushPromise
     }
 
 -- | The HTTP\/2-aware equivalent of 'Network.Wai.Application'.
-type Http2Application = Request -> PushFunc -> Responder
+type HTTP2Application = Request -> PushFunc -> Responder
 
 type Body a = (Builder -> IO ()) -> IO () -> IO a
 

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, RankNTypes #-}
+{-# LANGUAGE CPP #-}
 module Network.Wai.HTTP2
     ( Chunk(..)
     , HTTP2Application
@@ -14,6 +15,9 @@ module Network.Wai.HTTP2
     , streamSimple
     ) where
 
+#if __GLASGOW_HASKELL__ < 710
+import           Data.Functor ((<$))
+#endif
 import           Blaze.ByteString.Builder (Builder)
 import           Data.ByteString (ByteString)
 import qualified Network.HTTP.Types as H

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -16,7 +16,7 @@ import qualified Network.Wai.Internal as H1 (Request)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
-type Trailers = H.ResponseHeaders
+type Trailers = [H.Header]
 
 -- | The synthesized request and headers of a pushed stream.
 -- TODO(awpr): implement for real.

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -2,6 +2,7 @@
 module Network.Wai.HTTP2
     ( Http2Application
     , PushPromise
+    , Responder
     , Response
     , Trailers
     , absurd

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -1,8 +1,9 @@
 module Network.Wai.HTTP2
     ( Http2Application
-    , Response(..)
+    , Response
     , Trailers
     , responseStatus
+    , responseStream
     , responseHeaders
     ) where
 
@@ -20,10 +21,13 @@ type Http2Application = Request -> (Response -> IO ()) -> IO Trailers
 
 type StreamingBody = (Builder -> IO ()) -> IO () -> IO ()
 
-data Response = ResponseStream H.Status H.ResponseHeaders StreamingBody
+type Response = (H.Status, H.ResponseHeaders, StreamingBody)
 
 responseStatus :: Response -> H.Status
-responseStatus (ResponseStream s _ _) = s
+responseStatus (s, _, _) = s
 
 responseHeaders :: Response -> H.ResponseHeaders
-responseHeaders (ResponseStream _ h _) = h
+responseHeaders (_, h, _) = h
+
+responseStream :: H.Status -> H.ResponseHeaders -> StreamingBody -> Response
+responseStream = (,,)

--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -9,7 +9,7 @@ module Network.Wai.HTTP2
 import           Blaze.ByteString.Builder     (Builder)
 import qualified Network.HTTP.Types as H
 
-import Network.Wai.Internal (Request, FilePart)
+import Network.Wai.Internal (Request)
 
 -- | Headers sent after the end of a data stream, as defined by section 4.1.2 of
 -- the HTTP\/1.1 spec (RFC 7230), and section 8.1 of the HTTP\/2 spec.
@@ -20,18 +20,10 @@ type Http2Application = Request -> (Response -> IO ()) -> IO Trailers
 
 type StreamingBody = (Builder -> IO ()) -> IO () -> IO ()
 
-data Response
-    = ResponseFile H.Status H.ResponseHeaders FilePath (Maybe FilePart)
-    | ResponseBuilder H.Status H.ResponseHeaders Builder
-    | ResponseStream H.Status H.ResponseHeaders StreamingBody
+data Response = ResponseStream H.Status H.ResponseHeaders StreamingBody
 
 responseStatus :: Response -> H.Status
-responseStatus (ResponseFile s _ _ _) = s
-responseStatus (ResponseBuilder s _ _) = s
 responseStatus (ResponseStream s _ _) = s
 
 responseHeaders :: Response -> H.ResponseHeaders
-responseHeaders (ResponseFile _ h _ _) = h
-responseHeaders (ResponseBuilder _ h _) = h
 responseHeaders (ResponseStream _ h _) = h
-

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 -- | Internal constructors and helper functions. Note that no guarantees are
@@ -8,14 +9,22 @@
 module Network.Wai.Internal where
 
 import           Blaze.ByteString.Builder     (Builder)
-import qualified Data.ByteString              as B
+import           Control.Exception            (IOException, try)
+import qualified Data.ByteString              as B hiding (pack)
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Char8        as B (pack, readInteger)
+import qualified Data.ByteString.Lazy as L
+import           Data.Maybe                   (listToMaybe)
 import           Data.Text                    (Text)
 import           Data.Typeable                (Typeable)
-import Data.Vault.Lazy (Vault)
+import           Data.Vault.Lazy              (Vault)
 import           Data.Word                    (Word64)
 import qualified Network.HTTP.Types           as H
+import qualified Network.HTTP.Types.Header as HH
 import           Network.Socket               (SockAddr)
+import           Numeric                      (showInt)
 import           Data.List                    (intercalate)
+import qualified System.PosixCompat.Files     as P
 
 -- | Information on the request sent by the client. This abstracts away the
 -- details of the underlying implementation.
@@ -145,3 +154,87 @@ data FilePart = FilePart
 -- Since 3.0.0
 data ResponseReceived = ResponseReceived
     deriving Typeable
+
+-- | Look up the size of a file in 'Right' or the 'IOException' in 'Left'.
+tryGetFileSize :: FilePath -> IO (Either IOException Integer)
+tryGetFileSize path =
+    fmap (fromIntegral . P.fileSize) <$> try (P.getFileStatus path)
+
+-- | \"Content-Range\".
+hContentRange :: H.HeaderName
+hContentRange = "Content-Range"
+
+-- | @contentRangeHeader beg end total@ constructs a Content-Range 'H.Header'
+-- for the range specified.
+contentRangeHeader :: Integer -> Integer -> Integer -> H.Header
+contentRangeHeader beg end total = (hContentRange, range)
+  where
+    range = B.pack
+      -- building with ShowS
+      $ 'b' : 'y': 't' : 'e' : 's' : ' '
+      : (if beg > end then ('*':) else
+          showInt beg
+          . ('-' :)
+          . showInt end)
+      ( '/'
+      : showInt total "")
+
+-- | Given the full size of a file and optionally a Range header value,
+-- determine the range to serve by parsing the range header and obeying it, or
+-- serving the whole file if it's absent or malformed.
+chooseFilePart :: Integer -> Maybe B.ByteString -> FilePart
+chooseFilePart size Nothing      = FilePart 0 size size
+chooseFilePart size (Just range) = case parseByteRanges range >>= listToMaybe of
+    -- Range is broken
+    Nothing -> FilePart 0 size size
+    Just hrange -> checkRange hrange
+  where
+    checkRange (H.ByteRangeFrom   beg)     = fromRange beg (size - 1)
+    checkRange (H.ByteRangeFromTo beg end) = fromRange beg (min (size - 1) end)
+    checkRange (H.ByteRangeSuffix count)   = fromRange (max 0 (size - count)) (size - 1)
+
+    fromRange beg end = FilePart beg (end - beg + 1) size
+
+-- | Adjust the given 'H.Status' and 'H.ResponseHeaders' based on the given
+-- 'FilePart'.  This means replacing the status with 206 if the response is
+-- partial, and adding the Content-Length (always) and Content-Range (if
+-- appropriate) headers.
+adjustForFilePart :: H.Status -> H.ResponseHeaders -> FilePart -> (H.Status, H.ResponseHeaders)
+adjustForFilePart s h part = (s', h'')
+  where
+    off = filePartOffset part
+    len = filePartByteCount part
+    size = filePartFileSize part
+
+    contentRange = contentRangeHeader off (off + len - 1) size
+    lengthBS = L.toStrict $ B.toLazyByteString $ B.integerDec len
+    s' = if filePartByteCount part /= size then H.partialContent206 else s
+    h' = (H.hContentLength, lengthBS):h
+    h'' = (if len == size then id else (contentRange:)) h'
+
+-- | Parse the value of a Range header into a 'HH.ByteRanges'.
+parseByteRanges :: B.ByteString -> Maybe HH.ByteRanges
+parseByteRanges bs1 = do
+    bs2 <- stripPrefix "bytes=" bs1
+    (r, bs3) <- range bs2
+    ranges (r:) bs3
+  where
+    range bs2 = do
+        (i, bs3) <- B.readInteger bs2
+        if i < 0 -- has prefix "-" ("-0" is not valid, but here treated as "0-")
+            then Just (HH.ByteRangeSuffix (negate i), bs3)
+            else do
+                bs4 <- stripPrefix "-" bs3
+                case B.readInteger bs4 of
+                    Just (j, bs5) | j >= i -> Just (HH.ByteRangeFromTo i j, bs5)
+                    _ -> Just (HH.ByteRangeFrom i, bs4)
+    ranges front bs3
+        | B.null bs3 = Just (front [])
+        | otherwise = do
+            bs4 <- stripPrefix "," bs3
+            (r, bs5) <- range bs4
+            ranges (front . (r:)) bs5
+
+    stripPrefix x y
+        | x `B.isPrefixOf` y = Just (B.drop (B.length x) y)
+        | otherwise = Nothing

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -14,6 +14,9 @@ import qualified Data.ByteString              as B hiding (pack)
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Char8        as B (pack, readInteger)
 import qualified Data.ByteString.Lazy as L
+#if __GLASGOW_HASKELL__ < 709
+import           Data.Functor                 ((<$>))
+#endif
 import           Data.Maybe                   (listToMaybe)
 import           Data.Text                    (Text)
 import           Data.Typeable                (Typeable)

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -21,10 +21,12 @@ Source-repository head
 Library
   Build-Depends:     base                      >= 4        && < 5
                    , bytestring                >= 0.9.1.4
+                   , bytestring-builder        >= 0.10.4.0 && < 10.7
                    , blaze-builder             >= 0.2.1.4  && < 0.5
                    , network                   >= 2.2.1.5
                    , http-types                >= 0.7
                    , text                      >= 0.7
+                   , unix-compat               >= 0.2
                    , vault                     >= 0.3      && < 0.4
   Exposed-modules:   Network.Wai
                      Network.Wai.HTTP2

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -21,7 +21,7 @@ Source-repository head
 Library
   Build-Depends:     base                      >= 4        && < 5
                    , bytestring                >= 0.9.1.4
-                   , bytestring-builder        >= 0.10.4.0 && < 10.7
+                   , bytestring-builder        >= 0.10.4.0 && < 0.10.7
                    , blaze-builder             >= 0.2.1.4  && < 0.5
                    , network                   >= 2.2.1.5
                    , http-types                >= 0.7

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -27,6 +27,7 @@ Library
                    , text                      >= 0.7
                    , vault                     >= 0.3      && < 0.4
   Exposed-modules:   Network.Wai
+                     Network.Wai.HTTP2
                      Network.Wai.Internal
   ghc-options:       -Wall
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -228,6 +228,7 @@ f .: g = curry $ f . uncurry g
 runTLS :: TLSSettings -> Settings -> Application -> IO ()
 runTLS tset set = runServeTLS tset set . serveDefault
 
+-- | Run an HTTP\/2-aware server with 'TLSSettings' and 'Settings'.
 runHTTP2TLS :: TLSSettings -> Settings -> HTTP2Application -> Application -> IO ()
 runHTTP2TLS tset set = runServeTLS tset set .: serveHTTP2
 
@@ -245,7 +246,7 @@ runServeTLS tset set serve = withSocketsDo $
 runTLSSocket :: TLSSettings -> Settings -> Socket -> Application -> IO ()
 runTLSSocket tset set sock = runServeTLSSocket tset set sock . serveDefault
 
--- | Run an HTTP/2-aware server with 'TLSSettings' and 'Settings' using
+-- | Run an HTTP\/2-aware server with 'TLSSettings' and 'Settings' using
 --   specified 'Socket'.
 runHTTP2TLSSocket :: TLSSettings -> Settings -> Socket -> HTTP2Application -> Application -> IO ()
 runHTTP2TLSSocket tset set sock = runServeTLSSocket tset set sock .: serveHTTP2

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -35,8 +35,8 @@ module Network.Wai.Handler.WarpTLS (
     -- * Runner
     , runTLS
     , runTLSSocket
-    , runHttp2TLS
-    , runHttp2TLSSocket
+    , runHTTP2TLS
+    , runHTTP2TLSSocket
     -- * Exception
     , WarpTLSException (..)
     ) where
@@ -59,7 +59,7 @@ import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
 import qualified Network.TLS.Extra as TLSExtra
 import Network.Wai (Application)
-import Network.Wai.HTTP2 (Http2Application)
+import Network.Wai.HTTP2 (HTTP2Application)
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
 import System.IO.Error (isEOFError)
@@ -220,7 +220,7 @@ tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings
 
 ----------------------------------------------------------------
 
--- Composition over two arguments at once; used for runHttp2\*.
+-- Composition over two arguments at once; used for runHTTP2\*.
 (.:) :: (c -> d) -> (a -> b -> c) -> a -> b -> d
 f .: g = curry $ f . uncurry g
 
@@ -228,8 +228,8 @@ f .: g = curry $ f . uncurry g
 runTLS :: TLSSettings -> Settings -> Application -> IO ()
 runTLS tset set = runServeTLS tset set . serveDefault
 
-runHttp2TLS :: TLSSettings -> Settings -> Http2Application -> Application -> IO ()
-runHttp2TLS tset set = runServeTLS tset set .: serveHttp2
+runHTTP2TLS :: TLSSettings -> Settings -> HTTP2Application -> Application -> IO ()
+runHTTP2TLS tset set = runServeTLS tset set .: serveHTTP2
 
 runServeTLS :: TLSSettings -> Settings -> ServeConnection -> IO ()
 runServeTLS tset set serve = withSocketsDo $
@@ -247,8 +247,8 @@ runTLSSocket tset set sock = runServeTLSSocket tset set sock . serveDefault
 
 -- | Run an HTTP/2-aware server with 'TLSSettings' and 'Settings' using
 --   specified 'Socket'.
-runHttp2TLSSocket :: TLSSettings -> Settings -> Socket -> Http2Application -> Application -> IO ()
-runHttp2TLSSocket tset set sock = runServeTLSSocket tset set sock .: serveHttp2
+runHTTP2TLSSocket :: TLSSettings -> Settings -> Socket -> HTTP2Application -> Application -> IO ()
+runHTTP2TLSSocket tset set sock = runServeTLSSocket tset set sock .: serveHTTP2
 
 runServeTLSSocket :: TLSSettings -> Settings -> Socket -> ServeConnection -> IO ()
 runServeTLSSocket tlsset@TLSSettings{..} set sock serve = do

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -41,7 +41,9 @@ module Network.Wai.Handler.Warp (
     run
   , runEnv
   , runSettings
+  , runHttp2Settings
   , runSettingsSocket
+  , runHttp2SettingsSocket
     -- * Settings
   , Settings
   , defaultSettings
@@ -83,6 +85,7 @@ module Network.Wai.Handler.Warp (
   , InvalidRequest (..)
     -- * Utilities
   , pauseTimeout
+  , promoteApplication
     -- * Internal
     -- | The following APIs will be removed in Warp 3.2.0. Please use ones exported from Network.Wai.Handler.Warp.Internal.
 
@@ -135,6 +138,7 @@ import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Date
 import Network.Wai.Handler.Warp.FdCache
 import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.HTTP2 (promoteApplication)
 import Network.Wai.Handler.Warp.Request
 import Network.Wai.Handler.Warp.Response
 import Network.Wai.Handler.Warp.Run

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -38,11 +38,20 @@
 --
 module Network.Wai.Handler.Warp (
     -- * Run a Warp server
+    -- | All of these automatically serve the same 'Application' over HTTP\/1,
+    -- HTTP\/1.1, and HTTP\/2.
     run
   , runEnv
   , runSettings
-  , runHttp2Settings
   , runSettingsSocket
+    -- * Run an HTTP\/2-aware server
+    -- | Each of these takes an HTTP\/2-aware application as well as a backup
+    -- 'Application' to be used for HTTP\/1.1 and HTTP\/1 connections.  These
+    -- are only needed if your application needs access to HTTP\/2-specific
+    -- features such as trailers or pushed streams.
+  , runHttp2
+  , runHttp2Env
+  , runHttp2Settings
   , runHttp2SettingsSocket
     -- * Settings
   , Settings

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -49,10 +49,10 @@ module Network.Wai.Handler.Warp (
     -- 'Application' to be used for HTTP\/1.1 and HTTP\/1 connections.  These
     -- are only needed if your application needs access to HTTP\/2-specific
     -- features such as trailers or pushed streams.
-  , runHttp2
-  , runHttp2Env
-  , runHttp2Settings
-  , runHttp2SettingsSocket
+  , runHTTP2
+  , runHTTP2Env
+  , runHTTP2Settings
+  , runHTTP2SettingsSocket
     -- * Settings
   , Settings
   , defaultSettings

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -94,7 +94,6 @@ module Network.Wai.Handler.Warp (
   , InvalidRequest (..)
     -- * Utilities
   , pauseTimeout
-  , promoteApplication
     -- * Internal
     -- | The following APIs will be removed in Warp 3.2.0. Please use ones exported from Network.Wai.Handler.Warp.Internal.
 
@@ -147,7 +146,6 @@ import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Date
 import Network.Wai.Handler.Warp.FdCache
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.HTTP2 (promoteApplication)
 import Network.Wai.Handler.Warp.Request
 import Network.Wai.Handler.Warp.Response
 import Network.Wai.Handler.Warp.Run

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -17,7 +17,6 @@ import Network.HTTP2
 import Network.Socket (SockAddr)
 
 import Network.Wai (Application, responseToStream)
-import Network.Wai.HTTP2 (Response(..))
 import Network.Wai.HTTP2 (Http2Application)
 import Network.Wai.Internal (ResponseReceived(..))
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
@@ -80,5 +79,5 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 promoteApplication :: Application -> Http2Application
 promoteApplication app req respond = [] <$ app req respond'
   where
-    respond' r = ResponseReceived <$ (withBody $ respond . ResponseStream s h)
+    respond' r = ResponseReceived <$ (withBody $ \b -> respond (s, h, b))
       where (s, h, withBody) = responseToStream r

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -7,9 +7,11 @@ import Control.Concurrent (forkIO, killThread)
 import qualified Control.Exception as E
 import Control.Monad (when, unless, replicateM_)
 import Data.ByteString (ByteString)
+
 import Network.HTTP2
 import Network.Socket (SockAddr)
-import Network.Wai
+
+import Network.Wai.HTTP2 (Http2Application)
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Receiver
@@ -22,7 +24,7 @@ import Network.Wai.Handler.Warp.Types
 
 ----------------------------------------------------------------
 
-http2 :: Connection -> InternalInfo -> SockAddr -> Transport -> S.Settings -> (BufSize -> IO ByteString) -> Application -> IO ()
+http2 :: Connection -> InternalInfo -> SockAddr -> Transport -> S.Settings -> (BufSize -> IO ByteString) -> Http2Application -> IO ()
 http2 conn ii addr transport settings readN app = do
     checkTLS
     ok <- checkPreface

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -79,5 +79,5 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 promoteApplication :: Application -> Http2Application
 promoteApplication app (req, _) respond = [] <$ app req respond'
   where
-    respond' r = ResponseReceived <$ (withBody $ \b -> respond (s, h, b))
+    respond' r = ResponseReceived <$ (withBody $ respond s h)
       where (s, h, withBody) = responseToStream r

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -85,4 +85,7 @@ promoteResponse :: Response -> H2.Response
 promoteResponse (ResponseFile a b c d) = H2.ResponseFile a b c d
 promoteResponse (ResponseBuilder a b c) = H2.ResponseBuilder a b c
 promoteResponse (ResponseStream a b c) = H2.ResponseStream a b c
-promoteResponse (ResponseRaw a b) = H2.ResponseRaw a (promoteResponse b)
+promoteResponse (ResponseRaw _ b) =
+    -- There is no way to take over an HTTP/2 connection, so always serve the
+    -- backup response.
+    promoteResponse b

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Network.Wai.Handler.Warp.HTTP2 (isHTTP2, http2) where
+module Network.Wai.Handler.Warp.HTTP2
+    ( isHTTP2
+    , http2
+    , promoteApplication
+    ) where
 
 import Control.Concurrent (forkIO, killThread)
 import qualified Control.Exception as E
@@ -11,6 +15,7 @@ import Data.ByteString (ByteString)
 import Network.HTTP2
 import Network.Socket (SockAddr)
 
+import Network.Wai (Application)
 import Network.Wai.HTTP2 (Http2Application)
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
@@ -66,3 +71,8 @@ goaway :: Connection -> ErrorCodeId -> ByteString -> IO ()
 goaway Connection{..} etype debugmsg = connSendAll bytestream
   where
     bytestream = goawayFrame 0 etype debugmsg
+
+-- | Promote a normal WAI 'Application' to an 'Http2Application' by ignoring
+-- the HTTP/2-specific features.
+promoteApplication :: Application -> Http2Application
+promoteApplication app = app

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -7,6 +7,7 @@ module Network.Wai.Handler.Warp.HTTP2
     , promoteApplication
     ) where
 
+import Control.Applicative ((<$))
 import Control.Concurrent (forkIO, killThread)
 import qualified Control.Exception as E
 import Control.Monad (when, unless, replicateM_)
@@ -17,6 +18,7 @@ import Network.Socket (SockAddr)
 
 import Network.Wai (Application)
 import Network.Wai.HTTP2 (Http2Application)
+import Network.Wai.Internal (ResponseReceived(..))
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Receiver
@@ -75,4 +77,5 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 -- | Promote a normal WAI 'Application' to an 'Http2Application' by ignoring
 -- the HTTP/2-specific features.
 promoteApplication :: Application -> Http2Application
-promoteApplication app = app
+promoteApplication app req respond = [] <$ app req respond'
+  where respond' x = ResponseReceived <$ respond x

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -77,7 +77,7 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 -- | Promote a normal WAI 'Application' to an 'Http2Application' by ignoring
 -- the HTTP/2-specific features.
 promoteApplication :: Application -> Http2Application
-promoteApplication app (req, _) respond = [] <$ app req respond'
+promoteApplication app req _ respond = [] <$ app req respond'
   where
     respond' r = ResponseReceived <$ (withBody $ respond s h)
       where (s, h, withBody) = responseToStream r

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -17,7 +17,7 @@ import Network.HTTP2
 import Network.Socket (SockAddr)
 
 import Network.Wai (Application, responseToStream)
-import Network.Wai.HTTP2 (HTTP2Application)
+import Network.Wai.HTTP2 (HTTP2Application, Chunk(BuilderChunk))
 import Network.Wai.Internal (ResponseReceived(..))
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
@@ -79,5 +79,6 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 promoteApplication :: Application -> HTTP2Application
 promoteApplication app req _ respond = [] <$ app req respond'
   where
-    respond' r = ResponseReceived <$ (withBody $ respond s h)
+    respond' r = ResponseReceived <$ (withBody $ respond s h . convBody)
       where (s, h, withBody) = responseToStream r
+    convBody b = \send flush -> b (send . BuilderChunk) flush

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -16,10 +16,10 @@ import Data.ByteString (ByteString)
 import Network.HTTP2
 import Network.Socket (SockAddr)
 
-import Network.Wai (Application, Response)
-import qualified Network.Wai.HTTP2 as H2 (Response(..))
+import Network.Wai (Application, responseToStream)
+import Network.Wai.HTTP2 (Response(..))
 import Network.Wai.HTTP2 (Http2Application)
-import Network.Wai.Internal (ResponseReceived(..), Response(..))
+import Network.Wai.Internal (ResponseReceived(..))
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Receiver
@@ -79,13 +79,6 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 -- the HTTP/2-specific features.
 promoteApplication :: Application -> Http2Application
 promoteApplication app req respond = [] <$ app req respond'
-  where respond' x = ResponseReceived <$ respond (promoteResponse x)
-
-promoteResponse :: Response -> H2.Response
-promoteResponse (ResponseFile a b c d) = H2.ResponseFile a b c d
-promoteResponse (ResponseBuilder a b c) = H2.ResponseBuilder a b c
-promoteResponse (ResponseStream a b c) = H2.ResponseStream a b c
-promoteResponse (ResponseRaw _ b) =
-    -- There is no way to take over an HTTP/2 connection, so always serve the
-    -- backup response.
-    promoteResponse b
+  where
+    respond' r = ResponseReceived <$ (withBody $ respond . ResponseStream s h)
+      where (s, h, withBody) = responseToStream r

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -77,7 +77,7 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
 -- | Promote a normal WAI 'Application' to an 'Http2Application' by ignoring
 -- the HTTP/2-specific features.
 promoteApplication :: Application -> Http2Application
-promoteApplication app req respond = [] <$ app req respond'
+promoteApplication app (req, _) respond = [] <$ app req respond'
   where
     respond' r = ResponseReceived <$ (withBody $ \b -> respond (s, h, b))
       where (s, h, withBody) = responseToStream r

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -17,7 +17,7 @@ import Network.HTTP2
 import Network.Socket (SockAddr)
 
 import Network.Wai (Application, responseToStream)
-import Network.Wai.HTTP2 (Http2Application)
+import Network.Wai.HTTP2 (HTTP2Application)
 import Network.Wai.Internal (ResponseReceived(..))
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
@@ -31,7 +31,7 @@ import Network.Wai.Handler.Warp.Types
 
 ----------------------------------------------------------------
 
-http2 :: Connection -> InternalInfo -> SockAddr -> Transport -> S.Settings -> (BufSize -> IO ByteString) -> Http2Application -> IO ()
+http2 :: Connection -> InternalInfo -> SockAddr -> Transport -> S.Settings -> (BufSize -> IO ByteString) -> HTTP2Application -> IO ()
 http2 conn ii addr transport settings readN app = do
     checkTLS
     ok <- checkPreface
@@ -74,9 +74,9 @@ goaway Connection{..} etype debugmsg = connSendAll bytestream
   where
     bytestream = goawayFrame 0 etype debugmsg
 
--- | Promote a normal WAI 'Application' to an 'Http2Application' by ignoring
+-- | Promote a normal WAI 'Application' to an 'HTTP2Application' by ignoring
 -- the HTTP/2-specific features.
-promoteApplication :: Application -> Http2Application
+promoteApplication :: Application -> HTTP2Application
 promoteApplication app req _ respond = [] <$ app req respond'
   where
     respond' r = ResponseReceived <$ (withBody $ respond s h)

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -13,24 +13,23 @@ import Data.IORef (readIORef, writeIORef)
 import Network.HPACK
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
-import Network.Wai.HTTP2 (Trailers, Response, responseStatus, responseHeaders)
+import Network.Wai.HTTP2 (Trailers)
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.Response
 import qualified Network.Wai.Handler.Warp.Settings as S
 import Network.Wai.Handler.Warp.Types
 
-hpackEncodeHeader :: Context -> InternalInfo -> S.Settings -> Response
-                  -> IO Builder
-hpackEncodeHeader ctx ii settings rsp = do
-    hdr1 <- addServerAndDate hdr0
+hpackEncodeHeader :: Context -> InternalInfo -> S.Settings -> H.Status
+                  -> H.ResponseHeaders -> IO Builder
+hpackEncodeHeader ctx ii settings s h = do
+    hdr1 <- addServerAndDate h
     let hdr2 = (":status", status) : map (first foldedCase) hdr1
     hpackEncodeRawHeaders ctx hdr2
   where
-    hdr0 = responseHeaders rsp
-    status = B8.pack $ show $ H.statusCode $ responseStatus rsp
+    status = B8.pack $ show $ H.statusCode $ s
     dc = dateCacher ii
-    rspidxhdr = indexResponseHeader hdr0
+    rspidxhdr = indexResponseHeader h
     defServer = S.settingsServerName settings
     addServerAndDate = addDate dc rspidxhdr . addServer defServer rspidxhdr
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -13,7 +13,6 @@ import Data.IORef (readIORef, writeIORef)
 import Network.HPACK
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
-import Network.Wai.HTTP2 (Trailers)
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.Response

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -33,8 +33,8 @@ hpackEncodeHeader ctx ii settings s h = do
     defServer = S.settingsServerName settings
     addServerAndDate = addDate dc rspidxhdr . addServer defServer rspidxhdr
 
-hpackEncodeTrailers :: Context -> Trailers -> IO Builder
-hpackEncodeTrailers ctx = hpackEncodeRawHeaders ctx . map (first foldedCase)
+hpackEncodeCIHeaders :: Context -> [H.Header] -> IO Builder
+hpackEncodeCIHeaders ctx = hpackEncodeRawHeaders ctx . map (first foldedCase)
 
 hpackEncodeRawHeaders :: Context -> [(B.ByteString, B.ByteString)] -> IO Builder
 hpackEncodeRawHeaders Context{encodeDynamicTable} hdr = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -13,8 +13,7 @@ import Data.IORef (readIORef, writeIORef)
 import Network.HPACK
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
-import Network.Wai
-import Network.Wai.HTTP2 (Trailers)
+import Network.Wai.HTTP2 (Trailers, Response, responseStatus, responseHeaders)
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.Response

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -56,7 +56,7 @@ frameReceiver ctx mkreq recvN = loop `E.catch` sendGoaway
             cont <- processStreamGuardingError $ decodeFrameHeader hd
             when cont loop
 
-    processStreamGuardingError (_, FrameHeader{streamId})
+    processStreamGuardingError (FrameHeaders, FrameHeader{streamId})
       | isResponse streamId = E.throwIO $ ConnectionError ProtocolError "stream id should be odd"
     processStreamGuardingError (FrameUnknown _, FrameHeader{payloadLength}) = do
         mx <- readIORef continued

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -37,7 +37,7 @@ data ValidHeaders = ValidHeaders {
     vhMethod :: ByteString
   , vhPath   :: ByteString
   , vhAuth   :: Maybe ByteString
-  , vhCL     :: Maybe Int
+  , vhCL     :: Maybe Int -- ^ Content-Length
   , vhHeader :: RequestHeaders
   }
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -140,13 +140,13 @@ frameSender ctx@Context{outputQ,connectionWindow}
             fillDataHeaderSend strm 0 datPayloadLen mnext
             maybeEnqueueNext strm mnext
         loop
-    switch (OTrailers strm []) _ = do
+    switch (OTrailers strm []) = do
         let flag = setEndStream defaultFlags
         fillFrameHeader FrameData 0 (streamNumber strm) flag connWriteBuffer
         closed ctx strm Finished
         flushN frameHeaderLength
         loop
-    switch (OTrailers strm trailers) _ = do
+    switch (OTrailers strm trailers) = do
         -- Trailers always indicate the end of a stream; send them in
         -- consecutive header+continuation frames and end the stream.
         builder <- hpackEncodeTrailers ctx trailers
@@ -395,7 +395,7 @@ nextForStream :: Buffer -> BufSize -> TBQueue Sequence -> TVar Sync -> Stream
               -> Leftover -> Bool -> BytesFilled
               -> IO Next
 nextForStream _  _ _  tvar _ _ False len = do
-    atomically $ writeTVar tvar SyncFinish
+    atomically $ writeTVar tvar $ SyncFinish []
     return $ Next len CFinish
 nextForStream buf siz sq tvar strm LZero True len = do
     let out = ONext strm (fillBufStream buf siz LZero sq tvar strm)

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -120,7 +120,7 @@ frameSender ctx@Context{outputQ,connectionWindow}
     switch (OTrailers strm trailers) = do
         -- Trailers always indicate the end of a stream; send them in
         -- consecutive header+continuation frames and end the stream.
-        builder <- hpackEncodeTrailers ctx trailers
+        builder <- hpackEncodeCIHeaders ctx trailers
         off <- headerContinue (streamNumber strm) builder True
         closed ctx strm Finished
         flushN $ off + frameHeaderLength

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -318,7 +318,7 @@ readOpenFile :: OpenFile -> Buffer -> BufSize -> Integer -> IO Int
 #ifdef WINDOWS
 runStreamFile ii buf room path mpart = do
     (start, bytes) <- fileStartEnd path mpart
-    -- fixme: how to close Handle?  GC does it at this moment.
+    -- fixme: how to close Handle? GC does it at this moment.
     h <- IO.openBinaryFile path IO.ReadMode
     IO.hSeek h IO.AbsoluteSeek start
     fillBufFile buf room h start bytes (return ())

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -221,10 +221,7 @@ frameSender ctx@Context{outputQ,connectionWindow}
         let sid = streamNumber strm
             buf = connWriteBuffer `plusPtr` otherLen
             total = otherLen + frameHeaderLength + datPayloadLen
-            flag = case mnext of
-                CFinish -> setEndStream defaultFlags
-                _       -> defaultFlags
-        fillFrameHeader FrameData datPayloadLen sid flag buf
+        fillFrameHeader FrameData datPayloadLen sid defaultFlags buf
         -- "closed" must be before "connSendAll". If not,
         -- the context would be switched to the receiver,
         -- resulting the inconsistency of concurrency.
@@ -356,7 +353,7 @@ runStreamBuilder buf0 room0 sq = loop buf0 room0 0
                     B.More  _ writer  -> return (LOne writer, Nothing, total')
                     B.Chunk bs writer -> return (LTwo bs writer, Nothing, total')
             Just SFlush  -> return (LZero, Nothing, total)
-            Just SFinish -> return (LZero, Just [], total)
+            Just (SFinish trailers) -> return (LZero, Just trailers, total)
 
 fillBufStream :: Buffer -> BufSize -> Leftover -> TBQueue Sequence -> TVar Sync -> Stream -> DynaNext
 fillBufStream buf0 siz0 leftover0 sq tvar strm lim0 = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -18,7 +18,7 @@ import Foreign.Ptr
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
 import Network.HTTP2.Priority
-import Network.Wai.HTTP2 (Trailers, absurd)
+import Network.Wai.HTTP2 (Trailers, promiseHeaders)
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.HPACK
@@ -101,12 +101,11 @@ frameSender ctx@Context{outputQ,connectionWindow}
         unlessClosed ctx conn oldStrm $ do
             lim <- getWindowSize connectionWindow (streamWindow strm)
             -- Write and send the promise.
-            builder <- hpackEncodeCIHeaders ctx $ absurd push
+            builder <- hpackEncodeCIHeaders ctx $ promiseHeaders push
             off <- pushContinue (streamNumber oldStrm) (streamNumber strm) builder
             flushN $ off + frameHeaderLength
             -- TODO(awpr): refactor sendResponse to be able to handle non-zero
             -- initial offsets and use that to potentially avoid the extra syscall.
-
             sendResponse strm s h aux lim
         loop
     switch (OTrailers strm []) = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -27,7 +27,6 @@ import Network.Wai.Handler.Warp.HTTP2.HPACK
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.IORef
 import qualified Network.Wai.Handler.Warp.Settings as S
-import qualified Network.Wai.Handler.Warp.Timeout as T
 import Network.Wai.Handler.Warp.Types
 import qualified System.PosixCompat.Files as P
 
@@ -36,6 +35,7 @@ import qualified System.IO as IO
 #else
 import Network.Wai.Handler.Warp.FdCache (getFd)
 import Network.Wai.Handler.Warp.SendFile (positionRead)
+import qualified Network.Wai.Handler.Warp.Timeout as T
 import System.Posix.IO (openFd, OpenFileFlags(..), defaultFileFlags, OpenMode(ReadOnly), closeFd)
 import System.Posix.Types (Fd)
 #endif
@@ -316,7 +316,7 @@ runStreamFile :: InternalInfo -> Buffer -> BufSize -> FilePath -> Maybe FilePart
 readOpenFile :: OpenFile -> Buffer -> BufSize -> Integer -> IO Int
 
 #ifdef WINDOWS
-runStreamFile ii buf room path mpart = do
+runStreamFile _ buf room path mpart = do
     (start, bytes) <- fileStartEnd path mpart
     -- fixme: how to close Handle? GC does it at this moment.
     h <- IO.openBinaryFile path IO.ReadMode

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -15,8 +15,8 @@ import qualified Data.ByteString.Builder.Extra as B
 import Foreign.Ptr
 import Network.HTTP2
 import Network.HTTP2.Priority
-import Network.Wai
-import Network.Wai.HTTP2 (Trailers)
+import Network.Wai hiding (Response)
+import Network.Wai.HTTP2 (Trailers, Response(..))
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.HPACK
@@ -25,7 +25,6 @@ import Network.Wai.Handler.Warp.IORef
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
 import Network.Wai.Handler.Warp.Types
-import Network.Wai.Internal (Response(..))
 import qualified System.PosixCompat.Files as P
 
 #ifdef WINDOWS

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -81,12 +81,12 @@ frameSender ctx@Context{outputQ,connectionWindow}
     switch (OFrame frame)  = do
         connSendAll frame
         loop
-    switch (OResponse strm rsp aux) = do
+    switch (OResponse strm s h aux) = do
         unlessClosed ctx conn strm $ do
             lim <- getWindowSize connectionWindow (streamWindow strm)
             -- Header frame and Continuation frame
             let sid = streamNumber strm
-            builder <- hpackEncodeHeader ctx ii settings rsp
+            builder <- hpackEncodeHeader ctx ii settings s h
             len <- headerContinue sid builder False
             let total = len + frameHeaderLength
             case aux of

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -100,7 +100,7 @@ data Sequence = SFinish Trailers
               -- ^ Any buffered data should be sent immediately.
               | SBuilder Builder
               -- ^ Append a chunk of data to the stream.
-              | SFile FilePath (Maybe FilePart)
+              | SFile FilePath FilePart
               -- ^ Append a chunk of a file's contents to the stream.
 
 -- | A message from the sender to a stream's dedicated waiter thread.

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -18,7 +18,7 @@ import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Network.HTTP.Types as H
 import Network.Wai (Request)
-import Network.Wai.HTTP2 (Trailers, Response)
+import Network.Wai.HTTP2 (Trailers)
 import Network.Wai.Handler.Warp.IORef
 import Network.Wai.Handler.Warp.Types
 
@@ -66,7 +66,7 @@ data Output = OFinish
             -- ^ Send a goaway frame and terminate the connection.
             | OFrame  ByteString
             -- ^ Send an entire pre-encoded frame.
-            | OResponse Stream Response Aux
+            | OResponse Stream H.Status H.ResponseHeaders Aux
             -- ^ Send the headers and as much of the response as is immediately
             -- available.
             | ONext Stream DynaNext
@@ -75,9 +75,9 @@ data Output = OFinish
             -- ^ Send a series of trailers in header and continuation frames.
 
 outputStream :: Output -> Stream
-outputStream (OResponse strm _ _) = strm
-outputStream (ONext strm _)       = strm
-outputStream _                    = error "outputStream"
+outputStream (OResponse strm _ _ _) = strm
+outputStream (ONext strm _)         = strm
+outputStream _                      = error "outputStream"
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -17,7 +17,7 @@ import qualified Data.ByteString as BS
 import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Network.HTTP.Types as H
-import Network.Wai (Request)
+import Network.Wai (Request, FilePart)
 import Network.Wai.HTTP2 (PushPromise, Trailers)
 import Network.Wai.Handler.Warp.IORef
 import Network.Wai.Handler.Warp.Types
@@ -88,6 +88,7 @@ outputStream _                      = error "outputStream"
 data Sequence = SFinish Trailers
               | SFlush
               | SBuilder Builder
+              | SFile FilePath (Maybe FilePart)
 
 data Sync = SyncNone
           | SyncFinish Trailers

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -18,6 +18,7 @@ import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Network.HTTP.Types as H
 import Network.Wai (Request, Response)
+import Network.Wai.HTTP2 (Trailers)
 import Network.Wai.Handler.Warp.IORef
 import Network.Wai.Handler.Warp.Types
 
@@ -60,10 +61,18 @@ type BytesFilled = Int
 data Next = Next BytesFilled (Control DynaNext)
 
 data Output = OFinish
+            -- ^ Terminate the connection.
             | OGoaway ByteString
+            -- ^ Send a goaway frame and terminate the connection.
             | OFrame  ByteString
+            -- ^ Send an entire pre-encoded frame.
             | OResponse Stream Response Aux
+            -- ^ Send the headers and as much of the response as is immediately
+            -- available.
             | ONext Stream DynaNext
+            -- ^ Send a chunk of the response.
+            | OTrailers Stream Trailers
+            -- ^ Send a series of trailers in header and continuation frames.
 
 outputStream :: Output -> Stream
 outputStream (OResponse strm _ _) = strm

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -79,6 +79,8 @@ data Output = OFinish
 outputStream :: Output -> Stream
 outputStream (OResponse strm _ _ _) = strm
 outputStream (ONext strm _)         = strm
+outputStream (OPush strm _ _ _ _ _) = strm
+outputStream (OTrailers strm _)     = strm
 outputStream _                      = error "outputStream"
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -86,7 +86,7 @@ data Sequence = SFinish
               | SBuilder Builder
 
 data Sync = SyncNone
-          | SyncFinish
+          | SyncFinish Trailers
           | SyncNext Output
 
 data Aux = Oneshot Bool

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -82,14 +82,11 @@ data Output = OFinish
             -- MVar whether the promise has been sent.
             | ONext Stream DynaNext
             -- ^ Send a chunk of the response.
-            | OTrailers Stream Trailers
-            -- ^ Send a series of trailers in header and continuation frames.
 
 outputStream :: Output -> Stream
 outputStream (OResponse strm _ _ _)   = strm
 outputStream (ONext strm _)           = strm
 outputStream (OPush strm _ _ _ _ _ _) = strm
-outputStream (OTrailers strm _)       = strm
 outputStream _                        = error "outputStream"
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -81,7 +81,7 @@ outputStream _                    = error "outputStream"
 
 ----------------------------------------------------------------
 
-data Sequence = SFinish
+data Sequence = SFinish Trailers
               | SFlush
               | SBuilder Builder
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -37,7 +37,7 @@ isHTTP2 tls = useHTTP2
   where
     useHTTP2 = case tlsNegotiatedProtocol tls of
         Nothing    -> False
-        Just proto -> "h2-" `BS.isPrefixOf` proto
+        Just proto -> "h2-" `BS.isPrefixOf` proto || proto == "h2"
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -18,7 +18,7 @@ import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Network.HTTP.Types as H
 import Network.Wai (Request)
-import Network.Wai.HTTP2 (Trailers)
+import Network.Wai.HTTP2 (PushPromise, Trailers)
 import Network.Wai.Handler.Warp.IORef
 import Network.Wai.Handler.Warp.Types
 
@@ -69,6 +69,8 @@ data Output = OFinish
             | OResponse Stream H.Status H.ResponseHeaders Aux
             -- ^ Send the headers and as much of the response as is immediately
             -- available.
+            | OPush Stream PushPromise Stream H.Status H.ResponseHeaders Aux
+            -- ^ Send a PUSH_PROMISE frame, then act like OResponse.
             | ONext Stream DynaNext
             -- ^ Send a chunk of the response.
             | OTrailers Stream Trailers

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -17,8 +17,8 @@ import qualified Data.ByteString as BS
 import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
 import qualified Network.HTTP.Types as H
-import Network.Wai (Request, Response)
-import Network.Wai.HTTP2 (Trailers)
+import Network.Wai (Request)
+import Network.Wai.HTTP2 (Trailers, Response)
 import Network.Wai.Handler.Warp.IORef
 import Network.Wai.Handler.Warp.Types
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -89,8 +89,7 @@ data Sync = SyncNone
           | SyncFinish Trailers
           | SyncNext Output
 
-data Aux = Oneshot Bool
-         | Persist (TBQueue Sequence) (TVar Sync)
+data Aux = Persist (TBQueue Sequence) (TVar Sync)
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -104,6 +104,9 @@ data Context = Context {
   --   this requirement.
   , continued          :: IORef (Maybe StreamId)
   , currentStreamId    :: IORef StreamId
+  -- ^ Last client-initiated stream ID we've handled.
+  , nextPushStreamId   :: IORef StreamId
+  -- ^ Next available server-initiated stream ID.
   , inputQ             :: TQueue Input
   , outputQ            :: PriorityTree Output
   , encodeDynamicTable :: IORef DynamicTable
@@ -119,6 +122,7 @@ newContext = Context <$> newIORef defaultSettings
                      <*> newIORef 0
                      <*> newIORef Nothing
                      <*> newIORef 0
+                     <*> newIORef 2 -- first server push stream; 0 is reserved
                      <*> newTQueueIO
                      <*> newPriorityTree
                      <*> (newDynamicTableForEncoding defaultDynamicTableSize >>= newIORef)

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -5,7 +5,7 @@ module Network.Wai.Handler.Warp.HTTP2.Types where
 
 import Data.ByteString.Builder (Builder)
 #if __GLASGOW_HASKELL__ < 709
-import Control.Applicative ((<$>),(<*>))
+import Control.Applicative ((<$>), (<*>), pure)
 #endif
 import Control.Concurrent (forkIO)
 import Control.Concurrent.MVar (MVar)

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -71,7 +71,7 @@ response Context{outputQ} mgr tconf th strm req rsp = do
                     T.tickle th
                 flush  = atomically $ writeTBQueue sq SFlush
             strmbdy push flush
-            atomically $ writeTBQueue sq SFinish
+            atomically $ writeTBQueue sq $ SFinish []
         _ -> do
             setThreadContinue tconf True
             let hasBody = requestMethod req /= H.methodHead

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -217,14 +217,14 @@ waiter tvar sq strm outQ = do
     mx <- atomically $ do
         mout <- readTVar tvar
         case mout of
-            SyncNone            -> retry
-            SyncNext out        -> do
+            SyncNone     -> retry
+            SyncNext out -> do
                 writeTVar tvar SyncNone
-                return $ Right out
-            SyncFinish trailers -> return $ Left trailers
+                return $ Just out
+            SyncFinish   -> return Nothing
     case mx of
-        Left  trailers -> enqueueWhenWindowIsOpen outQ (OTrailers strm trailers)
-        Right out      -> do
+        Nothing  -> return ()
+        Just out -> do
             -- ensuring that the streaming queue is not empty.
             atomically $ do
                 isEmpty <- isEmptyTBQueue sq

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -21,8 +21,8 @@ import Data.Typeable
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
 import Network.HTTP2.Priority
-import Network.Wai
-import Network.Wai.HTTP2 (Http2Application)
+import Network.Wai.HTTP2 (Http2Application, Response(..), responseStatus)
+import Network.Wai hiding (Response, responseStatus)
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Types
@@ -30,7 +30,6 @@ import Network.Wai.Handler.Warp.IORef
 import qualified Network.Wai.Handler.Warp.Response as R
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
-import Network.Wai.Internal (Response(..))
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -21,7 +21,7 @@ import Control.Monad (void, when)
 import Data.Typeable
 import Network.HTTP2
 import Network.HTTP2.Priority
-import Network.Wai.HTTP2 (Http2Application, Response)
+import Network.Wai.HTTP2 (Http2Application, Response, absurd)
 import Network.Wai hiding (Response, responseStatus)
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
@@ -94,7 +94,7 @@ worker ctx@Context{inputQ,outputQ} set tm app responder = do
             setStreamInfo sinfo strm req
             T.resume th
             T.tickle th
-            app req $ responder tcont th strm sq
+            app (req, flip (const absurd)) $ responder tcont th strm sq
         cont1 <- case ex of
             Right trailers -> do
                 atomically $ writeTBQueue sq $ SFinish trailers

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -22,29 +22,28 @@ import Data.Typeable
 import qualified Network.HTTP.Types as H
 import Network.HTTP2
 import Network.HTTP2.Priority
-import Network.Wai.HTTP2 (Http2Application, PushPromise, Responder, Response)
-import Network.Wai hiding (Response, responseStatus)
+import Network.Wai
 import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.IORef
+import Network.Wai.HTTP2 (Http2Application, PushPromise, Responder, RespondFunc)
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
 
 ----------------------------------------------------------------
 
--- | An 'Http2Application' takes a @forall a. Response a -> IO a@; this type
---   implements that by currying some internal arguments.
+-- | An 'Http2Application' takes a 'RespondFunc'; this type implements that by
+--   currying some internal arguments.
 --
 --   This is the argument to a 'Responder'.
-type Respond = IO () -> Stream -> TBQueue Sequence ->
-               (forall a. Response a -> IO a)
+type Respond = IO () -> Stream -> TBQueue Sequence -> RespondFunc
 
 -- | This function is passed to workers.
---   They also pass 'Response's from 'Http2Application's to this function.
+--   They also pass responses from 'Http2Application's to this function.
 --   This function enqueues commands for the HTTP/2 sender.
 response :: Context -> Manager -> ThreadContinue -> Respond
-response ctx mgr tconf tickle strm sq rsp = do
+response ctx mgr tconf tickle strm sq s h strmbdy = do
     -- TODO(awpr) HEAD requests will still stream.
 
     -- We must not exit this WAI application.
@@ -56,12 +55,12 @@ response ctx mgr tconf tickle strm sq rsp = do
     -- After this work, this thread stops to decrease the number of workers.
     setThreadContinue tconf False
 
-    runStream ctx OResponse tickle strm sq rsp
+    runStream ctx OResponse tickle strm sq s h strmbdy
 
 runStream :: Context
           -> (Stream -> H.Status -> H.ResponseHeaders -> Aux -> Output)
           -> Respond
-runStream Context{outputQ} mkOutput tickle strm sq (s, h, strmbdy) = do
+runStream Context{outputQ} mkOutput tickle strm sq s h strmbdy = do
     tvar <- newTVarIO SyncNone
     let out = mkOutput strm s h (Persist sq tvar)
     -- Since we must not enqueue an empty queue to the priority

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -144,7 +144,7 @@ worker ctx@Context{inputQ} set tm app respond = do
             setStreamInfo sinfo strm req
             T.resume th
             T.tickle th
-            let responder = app (req, pushResponder ctx set strm)
+            let responder = app req $ pushResponder ctx set strm
             runResponder responder (respond tcont) (T.tickle th) strm
         cont1 <- case ex of
             Right () -> return True

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -27,17 +27,18 @@ import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.IORef
-import Network.Wai.HTTP2 (Chunk(..), HTTP2Application, PushPromise, Responder, RespondFunc)
+import Network.Wai.HTTP2 (Chunk(..), HTTP2Application, PushPromise, Responder)
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
 
 ----------------------------------------------------------------
 
--- | An 'HTTP2Application' takes a 'RespondFunc'; this type implements that by
---   currying some internal arguments.
+-- | An 'HTTP2Application' takes a function of status, headers, and body; this
+--   type implements that by currying some internal arguments.
 --
 --   This is the argument to a 'Responder'.
-type Respond = IO () -> Stream -> TBQueue Sequence -> RespondFunc
+type Respond = forall a. IO () -> Stream -> TBQueue Sequence
+            -> H.Status -> H.ResponseHeaders -> Body a -> IO a
 
 -- | This function is passed to workers.
 --   They also pass responses from 'HTTP2Application's to this function.

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -85,7 +85,7 @@ worker ctx@Context{inputQ,outputQ} set tm app responder = do
   where
     go sinfo tcont th = do
         setThreadContinue tcont True
-        -- Since 'StreamingBody' is loop, we cannot control it.
+        -- Since 'Body' is loop, we cannot control it.
         -- So, let's serialize 'Builder' with a designated queue.
         sq <- newTBQueueIO 10 -- fixme: hard coding: 10
         ex <- E.try $ do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -27,7 +27,13 @@ import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.IORef
-import Network.Wai.HTTP2 (Chunk(..), HTTP2Application, PushPromise, Responder)
+import Network.Wai.HTTP2
+    ( Body
+    , Chunk(..)
+    , HTTP2Application
+    , PushPromise
+    , Responder
+    )
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Worker.hs
@@ -27,20 +27,20 @@ import Network.Wai.Handler.Warp.HTTP2.EncodeFrame
 import Network.Wai.Handler.Warp.HTTP2.Manager
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.IORef
-import Network.Wai.HTTP2 (Http2Application, PushPromise, Responder, RespondFunc)
+import Network.Wai.HTTP2 (HTTP2Application, PushPromise, Responder, RespondFunc)
 import qualified Network.Wai.Handler.Warp.Settings as S
 import qualified Network.Wai.Handler.Warp.Timeout as T
 
 ----------------------------------------------------------------
 
--- | An 'Http2Application' takes a 'RespondFunc'; this type implements that by
+-- | An 'HTTP2Application' takes a 'RespondFunc'; this type implements that by
 --   currying some internal arguments.
 --
 --   This is the argument to a 'Responder'.
 type Respond = IO () -> Stream -> TBQueue Sequence -> RespondFunc
 
 -- | This function is passed to workers.
---   They also pass responses from 'Http2Application's to this function.
+--   They also pass responses from 'HTTP2Application's to this function.
 --   This function enqueues commands for the HTTP/2 sender.
 response :: Context -> Manager -> ThreadContinue -> Respond
 response ctx mgr tconf tickle strm sq s h strmbdy = do
@@ -125,7 +125,7 @@ instance Exception Break
 worker :: Context
        -> S.Settings
        -> T.Manager
-       -> Http2Application
+       -> HTTP2Application
        -> (ThreadContinue -> Respond)
        -> IO ()
 worker ctx@Context{inputQ} set tm app respond = do

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -8,7 +8,18 @@ module Network.Wai.Handler.Warp.Internal (
   , runSettingsConnection
   , runSettingsConnectionMaker
   , runSettingsConnectionMakerSecure
+  , runServe
+  , runServeEnv
+  , runServeSettings
+  , runServeSettingsSocket
+  , runServeSettingsConnection
+  , runServeSettingsConnectionMaker
+  , runServeSettingsConnectionMakerSecure
   , Transport (..)
+    -- * ServeConnection
+  , ServeConnection
+  , serveDefault
+  , serveHttp2
     -- * Connection
   , Connection (..)
   , socketConnection

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -19,7 +19,7 @@ module Network.Wai.Handler.Warp.Internal (
     -- * ServeConnection
   , ServeConnection
   , serveDefault
-  , serveHttp2
+  , serveHTTP2
     -- * Connection
   , Connection (..)
   , socketConnection

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -6,6 +6,9 @@
 
 module Network.Wai.Handler.Warp.Run where
 
+#if __GLASGOW_HASKELL__ < 709
+import Control.Applicative ((<*>))
+#endif
 import Control.Arrow (first)
 import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent as Conc (yield)

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -21,12 +21,12 @@ import Network (sClose, Socket)
 import Network.Socket (accept, withSocketsDo, SockAddr(SockAddrInet, SockAddrInet6))
 import qualified Network.Socket.ByteString as Sock
 import Network.Wai
-import Network.Wai.HTTP2 (HTTP2Application)
+import Network.Wai.HTTP2 (HTTP2Application, promoteApplication)
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Counter
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
-import Network.Wai.Handler.Warp.HTTP2 (http2, isHTTP2, promoteApplication)
+import Network.Wai.Handler.Warp.HTTP2 (http2, isHTTP2)
 import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.ReadInt
 import Network.Wai.Handler.Warp.Recv

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -25,7 +25,7 @@ import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Counter
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
-import Network.Wai.Handler.Warp.HTTP2
+import Network.Wai.Handler.Warp.HTTP2 (http2, isHTTP2, promoteApplication)
 import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.ReadInt
 import Network.Wai.Handler.Warp.Recv
@@ -311,7 +311,7 @@ serveConnection conn ii origAddr transport settings app = do
     if h2 then do
         recvN <- makeReceiveN bs (connRecv conn) (connRecvBuf conn)
         -- fixme: origAddr
-        http2 conn ii origAddr transport settings recvN app
+        http2 conn ii origAddr transport settings recvN $ promoteApplication app
       else do
         istatus <- newIORef False
         src <- mkSource (wrappedRecv conn th istatus (settingsSlowlorisSize settings))


### PR DESCRIPTION
There's a lot of prose in the commit messages if you find yourself wondering about the reasons behind some particular change.

I still need to try the Windows-specific stuff -- I haven't installed GHC on my Windows partition yet and I've heard it's rather difficult.

Fixes #402, relevant to #415.