### PR TITLE
fix doctests when 'network-data' and 'iproute' are installed

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 module Network.Wai.Handler.Warp.Run where
@@ -19,7 +20,7 @@ import Control.Monad (when, unless, void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import Data.Char (chr)
-import Data.IP (toHostAddress, toHostAddress6)
+import "iproute" Data.IP (toHostAddress, toHostAddress6)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Streaming.Network (bindPortTCP)
 import Network (sClose, Socket)


### PR DESCRIPTION
Before the patch tests failed for me as:

  Network/Wai/Handler/Warp/Run.hs:22:8:
    Ambiguous module name ‘Data.IP’:
      it was found in multiple packages:
      network-data-0.5.3@netwo_G5ThtIF3NpS8U3d3JAsmlG iproute-1.7.0@iprou_5PoZLY0zggKF8zyZ5Xj1ys

Patch explicitly lists all the packages for ghci/doctest run.

When added dependencies found missing 'template-haskell' depend.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>