### PR TITLE
warp-tls: Handle recv failure on mkConn

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -309,12 +309,13 @@ getter tlsset@TLSSettings{..} sock params = do
     return (mkConn tlsset s params, sa)
 
 mkConn :: TLS.TLSParams params => TLSSettings -> Socket -> params -> IO (Connection, Transport)
-mkConn tlsset s params = do
-    firstBS <- safeRecv s 4096
-    (if not (S.null firstBS) && S.head firstBS == 0x16 then
-        httpOverTls tlsset s firstBS params
-      else
-        plainHTTP tlsset s firstBS) `onException` sClose s
+mkConn tlsset s params = 
+    ( do firstBS <- safeRecv s 4096
+         if not (S.null firstBS) && S.head firstBS == 0x16 then
+             httpOverTls tlsset s firstBS params
+          else
+              plainHTTP tlsset s firstBS
+    ) `onException` sClose s
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
That `safeRecv` is no different than a `recv` except on Windows.

Without this patch, a simple connect scan (nmap -sT <ip> -p <port>)
leaks an open socket, because the first recv fails with `recv:
connection vanished`.

You can easily reproduce the bug with sending that `nmap` command
to any warp-tls application.