### PR TITLE
Bump blaze-builder minimum bound to 0.4 to fix build.

### DIFF
--- a/wai/Network/Wai/HTTP2.hs
+++ b/wai/Network/Wai/HTTP2.hs
@@ -54,6 +54,7 @@ module Network.Wai.HTTP2
     ) where
 
 import           Blaze.ByteString.Builder (Builder)
+import           Blaze.ByteString.Builder.ByteString (fromByteString)
 import           Control.Exception (Exception, throwIO)
 import           Control.Monad.Trans.Cont (ContT(..))
 import           Data.ByteString (ByteString)
@@ -186,7 +187,7 @@ respondFileExists s h path size reqHdrs =
 -- | Respond with a minimal 404 page with the given headers.
 respondNotFound :: H.ResponseHeaders -> Responder
 respondNotFound h = Responder $ \k -> k H.notFound404 h' $
-    streamBuilder "File not found."
+    streamBuilder $ fromByteString "File not found."
   where
     contentType = (H.hContentType, "text/plain; charset=utf-8")
     h' = contentType:filter ((/=H.hContentType) . fst) h


### PR DESCRIPTION
It's probably possible to make this continue to work with the older blaze-builder (instinctively I bet 0.4 was the first version to be aware of OverloadedStrings), but I haven't looked into it yet.  Should we take this version bump or change the code to avoid relying on the IsString Builder instance?

Fixes #443
Fixes #444