### PR TITLE
Add nix dependencies to stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,3 +13,8 @@ packages:
 - ./auto-update
 extra-deps:
 - http2-1.5.0
+nix:
+  enable: false
+  packages:
+  - fcgi
+  - zlib


### PR DESCRIPTION
This enables building on NixOS with `stack --nix`!