### PR TITLE
clean up stream resources when websockets completes

### DIFF
--- a/wai-websockets/Network/Wai/Handler/WebSockets.hs
+++ b/wai-websockets/Network/Wai/Handler/WebSockets.hs
@@ -7,7 +7,7 @@ module Network.Wai.Handler.WebSockets
     , runWebSockets
     ) where
 
-import              Control.Exception               (finally)
+import              Control.Exception               (bracket)
 import              Data.ByteString                 (ByteString)
 import qualified    Data.ByteString.Char8           as BC
 import qualified    Data.ByteString.Lazy            as BL
@@ -95,20 +95,20 @@ runWebSockets :: WS.ConnectionOptions
               -> IO ByteString
               -> (ByteString -> IO ())
               -> IO a
-runWebSockets opts req app src sink = do
-    stream <- WS.makeStream
-        (do
-            bs <- src
-            return $ if BC.null bs then Nothing else Just bs)
-        (\mbBl -> case mbBl of
-            Nothing -> return ()
-            Just bl -> mapM_ sink (BL.toChunks bl))
+runWebSockets opts req app src sink = bracket mkStream WS.close (app . pc)
+  where
+    mkStream =
+        WS.makeStream
+            (do
+                bs <- src
+                return $ if BC.null bs then Nothing else Just bs)
+            (\mbBl -> case mbBl of
+                Nothing -> return ()
+                Just bl -> mapM_ sink (BL.toChunks bl))
 
-    let pc = WS.PendingConnection
-                { WS.pendingOptions     = opts
-                , WS.pendingRequest     = req
-                , WS.pendingOnAccept    = \_ -> return ()
-                , WS.pendingStream      = stream
-                }
-
-    app pc `finally` WS.close stream
+    pc stream = WS.PendingConnection
+        { WS.pendingOptions     = opts
+        , WS.pendingRequest     = req
+        , WS.pendingOnAccept    = \_ -> return ()
+        , WS.pendingStream      = stream
+        }

--- a/wai-websockets/Network/Wai/Handler/WebSockets.hs
+++ b/wai-websockets/Network/Wai/Handler/WebSockets.hs
@@ -7,6 +7,7 @@ module Network.Wai.Handler.WebSockets
     , runWebSockets
     ) where
 
+import              Control.Exception               (finally)
 import              Data.ByteString                 (ByteString)
 import qualified    Data.ByteString.Char8           as BC
 import qualified    Data.ByteString.Lazy            as BL
@@ -110,4 +111,4 @@ runWebSockets opts req app src sink = do
                 , WS.pendingStream      = stream
                 }
 
-    app pc
+    app pc `finally` WS.close stream


### PR DESCRIPTION
The stream should be cleaned up when the websocket is finished with it. One of the production applications at my company receives websockets as a server and also is a websocket client. We found that this server, in it's capacity as a client, was sending unmasked ping frames to another server, which is a violation of the websocket protocol ([rfc 6455](https://tools.ietf.org/html/rfc6455) 6.1.5). We found that these pings were coming from [yesod hosting websockets in its capacity as a server](https://github.com/yesodweb/yesod/blob/master/yesod-websockets/Yesod/WebSockets.hs#L89). Digging down, we found that when the operating system reused file descriptors, sometimes `forkPingThread` would not notice that the connection it was pinging on was closed (and wouldn't be killed) and continue pinging on new client connections (and violating the rfc because these pings would be unmasked) causing them to be closed for these violations. These pings would continue to go through because the [Socket object](https://github.com/haskell/network/blob/916f83e72e71ba4941403f795946731ca7143ead/Network/Socket/Types.hsc#L81) is not cleaned up. Because it holds a file descriptor to write to, and in our case this would be a valid descriptor for a new connection. 

Clearly the fact that closed connections can reuse file descriptors is bad, and should be addressed in the lower level GHC networking library, but also the stream should be cleaned up here to prevent possible security implications of data being sent over the wrong file descriptors. 

We were able to reliably reproduce this issue on our own system, then we reimplemented the [runWebSockets](https://github.com/yesodweb/wai/blob/master/wai-websockets/Network/Wai/Handler/WebSockets.hs#L91) function to finally `WS.closeStream stream` and then could not reproduce this issue at all. Though I'm not sure how to make a minimal reproducible case that I can share here. Hopefully we can at least agree on the principle of cleaning up the `Stream` when the websocket has completed. 

I think this is an important issue with possible security implications, so let me know if I, or my colleagues, can improve or clarify anything. 