### PR TITLE
don't launch if server fails; kill server on exit #537

### DIFF
--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -34,9 +34,9 @@ import Data.Streaming.Blaze (newBlazeRecv, defaultStrategy)
 import qualified Data.Streaming.Zlib as Z
 
 ping :: IORef Bool -> Middleware
-ping  var app req sendResponse
+ping  active app req sendResponse
     | pathInfo req == ["_ping"] = do
-        liftIO $ writeIORef var True
+        liftIO $ writeIORef active True
         sendResponse $ responseLBS status200 [] ""
     | otherwise = app req $ \res -> do
         let isHtml hs =
@@ -210,10 +210,10 @@ runHostPortUrl host port url app = do
       (takeMVar ready >> launch port url >> loop active)
 
 loop :: IORef Bool -> IO ()
-loop x = do
+loop active = do
     let seconds = 120
     threadDelay $ 1000000 * seconds
-    b <- readIORef x
+    b <- readIORef active
     if b
-        then writeIORef x False >> loop x
+        then writeIORef active False >> loop active
         else return ()

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -21,6 +21,7 @@ Library
                    , bytestring              >= 0.9.1.4
                    , blaze-builder           >= 0.2.1.4 && < 0.5
                    , streaming-commons
+                   , async
 
     if os(windows)
         c-sources: windows.c


### PR DESCRIPTION
Make the server thread and launch/monitor thread more aware of each
other's failures, using async. Now if the server fails to start we won't
launch a browser. Also when the main thread terminates (eg from ctrl-c
in GHCI), we make sure the server thread does too. There is now a 0.1s
delay before launching the browser, which also helps ensure the server
is ready to serve.