### PR TITLE
Let solaris2 OSes use the sendfile() call (#484).

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -169,7 +169,7 @@ Test-Suite spec
                    , unordered-containers
                    , http-date
 
-  if (os(linux) || os(freebsd) || os(darwin)) && flag(allow-sendfilefd)
+  if (os(linux) || os(freebsd) || os(darwin) || os(solaris2)) && flag(allow-sendfilefd)
     Cpp-Options:   -DSENDFILEFD
     Build-Depends: unix
   if os(windows)


### PR DESCRIPTION
A straightforward way to get those of us on Solaris a nice performance boost.