### PR TITLE
Switch over to using Stack for building Travis

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -2,6 +2,19 @@
 
 set -eux
 
+# For simplicity, installing cabal-meta and Stack for both the Cabal and Stack
+# build plans, even though they're never both necessary.
+
+mkdir -p ~/.local/bin
+if [ `uname` = "Darwin" ]
+then
+  curl -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  brew install fcgi
+else
+  curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
+fi
+
 mkdir -p $HOME/.cabal
 cat > $HOME/.cabal/config <<EOF
 remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,54 +4,85 @@ sudo: false
 # Choose a lightweight base image; we provide our own build tools.
 language: c
 
-# GHC depends on GMP. You can add other dependencies here as well.
-addons:
-  apt:
-    packages:
-    - libgmp-dev
-    - libfcgi-dev
-
 matrix:
   include:
   - env: CABALVER=1.18 GHCVER=7.6.3 BUILD=cabal
-    compiler: ": #GHC 7.6.3"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [libfcgi-dev,cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
 
   - env: CABALVER=1.18 GHCVER=7.8.4 BUILD=cabal
-    compiler: ": #GHC 7.8.4"
-    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [libfcgi-dev,cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
 
   - env: CABALVER=1.22 GHCVER=7.10.1 BUILD=cabal
-    compiler: ": #GHC 7.10.1"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [libfcgi-dev,cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
 
   - env: CABALVER=1.22 GHCVER=7.10.2 BUILD=cabal
-    compiler: ": #GHC 7.10.2"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+    addons: {apt: {packages: [libfcgi-dev,cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
 
-  - env: CABALVER=head GHCVER=7.10.2 BUILD=cabal
-    compiler: ": #GHC head"
-    addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+  - env: CABALVER=head GHCVER=head BUILD=cabal
+    addons: {apt: {packages: [libfcgi-dev,cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  - env: ARGS= BUILD=stack
+    addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+
+  - env: ARGS="--resolver lts-3" BUILD=stack
+    addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+
+  - env: ARGS="--resolver lts" BUILD=stack
+    addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+
+  - env: ARGS="--resolver nightly" BUILD=stack
+    addons: {apt: {packages: [libfcgi-dev,libgmp-dev]}}
+
+  - env: ARGS= BUILD=stack
+    os: osx
+
+  - env: ARGS="--resolver lts-3" BUILD=stack
+    os: osx
+
+  - env: ARGS="--resolver lts" BUILD=stack
+    os: osx
+
+  - env: ARGS="--resolver nightly" BUILD=stack
+    os: osx
 
   allow_failures:
-  - env: GHCVER=head CABALVER=head
+  - env: CABALVER=head GHCVER=head BUILD=cabal
 
 before_install:
-- mkdir -p $HOME/.local/bin
-- export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
-- travis_retry curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
-- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-
+# Set up path and additional build tools
 - ./.travis-setup.sh
-- cabal --version
-- ghc --version
+- case "$BUILD" in
+    stack)
+      export PATH=$HOME/.local/bin:$HOME/.cabal/bin:$PATH;
+      stack --version;;
+    cabal)
+      export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH;
+      ghc --version;
+      cabal --version;;
+  esac
 
 install:
-- travis_retry cabal update
-- cabal unpack wai-logger
-- mv wai-logger-* wai-logger
-- cabal install hspec doctest HTTP temporary
-- cabal-meta install --force-reinstalls
+- case "$BUILD" in
+    stack)
+      stack $ARGS setup --no-terminal;;
+    cabal)
+      travis_retry cabal update;
+      cabal unpack wai-logger;
+      mv wai-logger-* wai-logger;
+      cabal install hspec doctest HTTP temporary;
+      cabal-meta install --force-reinstalls;;
+  esac
 
 script:
-- mega-sdist --test
+- case "$BUILD" in
+    stack)
+      stack $ARGS --no-terminal test --haddock;;
+    cabal)
+      mega-sdist --test;;
+  esac
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack
+  - $HOME/.cabal/packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,20 +37,21 @@ matrix:
   - env: GHCVER=head CABALVER=head
 
 before_install:
- - mkdir -p $HOME/.local/bin
- - export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
- - travis_retry curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
- - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- mkdir -p $HOME/.local/bin
+- export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+- travis_retry curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
- - ./.travis-setup.sh
- - cabal --version
- - ghc --version
+- ./.travis-setup.sh
+- cabal --version
+- ghc --version
 
 install:
-    - travis_retry cabal update
-    - cabal unpack wai-logger
-    - mv wai-logger-* wai-logger
-    - cabal install hspec doctest HTTP temporary
-    - cabal-meta install --force-reinstalls
+- travis_retry cabal update
+- cabal unpack wai-logger
+- mv wai-logger-* wai-logger
+- cabal install hspec doctest HTTP temporary
+- cabal-meta install --force-reinstalls
 
-script: mega-sdist --test
+script:
+- mega-sdist --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ matrix:
    - env: GHCVER=head CABALVER=head
 
 before_install:
+ - mkdir -p $HOME/.local/bin
+ - export PATH=$HOME/.local/bin:$PATH
+ - travis_retry curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
+ - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
@@ -25,7 +30,7 @@ install:
     - travis_retry cabal update
     - cabal unpack wai-logger
     - mv wai-logger-* wai-logger
-    - cabal install hspec doctest HTTP temporary cabal-meta cabal-src
+    - cabal install hspec doctest HTTP temporary
     - cabal-meta install --force-reinstalls
 
 script: mega-sdist --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,52 @@
+# Use new container infrastructure to enable caching
+sudo: false
 
-env:
- - GHCVER=7.6.3 CABALVER=1.18
- - GHCVER=7.8.4 CABALVER=1.18
- - GHCVER=7.10.1 CABALVER=1.22
- - GHCVER=7.10.2 CABALVER=1.22
- - GHCVER=head CABALVER=head
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+    - libfcgi-dev
 
 matrix:
+  include:
+  - env: CABALVER=1.18 GHCVER=7.6.3 BUILD=cabal
+    compiler: ": #GHC 7.6.3"
+    addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
+
+  - env: CABALVER=1.18 GHCVER=7.8.4 BUILD=cabal
+    compiler: ": #GHC 7.8.4"
+    addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+
+  - env: CABALVER=1.22 GHCVER=7.10.1 BUILD=cabal
+    compiler: ": #GHC 7.10.1"
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1], sources: [hvr-ghc]}}
+
+  - env: CABALVER=1.22 GHCVER=7.10.2 BUILD=cabal
+    compiler: ": #GHC 7.10.2"
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+
+  - env: CABALVER=head GHCVER=7.10.2 BUILD=cabal
+    compiler: ": #GHC head"
+    addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
   allow_failures:
-   - env: GHCVER=head CABALVER=head
+  - env: GHCVER=head CABALVER=head
 
 before_install:
  - mkdir -p $HOME/.local/bin
- - export PATH=$HOME/.local/bin:$PATH
+ - export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
  - travis_retry curl -L http://download.fpcomplete.com/michael/cabal-meta.tar.gz | tar xz -C $HOME/.local/bin
  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
  - ./.travis-setup.sh
  - cabal --version
+ - ghc --version
 
 install:
-    - ghc --version
-    - cabal --version
-    - sudo apt-get install libfcgi-dev
     - travis_retry cabal update
     - cabal unpack wai-logger
     - mv wai-logger-* wai-logger


### PR DESCRIPTION
There are three reasons for this:

* The build script is significantly simpler
* Build times should go down significantly due to precompiled tools (as
  opposed to building mega-sdist) and caching
* We'll catch bugs that arise due to older versions of libraries (like
  #479)

Downsides:

* It won't always check against the latest versions of dependencies,
  just the latest in Stackage Nightly
* We can't test any GHC before 7.8 with it

It's possible to modify this further to have a hybrid of Stack and cabal
for building.