### PR TITLE
add requestSizeCheck

### DIFF
--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 -- | Some helpers for interrogating a WAI 'Request'.
 
 module Network.Wai.Request

--- a/wai-extra/test/Network/Wai/RequestSpec.hs
+++ b/wai-extra/test/Network/Wai/RequestSpec.hs
@@ -8,52 +8,82 @@ import Test.Hspec
 
 import Data.ByteString (ByteString)
 import Network.HTTP.Types (HeaderName)
-import Network.Wai (Request(..), defaultRequest)
+import Network.Wai (Request(..), defaultRequest, RequestBodyLength(..))
 
 import Network.Wai.Request
+import Control.Exception (try)
+import Control.Monad (forever)
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec = describe "appearsSecure" $ do
-    let insecureRequest = defaultRequest
-            { isSecure = False
-            , requestHeaders =
-                [ ("HTTPS", "off")
-                , ("HTTP_X_FORWARDED_SSL", "off")
-                , ("HTTP_X_FORWARDED_SCHEME", "http")
-                , ("HTTP_X_FORWARDED_PROTO", "http,xyz")
-                ]
-            }
+spec = do
+    describe "requestSizeCheck" $ do
+        it "too large content length should throw RequestSizeException" $ do
+            let limit = 1024
+                largeRequest = defaultRequest
+                    { isSecure = False
+                    , requestBodyLength = KnownLength (limit + 1)
+                    , requestBody = return "repeat this chunk"
+                    }
+            checkedRequest <- requestSizeCheck limit largeRequest
+            body <- try (requestBody checkedRequest)
+            case body of
+                Left (RequestSizeException l) -> l `shouldBe` limit
+                Right _   -> expectationFailure "request size check failed"
 
-    it "returns False for an insecure request" $
-        insecureRequest `shouldSatisfy` not . appearsSecure
+        it "too many chunks should throw RequestSizeException" $ do
+            let limit = 1024
+                largeRequest = defaultRequest
+                    { isSecure = False
+                    , requestBodyLength = ChunkedBody
+                    , requestBody = return "repeat this chunk"
+                    }
+            checkedRequest <- requestSizeCheck limit largeRequest
+            body <- try (forever $ requestBody checkedRequest)
+            case body of
+                Left (RequestSizeException l) -> l `shouldBe` limit
+                Right _   -> expectationFailure "request size check failed"
 
-    it "checks if the Request is actually secure" $ do
-        let req = insecureRequest { isSecure = True }
+    describe "appearsSecure" $ do
+        let insecureRequest = defaultRequest
+                { isSecure = False
+                , requestHeaders =
+                    [ ("HTTPS", "off")
+                    , ("HTTP_X_FORWARDED_SSL", "off")
+                    , ("HTTP_X_FORWARDED_SCHEME", "http")
+                    , ("HTTP_X_FORWARDED_PROTO", "http,xyz")
+                    ]
+                }
 
-        req `shouldSatisfy` appearsSecure
+        it "returns False for an insecure request" $
+            insecureRequest `shouldSatisfy` not . appearsSecure
 
-    it "checks for HTTP: on" $ do
-        let req = addHeader "HTTPS" "on" insecureRequest
+        it "checks if the Request is actually secure" $ do
+            let req = insecureRequest { isSecure = True }
 
-        req `shouldSatisfy` appearsSecure
+            req `shouldSatisfy` appearsSecure
 
-    it "checks for HTTP_X_FORWARDED_SSL: on" $ do
-        let req = addHeader "HTTP_X_FORWARDED_SSL" "on" insecureRequest
+        it "checks for HTTP: on" $ do
+            let req = addHeader "HTTPS" "on" insecureRequest
 
-        req `shouldSatisfy` appearsSecure
+            req `shouldSatisfy` appearsSecure
 
-    it "checks for HTTP_X_FORWARDED_SCHEME: https" $ do
-        let req = addHeader "HTTP_X_FORWARDED_SCHEME" "https" insecureRequest
+        it "checks for HTTP_X_FORWARDED_SSL: on" $ do
+            let req = addHeader "HTTP_X_FORWARDED_SSL" "on" insecureRequest
 
-        req `shouldSatisfy` appearsSecure
+            req `shouldSatisfy` appearsSecure
 
-    it "checks for HTTP_X_FORWARDED_PROTO: https,..." $ do
-        let req = addHeader "HTTP_X_FORWARDED_PROTO" "https,xyz" insecureRequest
+        it "checks for HTTP_X_FORWARDED_SCHEME: https" $ do
+            let req = addHeader "HTTP_X_FORWARDED_SCHEME" "https" insecureRequest
 
-        req `shouldSatisfy` appearsSecure
+            req `shouldSatisfy` appearsSecure
+
+        it "checks for HTTP_X_FORWARDED_PROTO: https,..." $ do
+            let req = addHeader "HTTP_X_FORWARDED_PROTO" "https,xyz" insecureRequest
+
+            req `shouldSatisfy` appearsSecure
 
 addHeader :: HeaderName -> ByteString -> Request -> Request
 addHeader name value req = req

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -151,6 +151,7 @@ Library
                      Network.Wai.EventSource
                      Network.Wai.EventSource.EventStream
   other-modules:     Network.Wai.Middleware.RequestLogger.Internal
+  default-language:          Haskell2010
   ghc-options:       -Wall
 
 test-suite spec


### PR DESCRIPTION
This code are modified from Spock web framework when i'm trying to figure out a way to fix a server crash issue, then i realize it's a very common need to guard against large request body, would you review this patch and make a release please? Thank you!