### PR TITLE
accept(2) error handling

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -247,6 +247,8 @@ getOnException :: Settings -> Maybe Request -> SomeException -> IO ()
 getOnException = settingsOnException
 
 -- | Get the graceful shutdown timeout
+--
+-- Since 3.2.8
 getGracefulShutdownTimeout :: Settings -> Maybe Int
 getGracefulShutdownTimeout = settingsGracefulShutdownTimeout
 
@@ -356,6 +358,8 @@ setLogger lgr y = y { settingsLogger = lgr }
 -- | Set the graceful shutdown timeout. A timeout of `Nothing' will
 -- wait indefinitely, and a number, if provided, will be treated as seconds
 -- to wait for requests to finish, before shutting down the server entirely.
+--
+-- Since 3.2.8
 setGracefulShutdownTimeout :: Maybe Int
                            -> Settings -> Settings
 setGracefulShutdownTimeout time y = y { settingsGracefulShutdownTimeout = time }

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -70,12 +70,14 @@ module Network.Wai.Handler.Warp (
   , setSlowlorisSize
   , setHTTP2Disabled
   , setLogger
+  , setGracefulShutdownTimeout
     -- ** Getters
   , getPort
   , getHost
   , getOnOpen
   , getOnClose
   , getOnException
+  , getGracefulShutdownTimeout
     -- ** Exception handler
   , defaultOnException
   , defaultShouldDisplayException
@@ -244,6 +246,10 @@ getOnClose = settingsOnClose
 getOnException :: Settings -> Maybe Request -> SomeException -> IO ()
 getOnException = settingsOnException
 
+-- | Get the graceful shutdown timeout
+getGracefulShutdownTimeout :: Settings -> Maybe Int
+getGracefulShutdownTimeout = settingsGracefulShutdownTimeout
+
 -- | A code to install shutdown handler.
 --
 -- For instance, this code should set up a UNIX signal
@@ -346,6 +352,13 @@ setHTTP2Disabled y = y { settingsHTTP2Enabled = False }
 setLogger :: (Request -> H.Status -> Maybe Integer -> IO ())
           -> Settings -> Settings
 setLogger lgr y = y { settingsLogger = lgr }
+
+-- | Set the graceful shutdown timeout. A timeout of `Nothing' will
+-- wait indefinitely, and a number, if provided, will be treated as seconds
+-- to wait for requests to finish, before shutting down the server entirely.
+setGracefulShutdownTimeout :: Maybe Int
+                           -> Settings -> Settings
+setGracefulShutdownTimeout time y = y { settingsGracefulShutdownTimeout = time }
 
 -- | Explicitly pause the slowloris timeout.
 --

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -101,6 +101,9 @@ data Settings = Settings
       -- ^ A log function. Default: no action.
       --
       -- Since 3.X.X.
+    , settingsGracefulShutdownTimeout :: Maybe Int
+      -- ^ An optional timeout to limit the time (in seconds) waiting for
+      -- a graceful shutdown of the web server.
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -135,6 +138,7 @@ defaultSettings = Settings
     , settingsSlowlorisSize = 2048
     , settingsHTTP2Enabled = True
     , settingsLogger = \_ _ _ -> return ()
+    , settingsGracefulShutdownTimeout = Nothing
     }
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -104,6 +104,8 @@ data Settings = Settings
     , settingsGracefulShutdownTimeout :: Maybe Int
       -- ^ An optional timeout to limit the time (in seconds) waiting for
       -- a graceful shutdown of the web server.
+      --
+      -- Since 3.2.8
     }
 
 -- | Specify usage of the PROXY protocol.


### PR DESCRIPTION
This PR contains three commits which deal with an issue we've been having with our production Warp services. Currently, Warp treats all exceptions that can be raised by `accept` as unrecoverable (other than its special handling of `ResourceExhausted`, which I've removed for reasons described in 3011cade3b7a6eb9dab124b1f6f6c4fc15efa121). However, some errors from the `accept` syscall _are_ recoverable, and do not imply the entire listening socket is closed or in a bad state. Specifically, accept(2) and accept4(2) will return ECONNABORTED if a connection request is aborted between entering the socket's listen queue, and actually being accepted. In this case, a subsequent call to `accept` will simply return the next socket on the queue.

Since this was treated as a fatal error before, when this would happen to us in production, the webserver would begin its graceful shutdown routine, but since we use long-lived connections, graceful shutdown would wait indefinitely for HTTP requests that will never finish (we leave an HTTP connection open and stream data). This manifested itself as the entire application hanging indefinitely. In aebd8d4081297a31726bcfeb947d525bfd816437, I've added an option to the Warp `Settings` for an optional graceful shutdown timeout, so that if there is a fatal error raised by `accept`, the webserver won't simply hang forever, waiting to shut down.

I've kept this in three commits, so that it's easier to review, and if you only want some of this functionality, it can be cherry-picked.