### PR TITLE
Add {test,}withApplicationSettings

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -91,7 +91,9 @@ module Network.Wai.Handler.Warp (
   , FileInfo(..)
   , getFileInfo
   , withApplication
+  , withApplicationSettings
   , testWithApplication
+  , testWithApplicationSettings
   , openFreePort
     -- * Version
   , warpVersion


### PR DESCRIPTION
`withApplication` was using `defaultSettings` implicitly, this patch implements `withApplicationSettings` and `testWithApplicationSettings` functions that run `Application`'s with given `Settings`.

Without this patch, I was unable to increase Warp's timeout on `testWithApplication`.