### PR TITLE
Make sure HEAD response bodies are empty (fixes #468)

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eux
+
+mkdir -p $HOME/.cabal
+cat > $HOME/.cabal/config <<EOF
+remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/
+remote-repo-cache: $HOME/.cabal/packages
+jobs: \$ncpus
+EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+ - ./.travis-setup.sh
  - cabal --version
 
 install:

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -180,14 +180,12 @@ sendResponse defServer conn ii req reqidxhdr src response = do
     isChunked = not isHead && isChunked0
     (isKeepAlive, needsChunked) = infoFromResponse rspidxhdr (isPersist,isChunked)
     isHead = requestMethod req == H.methodHead
-    rsp = case response of
-        ResponseFile _ _ path mPart -> RspFile path mPart mRange isHead (T.tickle th)
-        ResponseBuilder _ _ b
-          | isHead                  -> RspBuilder mempty False
-          | otherwise               -> RspBuilder b needsChunked
-        ResponseStream _ _ fb
-          | isHead                  -> RspBuilder mempty False
-          | otherwise               -> RspStream fb needsChunked th
+    rsp
+      | isHead    = RspBuilder mempty False
+      | otherwise = case response of
+        ResponseFile _ _ path mPart -> RspFile path mPart mRange (T.tickle th)
+        ResponseBuilder _ _ b       -> RspBuilder b needsChunked
+        ResponseStream _ _ fb       -> RspStream fb needsChunked th
         ResponseRaw raw _           -> RspRaw raw src (T.tickle th)
     ret = case response of
         ResponseFile    {} -> isPersist
@@ -222,7 +220,7 @@ sanitizeHeaderValue v = case S8.lines $ S.filter (/= _cr) v of
 
 ----------------------------------------------------------------
 
-data Rsp = RspFile FilePath (Maybe FilePart) (Maybe HeaderValue) Bool (IO ())
+data Rsp = RspFile FilePath (Maybe FilePart) (Maybe HeaderValue) (IO ())
          | RspBuilder Builder Bool
          | RspStream StreamingBody Bool T.Handle
          | RspRaw (IO ByteString -> (ByteString -> IO ()) -> IO ()) (IO ByteString) (IO ())
@@ -236,7 +234,7 @@ sendRsp :: Connection
         -> H.ResponseHeaders
         -> Rsp
         -> IO ()
-sendRsp conn mfdc ver s0 hs0 (RspFile path mPart mRange isHead hook) = do
+sendRsp conn mfdc ver s0 hs0 (RspFile path mPart mRange hook) = do
     ex <- fileRange s0 hs0 path mPart mRange
     case ex of
         Left _ex ->
@@ -245,24 +243,21 @@ sendRsp conn mfdc ver s0 hs0 (RspFile path mPart mRange isHead hook) = do
 #endif
           sendRsp conn mfdc ver s2 hs2 (RspBuilder body True)
         Right (s, hs, beg, len)
-          | len >= 0 ->
-            if isHead then
-                sendRsp conn mfdc ver s hs (RspBuilder mempty False)
-              else do
-                lheader <- composeHeader ver s hs
+          | len >= 0 -> do
+            lheader <- composeHeader ver s hs
 #ifdef WINDOWS
-                let fid = FileId path Nothing
-                    hook' = hook
+            let fid = FileId path Nothing
+                hook' = hook
 #else
-                (mfd, hook') <- case mfdc of
-                   -- settingsFdCacheDuration is 0
-                   Nothing  -> return (Nothing, hook)
-                   Just fdc -> do
-                      (fd, fresher) <- F.getFd fdc path
-                      return (Just fd, hook >> fresher)
-                let fid = FileId path mfd
+            (mfd, hook') <- case mfdc of
+               -- settingsFdCacheDuration is 0
+               Nothing  -> return (Nothing, hook)
+               Just fdc -> do
+                  (fd, fresher) <- F.getFd fdc path
+                  return (Just fd, hook >> fresher)
+            let fid = FileId path mfd
 #endif
-                connSendFile conn fid beg len hook' [lheader]
+            connSendFile conn fid beg len hook' [lheader]
           | otherwise ->
             sendRsp conn mfdc ver H.status416
                 (filter (\(k, _) -> k /= "content-length") hs)

--- a/warp/test/HTTP.hs
+++ b/warp/test/HTTP.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module HTTP (
     sendGET
+  , sendHEAD
   , sendGETwH
   , rspBody
   , rspCode
@@ -18,6 +19,9 @@ sendGET url = sendGETwH url []
 
 sendGETwH :: String -> [Header] -> IO (Response String)
 sendGETwH url hdr = unResult $ simpleHTTP $ (getRequest url) { rqHeaders = hdr }
+
+sendHEAD :: String -> IO (Response String)
+sendHEAD url = unResult $ simpleHTTP $ headRequest url
 
 unResult :: IO (Result (Response String)) -> IO (Response String)
 unResult action = do

--- a/warp/test/HTTP.hs
+++ b/warp/test/HTTP.hs
@@ -2,13 +2,15 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module HTTP (
     sendGET
-  , sendHEAD
   , sendGETwH
+  , sendHEAD
+  , sendHEADwH
   , rspBody
   , rspCode
   , rspHeaders
   , getHeaderValue
   , HeaderName(..)
+  , mkHeader
   ) where
 
 import Network.HTTP
@@ -21,7 +23,10 @@ sendGETwH :: String -> [Header] -> IO (Response String)
 sendGETwH url hdr = unResult $ simpleHTTP $ (getRequest url) { rqHeaders = hdr }
 
 sendHEAD :: String -> IO (Response String)
-sendHEAD url = unResult $ simpleHTTP $ headRequest url
+sendHEAD url = sendHEADwH url []
+
+sendHEADwH :: String -> [Header] -> IO (Response String)
+sendHEADwH url hdr = unResult $ simpleHTTP $ (headRequest url) { rqHeaders = hdr }
 
 unResult :: IO (Result (Response String)) -> IO (Response String)
 unResult action = do

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -395,12 +395,12 @@ spec = do
         it "file, no range" $ withApp defaultSettings app $ \port -> do
             bs <- S.readFile fp
             res <- sendHEAD $ concat ["http://127.0.0.1:", show port, "/file"]
-            getHeaderValue HdrContentLength res `shouldBe` Just (show $ S.length bs)
+            getHeaderValue HdrContentLength res `shouldBe` Nothing
         it "file, with range" $ withApp defaultSettings app $ \port -> do
             res <- sendHEADwH
                 (concat ["http://127.0.0.1:", show port, "/file"])
                 [mkHeader HdrRange "bytes=0-1"]
-            getHeaderValue HdrContentLength res `shouldBe` Just "2"
+            getHeaderValue HdrContentLength res `shouldBe` Nothing
 
 consumeBody :: IO ByteString -> IO [ByteString]
 consumeBody body =

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -377,6 +377,22 @@ spec = do
             res <- sendGET $ "http://127.0.0.1:" ++ show port
             rspBody res `shouldBe` "HelloHelloHelloHello"
 
+    describe "head requests" $ do
+        let fp = "test/head-response"
+        let app req f =
+                f $ case pathInfo req of
+                    ["builder"] -> responseBuilder status200 [] $ error "should never be evaluated"
+                    ["streaming"] -> responseStream status200 [] $ \write _ ->
+                        write $ error "should never be evaluated"
+                    ["file"] -> responseFile status200 [] fp Nothing
+                    _ -> error "invalid path"
+        it "builder" $ withApp defaultSettings app $ \port -> do
+            res <- sendHEAD $ concat ["http://127.0.0.1:", show port, "/builder"]
+            rspBody res `shouldBe` ""
+        it "streaming" $ withApp defaultSettings app $ \port -> do
+            res <- sendHEAD $ concat ["http://127.0.0.1:", show port, "/streaming"]
+            rspBody res `shouldBe` ""
+
 consumeBody :: IO ByteString -> IO [ByteString]
 consumeBody body =
     loop id

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -392,6 +392,15 @@ spec = do
         it "streaming" $ withApp defaultSettings app $ \port -> do
             res <- sendHEAD $ concat ["http://127.0.0.1:", show port, "/streaming"]
             rspBody res `shouldBe` ""
+        it "file, no range" $ withApp defaultSettings app $ \port -> do
+            bs <- S.readFile fp
+            res <- sendHEAD $ concat ["http://127.0.0.1:", show port, "/file"]
+            getHeaderValue HdrContentLength res `shouldBe` Just (show $ S.length bs)
+        it "file, with range" $ withApp defaultSettings app $ \port -> do
+            res <- sendHEADwH
+                (concat ["http://127.0.0.1:", show port, "/file"])
+                [mkHeader HdrRange "bytes=0-1"]
+            getHeaderValue HdrContentLength res `shouldBe` Just "2"
 
 consumeBody :: IO ByteString -> IO [ByteString]
 consumeBody body =

--- a/warp/test/head-response
+++ b/warp/test/head-response
@@ -1,0 +1,1 @@
+This is the body

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -18,6 +18,7 @@ description:         HTTP\/1.0, HTTP\/1.1 and HTTP\/2 are supported.
 extra-source-files:  attic/hex
                      ChangeLog.md
                      README.md
+                     test/head-response
 
 Flag network-bytestring
     Default: False


### PR DESCRIPTION
I've put together an initial patch to handle this. I'd still like to add a regression test to ensure that HEAD requests on ResponseFile, ResponseBuilder, and ResponseStream all return empty bodies, but I wanted to get your feedback on the approach.