### PR TITLE
warp: make .ghci work with stack

### DIFF
--- a/warp/.ghci
+++ b/warp/.ghci
@@ -1,1 +1,1 @@
-:set -itest -idist/build/autogen -optP-include -optPdist/build/autogen/cabal_macros.h
+:set -itest -idist/build/autogen -i.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/build/autogen


### PR DESCRIPTION
This change makes it possible to load the test-suite of `warp` into `ghci` while using `stack`. This is currently broken.

I don't expect this to be merged as is. Here's some questions:

- Do we want a `.ghci` file that works both with `stack` and `cabal-install`? Or can we just go with `stack`? Or `cabal-install`?
- It would be nice to have a way to make `ghc` find the `Paths_warp` module without relying on the processor architecture, the operating system and the cabal version. I imagine if any of those change, this'll break. Is there a way to do that?
