### PR TITLE
Case insensitive multipart request header lookup

### DIFF
--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -45,6 +45,7 @@ import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (allocate, release, register, InternalState, runInternalState)
 import Data.IORef
 import Network.HTTP.Types (hContentType)
+import Data.CaseInsensitive (mk)
 
 breakDiscard :: Word8 -> S.ByteString -> (S.ByteString, S.ByteString)
 breakDiscard w s =
@@ -300,11 +301,11 @@ parsePieces sink bound rbody add =
                     (wasFound, ()) <- sinkTillBound bound iter seed src
                     when wasFound (loop src)
       where
-        contDisp = S8.pack "Content-Disposition"
-        contType = S8.pack "Content-Type"
+        contDisp = mk $ S8.pack "Content-Disposition"
+        contType = mk $ S8.pack "Content-Type"
         parsePair s =
             let (x, y) = breakDiscard 58 s -- colon
-             in (x, S.dropWhile (== 32) y) -- space
+             in (mk $ x, S.dropWhile (== 32) y) -- space
 
 data Bound = FoundBound S.ByteString S.ByteString
            | NoBound


### PR DESCRIPTION
Treat `Content-Type` and `Content-Disposition` header names as case
insensitive when parsing the parts of multipart requests. These names
were previously treated as case sensitive which causes parsing problems
when attempting to parse requests that may use all lower case header
names.

I hit this problem yesterday when trying to process a multipart request
composed with a library that sends all the part header field names as 
lower case. Most libraries use the expected camel case for the header names, but 
RFC 2616 and RFC 7230 both say the header field names are case insensitive so 
I made this small change to address it.