### PR TITLE
Add back http-types 0.8 support

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -46,7 +46,6 @@ import Data.Streaming.Blaze (newBlazeRecv, reuseBufferStrategy)
 import Data.Version (showVersion)
 import Data.Word8 (_cr, _lf)
 import qualified Network.HTTP.Types as H
-import qualified Network.HTTP.Types.Header as H
 import Network.Wai
 import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
@@ -378,7 +377,7 @@ hasBody s = sc /= 204
 ----------------------------------------------------------------
 
 addTransferEncoding :: H.ResponseHeaders -> H.ResponseHeaders
-addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
+addTransferEncoding hdrs = ("transfer-encoding", "chunked") : hdrs
 
 addDate :: D.DateCache -> IndexedHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
 addDate dc rspidxhdr hdrs = case rspidxhdr ! idxDate of

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -40,7 +40,7 @@ Library
                    , case-insensitive          >= 0.2
                    , containers
                    , ghc-prim
-                   , http-types                >= 0.9
+                   , http-types                >= 0.8
                    , iproute                   >= 1.3.1
                    , http2                     >= 1.1
                    , simple-sendfile           >= 0.2.7    && < 0.3


### PR DESCRIPTION
Reason: many packages do not yet support http-types 0.9. This increased
lower bound causes many imcompatibility issues on Hackage. I'd like to
get this merged and released ASAP if there are no objection.

Pinging @kazu-yamamoto 