### PR TITLE
warp: add example of normal exception handling to Warp.hs haddocks

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -138,8 +138,17 @@ setOnException :: (Maybe Request -> SomeException -> IO ()) -> Settings -> Setti
 setOnException x y = y { settingsOnException = x }
 
 -- | A function to create a `Response` when an exception occurs.
---
 -- Default: 'defaultOnExceptionResponse'
+--
+-- Note that an application can handle its own exceptions without interfering with Warp:
+--
+-- > myApp :: Application
+-- > myApp request respond = innerApp `catch` onError
+-- >   where
+-- >     onError = respond . response500 request
+-- >
+-- > response500 :: Request -> SomeException -> Response
+-- > response500 req someEx = responseLBS status500 -- ...
 --
 -- Since 2.1.0
 setOnExceptionResponse :: (SomeException -> Response) -> Settings -> Settings


### PR DESCRIPTION
As clarified in #555, it's safe to catch `SomeException` in an `Application` and respond with a 500 status. (Thanks @kazu-yamamoto @snoyberg) This is a rare exception to rule that catching `SomeException` is a [bad thing to do](https://www.schoolofhaskell.com/user/snoyberg/general-haskell/exceptions/catching-all-exceptions).

Here I've added some example code to `Warp.hs`. Is this the right place for it?