### PR TITLE
Make warp benchmarks build with modern criterion

### DIFF
--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -32,15 +32,15 @@ main = do
     defaultMain [
         bgroup "requestLine1" [
              bench "parseRequestLine3" $ whnf parseRequestLine3 requestLine1
-           , bench "parseRequestLine2" $ parseRequestLine2 requestLine1
-           , bench "parseRequestLine1" $ parseRequestLine1 requestLine1
-           , bench "parseRequestLine0" $ parseRequestLine0 requestLine1
+           , bench "parseRequestLine2" $ whnfIO $ parseRequestLine2 requestLine1
+           , bench "parseRequestLine1" $ whnfIO $ parseRequestLine1 requestLine1
+           , bench "parseRequestLine0" $ whnfIO $ parseRequestLine0 requestLine1
            ]
       , bgroup "requestLine2" [
              bench "parseRequestLine3" $ whnf parseRequestLine3 requestLine2
-           , bench "parseRequestLine2" $ parseRequestLine2 requestLine2
-           , bench "parseRequestLine1" $ parseRequestLine1 requestLine2
-           , bench "parseRequestLine0" $ parseRequestLine0 requestLine2
+           , bench "parseRequestLine2" $ whnfIO $ parseRequestLine2 requestLine2
+           , bench "parseRequestLine1" $ whnfIO $ parseRequestLine1 requestLine2
+           , bench "parseRequestLine0" $ whnfIO $ parseRequestLine0 requestLine2
            ]
       ]
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -185,11 +185,22 @@ Benchmark parser
     Main-Is:        Parser.hs
     HS-Source-Dirs: bench .
     Build-Depends:  base
+                  , auto-update
                   , bytestring
-                  , criterion
+                  , containers
+                  , criterion >= 1
+                  , hashable
+                  , http-date
                   , http-types
                   , network
                   , network
+                  , unix-compat
+
+  if (os(linux) || os(freebsd) || os(darwin)) && flag(allow-sendfilefd)
+    Cpp-Options:   -DSENDFILEFD
+    Build-Depends: unix
+  if os(windows)
+      Cpp-Options:   -DWINDOWS
 
 Source-Repository head
   Type:     git


### PR DESCRIPTION
I had to make some changes to get the `warp` benchmarks to build:

* I had to list some missing dependencies in the `benchmark` stanza
* I had to update the code a little for `criterion >= 1`

See also https://github.com/iu-parfunc/sc-haskell/issues/7