### PR TITLE
warp: add withApplication and openFreePort

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -90,6 +90,8 @@ module Network.Wai.Handler.Warp (
   , pauseTimeout
   , FileInfo(..)
   , getFileInfo
+  , withApplication
+  , openFreePort
     -- * Version
   , warpVersion
   ) where
@@ -109,6 +111,7 @@ import Network.Wai.Handler.Warp.Run
 import Network.Wai.Handler.Warp.Settings
 import Network.Wai.Handler.Warp.Timeout
 import Network.Wai.Handler.Warp.Types hiding (getFileInfo)
+import Network.Wai.Handler.Warp.WithApplication
 
 -- | Port to listen on. Default value: 3000
 --

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -91,6 +91,7 @@ module Network.Wai.Handler.Warp (
   , FileInfo(..)
   , getFileInfo
   , withApplication
+  , testWithApplication
   , openFreePort
     -- * Version
   , warpVersion

--- a/warp/Network/Wai/Handler/Warp/WithApplication.hs
+++ b/warp/Network/Wai/Handler/Warp/WithApplication.hs
@@ -1,0 +1,87 @@
+
+module Network.Wai.Handler.Warp.WithApplication (
+  withApplication,
+  openFreePort,
+) where
+
+import           Control.Concurrent
+import           Control.Exception
+import           Network.Socket
+import           Network.Wai
+import           Network.Wai.Handler.Warp.Run
+import           Network.Wai.Handler.Warp.Settings
+import           Network.Wai.Handler.Warp.Types
+
+data App
+  = App {
+    appThread :: ThreadId,
+    appKilled :: Waiter (),
+    appExceptionMVar :: MVar (Maybe SomeException),
+    appPort :: Int
+  }
+
+-- | Runs the given 'Application' on a free port. Passes the port to the given
+-- operation and executes it, while the 'Application' is running. Shuts down the
+-- server before returning.
+--
+-- Handy for e.g. testing 'Application's over a real network port.
+withApplication :: IO Application -> (Port -> IO a) -> IO a
+withApplication mkApp action = do
+  app <- mkApp
+  bracket (acquire app) free (\ runningApp -> action (appPort runningApp))
+  where
+    acquire :: Application -> IO App
+    acquire app = do
+      start <- mkWaiter
+      killed <- mkWaiter
+      exceptionMVar_ <- newMVar Nothing
+      thread <- forkIO $ do
+        (port, sock) <- openFreePort
+        let settings =
+              defaultSettings{
+                settingsBeforeMainLoop = notify start port
+              }
+        runSettingsSocket settings sock (handleApp exceptionMVar_ app)
+          `finally` notify killed ()
+      port <- waitFor start
+      return $ App thread killed exceptionMVar_ port
+
+    free :: App -> IO ()
+    free runningApp = do
+      killThread $ appThread runningApp
+      waitFor $ appKilled runningApp
+      exception <- readMVar (appExceptionMVar runningApp)
+      case exception of
+        Nothing -> return ()
+        Just e -> throwIO e
+
+handleApp :: MVar (Maybe SomeException) -> Application -> Application
+handleApp mvar app request respond = do
+  catch (app request respond) $ \ e -> do
+    modifyMVar_ mvar $ \ _ ->
+      return (Just e)
+    throwIO e
+
+data Waiter a
+  = Waiter {
+    notify :: a -> IO (),
+    waitFor :: IO a
+  }
+
+mkWaiter :: IO (Waiter a)
+mkWaiter = do
+  mvar <- newEmptyMVar
+  return $ Waiter {
+    notify = putMVar mvar,
+    waitFor = readMVar mvar
+  }
+
+-- | Opens a socket on a free port and returns both port and socket.
+openFreePort :: IO (Port, Socket)
+openFreePort = do
+  s <- socket AF_INET Stream defaultProtocol
+  localhost <- inet_addr "127.0.0.1"
+  bind s (SockAddrInet aNY_PORT localhost)
+  listen s 1
+  port <- socketPort s
+  return (fromIntegral port, s)

--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module WithApplicationSpec where
+
+import           Control.Exception
+import           Network.HTTP.Types
+import           Network.Wai
+import           System.IO
+import           System.IO.Silently
+import           System.Process
+import           Test.Hspec
+
+import           Network.Wai.Handler.Warp.WithApplication
+
+spec :: Spec
+spec = do
+  describe "withApplication" $ do
+    it "runs a wai Application while executing the given action" $ do
+      let mkApp = return $ \ _request respond -> respond $ responseLBS ok200 [] "foo"
+      withApplication mkApp $ \ port -> do
+        output <- readProcess "curl" ["-s", "localhost:" ++ show port] ""
+        output `shouldBe` "foo"
+
+    it "propagates exceptions from the server to the executing thread" $
+      hSilence [stderr] $ do
+        let mkApp = return $ \ _request _respond -> throwIO $ ErrorCall "foo"
+        (withApplication mkApp $ \ port -> do
+            readProcess "curl" ["-s", "localhost:" ++ show port] "")
+          `shouldThrow` (errorCall "foo")

--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -2,8 +2,10 @@
 
 module WithApplicationSpec where
 
+import           Control.Concurrent
 import           Control.Exception
 import           Network.HTTP.Types
+import           Network.Socket
 import           Network.Wai
 import           System.IO
 import           System.IO.Silently
@@ -35,3 +37,9 @@ spec = do
         (testWithApplication mkApp $ \ port -> do
             readProcess "curl" ["-s", "localhost:" ++ show port] "")
           `shouldThrow` (errorCall "foo")
+
+  describe "withFreePort" $ do
+    it "closes the socket before exiting" $ do
+      MkSocket _ _ _ _ statusMVar <- withFreePort $ \ (_, sock) -> do
+        return sock
+      readMVar statusMVar `shouldReturn` Closed

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -34,6 +34,7 @@ Flag warp-debug
 Library
   Build-Depends:     base                      >= 3        && < 5
                    , array
+                   , async
                    , auto-update               >= 0.1.3    && < 0.2
                    , blaze-builder             >= 0.4
                    , bytestring                >= 0.9.1.4

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -93,6 +93,7 @@ Library
                      Network.Wai.Handler.Warp.Timeout
                      Network.Wai.Handler.Warp.Types
                      Network.Wai.Handler.Warp.Windows
+                     Network.Wai.Handler.Warp.WithApplication
                      Paths_warp
   Ghc-Options:       -Wall
 
@@ -129,6 +130,7 @@ Test-Suite spec
                      ResponseSpec
                      RunSpec
                      SendFileSpec
+                     WithApplicationSpec
                      HTTP
     Hs-Source-Dirs:  test, .
     Type:            exitcode-stdio-1.0
@@ -157,6 +159,7 @@ Test-Suite spec
                    , time
                    , text
                    , streaming-commons         >= 0.1.10
+                   , silently
                    , async
                    , vault
                    , stm                       >= 2.3


### PR DESCRIPTION
@snoyberg: You mentioned that this could be implemented using `async`. I used it in one place now, but I don't see how anything else could be replaced by operations from `async`. But I'm also not too familiar with that package.