### PR TITLE
Fixed a typo for windows version, changed h to hdl

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Sender.hs
@@ -296,7 +296,7 @@ fillFileBodyGetNext Connection{connWriteBuffer,connBufferSize}
     (start, bytes) <- fileStartEnd path mpart
     -- fixme: how to close Handle? GC does it at this moment.
     hdl <- IO.openBinaryFile path IO.ReadMode
-    IO.hSeek h IO.AbsoluteSeek start
+    IO.hSeek hdl IO.AbsoluteSeek start
     len <- IO.hGetBufSome hdl datBuf (mini room bytes)
     let bytes' = bytes - fromIntegral len
     -- fixme: connWriteBuffer connBufferSize


### PR DESCRIPTION
There was an error / typo which prevented warp 3.2.1 from compiling on windows.

It would be nice if you could merge this soon, since I have some project to finish and I want to have it all nice and tight without manually installing cabal packages.

    Network\Wai\Handler\Warp\HTTP2\Sender.hs:299:14: Not in scope: `h'

