### PR TITLE
compress favicon.ico

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -65,6 +65,7 @@ defaultCheckMime bs =
         [ "application/json"
         , "application/javascript"
         , "application/ecmascript"
+        , "image/x-icon"
         ]
 
 -- | Use gzip to compress the body of the response.


### PR DESCRIPTION
This reduces complaints about compression from performance testing websites for wai using websites (especially yesod powered).