### PR TITLE
wai-handler-launch: Improvements to ping's javascript script.

### DIFF
--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -81,7 +81,7 @@ decode sendInner flushInner streamingBody = do
     Z.finishInflate inflate >>= sendInner . fromByteString
 
 toInsert :: S.ByteString
-toInsert = "<script>setInterval(function(){var x;if(window.XMLHttpRequest){x=new XMLHttpRequest();}else{x=new ActiveXObject(\"Microsoft.XMLHTTP\");}x.open(\"GET\",\"/_ping\",false);x.send();},60000)</script>"
+toInsert = "<script>setInterval(function(){var x;if(window.XMLHttpRequest){x=new XMLHttpRequest();}else{x=new ActiveXObject(\"Microsoft.XMLHTTP\");}x.open(\"GET\",\"/_ping?\" + (new Date()).getTime(),true);x.send();},60000)</script>"
 
 addInsideHead :: (Builder -> IO ())
               -> IO ()


### PR DESCRIPTION
-   Avoid using the browser's cache for the response. 
  
  Because the ping request uses GET method, IE returns the response from
  cache and does not send the ping request to the server causing the server 
  to shut down.
-   Make the javascript use the asynchronous ajax request instead of
  synchronous request. 
  
  This fixes the warning displayed in Chrome: `Synchronous XMLHttpRequest on the
  main thread is deprecated because of its detrimental effects to the end
  user's experience. For more help, check 
  http://xhr.spec.whatwg.org/.`
