### PR TITLE
add 404 handler

### DIFF
--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -255,7 +255,9 @@ staticAppPieces ss rawPieces req sendResponse = liftIO $ do
                 , ("Location", path)
                 ] "Redirect"
 
-    response NotFound = sendResponse $ W.responseLBS H.status404
+    response NotFound = case (ss404Handler ss) of
+        Just app -> app req sendResponde
+        Nothing  -> sendResponse $ W.responseLBS H.status404
                         [ ("Content-Type", "text/plain")
                         ] "File not found"
 

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -256,7 +256,7 @@ staticAppPieces ss rawPieces req sendResponse = liftIO $ do
                 ] "Redirect"
 
     response NotFound = case (ss404Handler ss) of
-        Just app -> app req sendResponde
+        Just app -> app req sendResponse
         Nothing  -> sendResponse $ W.responseLBS H.status404
                         [ ("Content-Type", "text/plain")
                         ] "File not found"

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -22,6 +22,7 @@ module Network.Wai.Application.Static
     , ssMaxAge
     , ssRedirectToIndex
     , ssAddTrailingSlash
+    , ss404Handler
     ) where
 
 import Prelude hiding (FilePath)

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -47,6 +47,7 @@ defaultWebAppSettings root = StaticSettings
     , ssRedirectToIndex = False
     , ssUseHash = True
     , ssAddTrailingSlash = False
+    , ss404Handler = Nothing
     }
 
 -- | Settings optimized for a file server. More conservative caching will be
@@ -63,6 +64,7 @@ defaultFileServerSettings root = StaticSettings
     , ssRedirectToIndex = False
     , ssUseHash = False
     , ssAddTrailingSlash = False
+    , ss404Handler = Nothing
     }
 
 -- | Same as @defaultWebAppSettings@, but additionally uses a specialized

--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -144,4 +144,7 @@ data StaticSettings = StaticSettings
 
       -- | Force a trailing slash at the end of directories
     , ssAddTrailingSlash :: Bool
+
+      -- | Optional `W.Application` to be used in case of 404 errors
+    , ss404Handler :: Maybe W.Application
     }


### PR DESCRIPTION
Adds a new setting called `ss404Handler` that specifies a `Maybe Application` to be called in case of 404 errors.