### PR TITLE
Fix http2 header parsing

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -44,6 +44,7 @@ module Network.Wai.Handler.WarpTLS (
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative ((<$>))
 #endif
+import Control.Applicative ((<|>))
 import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException, SomeException(..))
 import qualified Control.Exception as E
 import Control.Monad (void)
@@ -279,7 +280,8 @@ runServeTLSSocket' tlsset@TLSSettings{..} set credential sock serve =
       }
     -- Adding alpn to user's tlsServerHooks.
     hooks = tlsServerHooks {
-        TLS.onALPNClientSuggest = Just alpn
+        TLS.onALPNClientSuggest = TLS.onALPNClientSuggest tlsServerHooks <|>
+          (if settingsHTTP2Enabled set then Just alpn else Nothing)
       }
     shared = def {
         TLS.sharedCredentials = TLS.Credentials [credential]

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -76,6 +76,7 @@ module Network.Wai.Handler.Warp (
   , setProxyProtocolRequired
   , setProxyProtocolOptional
   , setSlowlorisSize
+  , setHTTP2Disabled
     -- ** Getters
   , getPort
   , getHost
@@ -355,6 +356,12 @@ setProxyProtocolOptional y = y { settingsProxyProtocol = ProxyProtocolOptional }
 -- Since 3.1.2
 setSlowlorisSize :: Int -> Settings -> Settings
 setSlowlorisSize x y = y { settingsSlowlorisSize = x }
+
+-- | Disable HTTP2.
+--
+-- Since 3.1.7
+setHTTP2Disabled :: Settings -> Settings
+setHTTP2Disabled y = y { settingsHTTP2Enabled = False }
 
 -- | Explicitly pause the slowloris timeout.
 --

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -65,7 +65,9 @@ hpackDecodeHeader hdrblk Context{decodeDynamicTable} = do
 -- >>> concatCookie [("cookie","a=b"),("foo","bar"),("cookie","c=d"),("cookie","e=f")]
 -- [("cookie","a=b; c=d; e=f"),("foo","bar")]
 concatCookie :: HeaderList -> HeaderList
-concatCookie hdr = case L.partition (\x -> fst x == "cookie") hdr of
-    ([],_)           -> hdr
-    (cookies,others) -> let cookieValue = B.intercalate "; " (map snd cookies)
-                        in ("cookie",cookieValue) : others
+concatCookie = collect []
+  where
+    collect cookies (("cookie",c):rest) = collect (cookies ++ [c]) rest
+    collect cookies (h:rest) = h : collect cookies rest
+    collect [] [] = []
+    collect cookies [] = [("cookie", B.intercalate "; " cookies)]

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -10,7 +10,6 @@ import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Char8 as B8
 import Data.CaseInsensitive (foldedCase)
 import Data.IORef (readIORef, writeIORef)
-import qualified Data.List as L
 import Network.HPACK
 import qualified Network.HTTP.Types as H
 import Network.HTTP2

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -62,7 +62,7 @@ hpackDecodeHeader hdrblk Context{decodeDynamicTable} = do
 -- >>> concatCookie [("foo","bar")]
 -- [("foo","bar")]
 -- >>> concatCookie [("cookie","a=b"),("foo","bar"),("cookie","c=d"),("cookie","e=f")]
--- [("cookie","a=b; c=d; e=f"),("foo","bar")]
+-- [("foo","bar"),("cookie","a=b; c=d; e=f")]
 concatCookie :: HeaderList -> HeaderList
 concatCookie = collect []
   where

--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -64,16 +64,8 @@ hpackDecodeHeader hdrblk Context{decodeDynamicTable} = do
 -- [("foo","bar")]
 -- >>> concatCookie [("cookie","a=b"),("foo","bar"),("cookie","c=d"),("cookie","e=f")]
 -- [("cookie","a=b; c=d; e=f"),("foo","bar")]
--- >>> concatCookie [(":pseudo","pseudo"),("cookie","a=b"),("foo","bar"),("cookie","c=d"),("cookie","e=f")]
--- [(":pseudo","pseudo"),("cookie","a=b; c=d; e=f"),("foo","bar")]
 concatCookie :: HeaderList -> HeaderList
 concatCookie hdr = case L.partition (\x -> fst x == "cookie") hdr of
     ([],_)           -> hdr
     (cookies,others) -> let cookieValue = B.intercalate "; " (map snd cookies)
-                        in insertAfterPseudo ("cookie",cookieValue) others
-
-insertAfterPseudo :: Header -> HeaderList -> HeaderList
-insertAfterPseudo x [] = [x]
-insertAfterPseudo x yys@(y:ys)
-  | isPseudo (fst y) = y : insertAfterPseudo x ys
-  | otherwise        = x : yys
+                        in ("cookie",cookieValue) : others

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -22,7 +22,7 @@ import Data.Maybe (isJust)
 #if __GLASGOW_HASKELL__ < 709
 import Data.Monoid (mempty)
 #endif
-import Data.Word8 (isUpper)
+import Data.Word8 (isUpper,_colon)
 import Network.HPACK
 import Network.HTTP.Types (RequestHeaders,hRange)
 import qualified Network.HTTP.Types as H
@@ -118,6 +118,10 @@ validateHeaders hs = case pseudo hs (emptyPseudo,id) of
       | otherwise         = case BS.find isUpper k of
                                  Nothing -> normal kvs (p, b . ((mk k,v) :))
                                  Just _  -> Nothing
+
+    isPseudo "" = False
+    isPseudo k  = BS.head k == _colon
+
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -17,7 +17,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.IntMap.Strict (IntMap, IntMap)
 import qualified Data.IntMap.Strict as M
-import Data.Word8 (_colon)
 import qualified Network.HTTP.Types as H
 import Network.Wai (Request, FilePart)
 import Network.Wai.HTTP2 (PushPromise, Trailers)
@@ -309,10 +308,3 @@ enqueueOrSpawnTemporaryWaiter strm outQ out = do
       else do
         pri <- readIORef $ streamPriority strm
         enqueue outQ out pri
-
-----------------------------------------------------------------
-
-{-# INLINE isPseudo #-}
-isPseudo :: ByteString -> Bool
-isPseudo "" = False
-isPseudo k  = BS.head k == _colon

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -387,7 +387,7 @@ serveHTTP2 app2 app conn ii origAddr transport settings = do
                        return (True, bs0)
                      else
                        return (False, bs0)
-    if h2 then do
+    if settingsHTTP2Enabled settings && h2 then do
         recvN <- makeReceiveN bs (connRecv conn) (connRecvBuf conn)
         -- fixme: origAddr
         http2 conn ii origAddr transport settings recvN app2

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -92,6 +92,10 @@ data Settings = Settings
       -- ^ Size of bytes read to prevent Slowloris protection. Default value: 2048
       --
       -- Since 3.1.2.
+    , settingsHTTP2Enabled :: Bool
+      -- ^ Whether to enable HTTP2 ALPN/upgrades. Default: True
+      --
+      -- Since 3.1.7.
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -123,6 +127,7 @@ defaultSettings = Settings
     , settingsMaximumBodyFlush = Just 8192
     , settingsProxyProtocol = ProxyProtocolNone
     , settingsSlowlorisSize = 2048
+    , settingsHTTP2Enabled = True
     }
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an


### PR DESCRIPTION
We've been having consistent failures with http2 across multiple browsers and platforms for months (see #450), which turned out primarily to happen when there were cookies in the request. Looking at the `HeaderList` being parsed to `validateHeaders` I see something like:
`[("cookie","session=..."),(":method","GET"),(":path","/"),(":authority","localhost"),(":scheme","https"),("user-agent","Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0"),("accept","text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),("accept-language","en-US,en;q=0.5"),("accept-encoding","gzip, deflate")]`
But `validateHeaders` doesn't allow pseudo-headers to be parsed after normal headers.  I'm not quite sure why header parsing was split up this way, nor have I looked into the http2 spec or where the `HeaderList` comes from, but this is clearly happening in practice.  Allowing `normal` to chain back into `pseudo` fixes this, at least for one browser so far. (The two functions could obviously be merged and cleaned up but this was the simplest fix.)