### PR TITLE
wai-app-static: use cryptonite instead of cryptohash

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -16,8 +16,7 @@ import qualified Data.Text as T
 import Data.Ord
 import qualified Data.ByteString as S
 import Crypto.Hash (hash, MD5, Digest)
-import Data.Byteable (toBytes)
-import qualified Data.ByteString.Base64 as B64
+import Data.ByteArray.Encoding
 import WaiAppStatic.Storage.Filesystem (defaultFileServerSettings)
 import System.FilePath (isPathSeparator)
 
@@ -95,4 +94,4 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
-runHash = B64.encode . toBytes . (hash :: S.ByteString -> Digest MD5)
+runHash = convertToBase Base64 . (hash :: S.ByteString -> Digest MD5)

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -23,10 +23,9 @@ import WaiAppStatic.Listing
 import Network.Mime
 import System.PosixCompat.Files (fileSize, getFileStatus, modificationTime, isRegularFile)
 import Data.Maybe (catMaybes)
-import qualified Crypto.Hash.Conduit (hashFile)
-import Data.Byteable (toBytes)
-import Crypto.Hash (MD5, Digest)
-import qualified Data.ByteString.Base64 as B64
+import Data.ByteArray.Encoding
+import Crypto.Hash (hashlazy, MD5, Digest)
+import qualified Data.ByteString.Lazy as BL (readFile)
 import qualified Data.Text as T
 
 -- | Construct a new path from a root and some @Pieces@.
@@ -120,8 +119,8 @@ webAppLookup hashFunc prefix pieces =
 -- exists.
 hashFile :: FilePath -> IO ByteString
 hashFile fp = do
-    h <- Crypto.Hash.Conduit.hashFile fp
-    return $ B64.encode $ toBytes (h :: Digest MD5)
+    f <- BL.readFile fp
+    return $ convertToBase Base64 (hashlazy f :: Digest MD5)
 
 hashFileIfExists :: ETagLookup
 hashFileIfExists fp = do

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -38,9 +38,8 @@ library
                    , file-embed                >= 0.0.3.1
                    , text                      >= 0.7
                    , blaze-builder             >= 0.2.1.4
-                   , base64-bytestring         >= 0.1
-                   , byteable
-                   , cryptohash                >= 0.11
+                   , cryptonite                >= 0.10
+                   , memory                >= 0.10
                    , http-date
                    , blaze-html                >= 0.5
                    , blaze-markup              >= 0.5.1
@@ -52,8 +51,6 @@ library
                    , wai-extra                 >= 3.0      && < 3.1
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.3
-                   -- Used exclusively for hashFile function
-                   , cryptohash-conduit
 
     exposed-modules: Network.Wai.Application.Static
                      WaiAppStatic.Storage.Filesystem

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -38,8 +38,8 @@ library
                    , file-embed                >= 0.0.3.1
                    , text                      >= 0.7
                    , blaze-builder             >= 0.2.1.4
-                   , cryptonite                >= 0.10
-                   , memory                >= 0.10
+                   , cryptonite                >= 0.6
+                   , memory                    >= 0.7
                    , http-date
                    , blaze-html                >= 0.5
                    , blaze-markup              >= 0.5.1


### PR DESCRIPTION
`cryptohash` is deprecated in favor of `cryptonite`. Not marked as such on Hackage yet, only [on GitHub](https://github.com/vincenthz/hs-cryptohash). But `tls` uses `cryptonite` already, so these two packages already clash (they export the exact same API).

Also, `memory` instead of `base64-bytestring` for Base64 encoding (`memory` is a dependency of `cryptonite`).

Yes, `conduit` is also dropped, because `cryptohash-conduit` wasn't updated in a long time, and wasn't ported to `cryptonite`. I think it's perfectly fine to use lazy I/O here, for the sake of fewer dependencies.