### PR TITLE
Add various limits like filesize

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.16.0
+
+* Add a new function "parseRequestBodyEx" that allows various size limits to be set.
+
 ## 3.0.15.2
 
 * Doc improvements

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -51,8 +51,6 @@ import Data.IORef
 import Network.HTTP.Types (hContentType)
 import Data.CaseInsensitive (mk)
 
-import Debug.Trace
-
 breakDiscard :: Word8 -> S.ByteString -> (S.ByteString, S.ByteString)
 breakDiscard w s =
     let (x, y) = S.break (== w) s

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -586,7 +586,7 @@ wrapTillBound bound src max' = do
             WTBDone _ -> return S.empty
             WTBWorking front -> do
                 bs <- readSource src
-                cur <- atomicModifyIORef sref $ \ cur ->
+                cur <- atomicModifyIORef' sref $ \ cur ->
                     let new = cur + fromIntegral (S.length bs) in (new, new)
                 case max' of
                     Just max'' | cur > max'' -> error "Maximum size exceeded"

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -45,6 +45,7 @@ import System.Directory (removeFile, getTemporaryDirectory)
 import System.IO (hClose, openBinaryTempFile)
 import Network.Wai
 import qualified Network.HTTP.Types as H
+import Control.Applicative ((<$>))
 import Control.Monad (when, unless)
 import Control.Monad.Trans.Resource (allocate, release, register, InternalState, runInternalState)
 import Data.IORef

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -219,8 +219,9 @@ clearMaxHeaderLineLength p = p { prboMaxHeaderLineLength=Nothing }
 -- maximum files: 10; filesize unlimited; maximum
 -- size for parameters: 64kbytes; maximum number of header
 -- lines: 32 bytes (applies only to headers of a mime/multipart message);
--- maximum header line length: 8190 bytes (applies only to headers of
--- a mime/multipart message)
+-- maximum header line length: Apache's default for that is 8190 bytes
+-- (http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestline)
+-- so we're using that here as well.
 defaultParseRequestBodyOptions :: ParseRequestBodyOptions
 defaultParseRequestBodyOptions = ParseRequestBodyOptions
     { prboKeyLength=Just 32
@@ -380,9 +381,6 @@ conduitRequestBodyEx o backend (Multipart bound) rbody add =
 
 
 -- | Take one header or subheader line.
--- It makes sense to limit the maximum line length.
--- Apache's default is 8190 (http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestline)
--- so we're using that here as well.
 takeLine :: Maybe Int -> Source -> IO (Maybe S.ByteString)
 takeLine maxlen src =
     go ""

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -11,6 +11,7 @@ module Network.Wai.Parse
     , RequestBodyType (..)
     , getRequestBodyType
     , sinkRequestBody
+    , sinkRequestBodyEx
     , BackEnd
     , lbsBackEnd
     , tempFileBackEnd
@@ -19,8 +20,23 @@ module Network.Wai.Parse
     , File
     , FileInfo (..)
     , parseContentType
-    , ParseRequestBodyOptions (..)
+    , ParseRequestBodyOptions
+    , defaultParseRequestBodyOptions
     , parseRequestBodyEx
+    , setMaxRequestKeyLength
+    , clearMaxRequestKeyLength
+    , setMaxRequestNumFiles
+    , clearMaxRequestNumFiles
+    , setMaxRequestFileSize
+    , clearMaxRequestFileSize
+    , setMaxRequestFilesSize
+    , clearMaxRequestFilesSize
+    , setMaxRequestParmsSize
+    , clearMaxRequestParmsSize
+    , setMaxHeaderLines
+    , clearMaxHeaderLines
+    , setMaxHeaderLineLength
+    , clearMaxHeaderLineLength
 #if TEST
     , Bound (..)
     , findBound
@@ -35,7 +51,6 @@ import qualified Data.ByteString.Search as Search
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Char8 as S8
-import Data.Default (Default, def)
 import Data.Word (Word8)
 import Data.Int (Int64)
 import Data.Maybe (catMaybes, fromMaybe)
@@ -51,6 +66,8 @@ import Control.Monad.Trans.Resource (allocate, release, register, InternalState,
 import Data.IORef
 import Network.HTTP.Types (hContentType)
 import Data.CaseInsensitive (mk)
+
+import Prelude hiding (lines)
 
 breakDiscard :: Word8 -> S.ByteString -> (S.ByteString, S.ByteString)
 breakDiscard w s =
@@ -127,26 +144,103 @@ tempFileBackEndOpts getTmpDir pattrn internalState _ _ popper = do
 -- the parseRequestBodyEx function.
 data ParseRequestBodyOptions = ParseRequestBodyOptions
     { -- | The maximum length of a filename
-      prboKeyLength             :: Int
+      prboKeyLength             :: Maybe Int
     , -- | The maximum number of files.
-      prboMaxNumFiles           :: Int
+      prboMaxNumFiles           :: Maybe Int
     , -- | The maximum filesize per file.
       prboMaxFileSize           :: Maybe Int64
     , -- | The maximum total filesize.
       prboMaxFilesSize          :: Maybe Int64
-    , -- | The maximum size of the sum of all parameters values
-      prboMaxParmsValueSize     :: Int
-    , -- | The maximum header lines per entry
-      prboMaxHeaderLines        :: Int }
+    , -- | The maximum size of the sum of all parameters
+      prboMaxParmsSize          :: Maybe Int
+    , -- | The maximum header lines per mime/multipart entry
+      prboMaxHeaderLines        :: Maybe Int
+    , -- | The maximum header line length per mime/multipart entry
+      prboMaxHeaderLineLength   :: Maybe Int }
 
-instance Default ParseRequestBodyOptions where
-    def = ParseRequestBodyOptions
-        { prboKeyLength=32
-        , prboMaxNumFiles=10
-        , prboMaxFileSize=Nothing
-        , prboMaxFilesSize=Nothing
-        , prboMaxParmsValueSize=65336
-        , prboMaxHeaderLines=32 }
+-- | Set the maximum length of a filename.
+setMaxRequestKeyLength :: Int -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxRequestKeyLength l p = p { prboKeyLength=Just l }
+
+-- | Do not limit the length of filenames.
+clearMaxRequestKeyLength :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxRequestKeyLength p = p { prboKeyLength=Nothing }
+
+-- | Set the maximum number of files per request.
+setMaxRequestNumFiles :: Int -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxRequestNumFiles l p = p { prboMaxNumFiles=Just l }
+
+-- | Do not limit the maximum number of files per request.
+clearMaxRequestNumFiles :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxRequestNumFiles p = p { prboMaxNumFiles=Nothing }
+
+-- | Set the maximum filesize per file.
+setMaxRequestFileSize :: Int64 -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxRequestFileSize l p = p { prboMaxFileSize=Just l }
+
+-- | Do not limit the maximum filesize per file.
+clearMaxRequestFileSize :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxRequestFileSize p = p { prboMaxFileSize=Nothing }
+
+-- | Set the maximum size of all files per request.
+setMaxRequestFilesSize :: Int64 -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxRequestFilesSize l p = p { prboMaxFilesSize=Just l }
+
+-- | Do not limit the maximum size of all files per request.
+clearMaxRequestFilesSize :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxRequestFilesSize p = p { prboMaxFilesSize=Nothing }
+
+-- | Set the maximum size of the sum of all parameters.
+setMaxRequestParmsSize :: Int -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxRequestParmsSize l p = p { prboMaxParmsSize=Just l }
+
+-- | Do not limit the maximum size of the sum of all parameters.
+clearMaxRequestParmsSize :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxRequestParmsSize p = p { prboMaxParmsSize=Nothing }
+
+-- | Set the maximum header lines per mime/multipart entry.
+setMaxHeaderLines :: Int -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxHeaderLines l p = p { prboMaxHeaderLines=Just l }
+
+-- | Do not limit the maximum header lines per mime/multipart entry.
+clearMaxHeaderLines:: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxHeaderLines p = p { prboMaxHeaderLines=Nothing }
+
+-- | Set the maximum header line length per mime/multipart entry.
+setMaxHeaderLineLength :: Int -> ParseRequestBodyOptions -> ParseRequestBodyOptions
+setMaxHeaderLineLength l p = p { prboMaxHeaderLineLength=Just l }
+
+-- | Do not limit the maximum header lines per mime/multipart entry.
+clearMaxHeaderLineLength :: ParseRequestBodyOptions -> ParseRequestBodyOptions
+clearMaxHeaderLineLength p = p { prboMaxHeaderLineLength=Nothing }
+
+-- | A reasonable default set of parsing options.
+-- Maximum key/filename length: 32 bytes;
+-- maximum files: 10; filesize unlimited; maximum
+-- size for parameters: 64kbytes; maximum number of header
+-- lines: 32 bytes (applies only to headers of a mime/multipart message);
+-- maximum header line length: 8190 bytes (applies only to headers of
+-- a mime/multipart message)
+defaultParseRequestBodyOptions :: ParseRequestBodyOptions
+defaultParseRequestBodyOptions = ParseRequestBodyOptions
+    { prboKeyLength=Just 32
+    , prboMaxNumFiles=Just 10
+    , prboMaxFileSize=Nothing
+    , prboMaxFilesSize=Nothing
+    , prboMaxParmsSize=Just 65336
+    , prboMaxHeaderLines=Just 32
+    , prboMaxHeaderLineLength=Just 8190 }
+
+-- | Do not impose any memory limits.
+noLimitParseRequestBodyOptions :: ParseRequestBodyOptions
+noLimitParseRequestBodyOptions = ParseRequestBodyOptions
+    { prboKeyLength=Nothing
+    , prboMaxNumFiles=Nothing
+    , prboMaxFileSize=Nothing
+    , prboMaxFilesSize=Nothing
+    , prboMaxParmsSize=Nothing
+    , prboMaxHeaderLines=Nothing
+    , prboMaxHeaderLineLength=Nothing }
 
 -- | Information on an uploaded file.
 data FileInfo c = FileInfo
@@ -221,10 +315,7 @@ parseContentType a = do
 parseRequestBody :: BackEnd y
                  -> Request
                  -> IO ([Param], [File y])
-parseRequestBody s r =
-    case getRequestBodyType r of
-        Nothing -> return ([], [])
-        Just rbt -> sinkRequestBody s rbt (requestBody r)
+parseRequestBody = parseRequestBodyEx noLimitParseRequestBodyOptions
 
 -- | Parse the body of an HTTP request, limit resource usage.
 -- The HTTP body can contain both parameters and files.
@@ -245,15 +336,7 @@ sinkRequestBody :: BackEnd y
                 -> RequestBodyType
                 -> IO S.ByteString
                 -> IO ([Param], [File y])
-sinkRequestBody s r body = do
-    ref <- newIORef (id, id)
-    let add x = atomicModifyIORef ref $ \(y, z) ->
-            case x of
-                Left y' -> ((y . (y':), z), ())
-                Right z' -> ((y, z . (z':)), ())
-    conduitRequestBody s r body add
-    (x, y) <- readIORef ref
-    return (x [], y [])
+sinkRequestBody = sinkRequestBodyEx noLimitParseRequestBodyOptions
 
 sinkRequestBodyEx :: ParseRequestBodyOptions
                   -> BackEnd y
@@ -267,26 +350,7 @@ sinkRequestBodyEx o s r body = do
                 Left y'  -> ((y':y, z), ())
                 Right z' -> ((y, z':z), ())
     conduitRequestBodyEx o s r body add
-    readIORef ref
-
-conduitRequestBody :: BackEnd y
-                   -> RequestBodyType
-                   -> IO S.ByteString
-                   -> (Either Param (File y) -> IO ())
-                   -> IO ()
-conduitRequestBody _ UrlEncoded rbody add = do
-    -- NOTE: in general, url-encoded data will be in a single chunk.
-    -- Therefore, I'm optimizing for the usual case by sticking with
-    -- strict byte strings here.
-    let loop front = do
-            bs <- rbody
-            if S.null bs
-                then return $ S.concat $ front []
-                else loop $ front . (bs:)
-    bs <- loop id
-    mapM_ (add . Left) $ H.parseSimpleQuery bs
-conduitRequestBody backend (Multipart bound) rbody add =
-    parsePieces backend (S8.pack "--" `S.append` bound) rbody add
+    (\(a, b) -> (reverse a, reverse b)) <$> readIORef ref
 
 conduitRequestBodyEx :: ParseRequestBodyOptions
                      -> BackEnd y
@@ -298,18 +362,18 @@ conduitRequestBodyEx o _ UrlEncoded rbody add = do
     -- NOTE: in general, url-encoded data will be in a single chunk.
     -- Therefore, I'm optimizing for the usual case by sticking with
     -- strict byte strings here.
-    size <- newIORef 0
-    let loop front = do
+    let loop size front = do
             bs <- rbody
             if S.null bs
                 then return $ S.concat $ front []
                 else do
-                    newsize <- atomicModifyIORef size $
-                        \cursize -> let newsize = cursize + S.length bs in (newsize, newsize)
-                    when (newsize > prboMaxParmsValueSize o) $
-                        error "Maximum size of parameters exceeded"
-                    loop $ front . (bs:)
-    bs <- loop id
+                    let newsize = size + S.length bs
+                    case prboMaxParmsSize o of
+                        Just maxSize -> when (newsize > maxSize) $
+                            error "Maximum size of parameters exceeded"
+                        Nothing -> return ()
+                    loop newsize $ front . (bs:)
+    bs <- loop 0 id
     mapM_ (add . Left) $ H.parseSimpleQuery bs
 conduitRequestBodyEx o backend (Multipart bound) rbody add =
     parsePiecesEx o backend (S8.pack "--" `S.append` bound) rbody add
@@ -319,13 +383,16 @@ conduitRequestBodyEx o backend (Multipart bound) rbody add =
 -- It makes sense to limit the maximum line length.
 -- Apache's default is 8190 (http://httpd.apache.org/docs/2.2/mod/core.html#limitrequestline)
 -- so we're using that here as well.
-takeLine :: Source -> IO (Maybe S.ByteString)
-takeLine src =
+takeLine :: Maybe Int -> Source -> IO (Maybe S.ByteString)
+takeLine maxlen src =
     go ""
   where
     go front = do
         bs <- readSource src
-        when (S.length front + S.length bs > 8190) $ error "Header line length exceeds allowed maximum."
+        case maxlen of
+            Just maxlen' -> when (S.length front + S.length bs > maxlen') $
+                error "Header line length exceeds allowed maximum."
+            Nothing -> return ()
         if S.null bs
             then close front
             else push front bs
@@ -339,30 +406,28 @@ takeLine src =
                     when (S.length y > 1) $ leftover src $ S.drop 1 y
                     return $ Just $ killCR $ front `S.append` x
 
-takeLines :: Source -> IO [S.ByteString]
-takeLines src = do
-    res <- takeLine src
+takeLines' :: Maybe Int -> Maybe Int -> Source -> IO [S.ByteString]
+takeLines' lineLength maxLines source =
+    reverse <$> takeLines'' [] lineLength maxLines source
+
+takeLines''
+    :: [S.ByteString]
+    -> Maybe Int
+    -> Maybe Int
+    -> Source
+    -> IO [S.ByteString]
+takeLines'' lines lineLength maxLines src = do
+    case maxLines of
+        Just maxLines' ->
+            when (length lines > maxLines') $
+                error "Too many lines in mime/multipart header"
+        Nothing -> return ()
+    res <- takeLine lineLength src
     case res of
-        Nothing -> return []
+        Nothing -> return lines
         Just l
-            | S.null l -> return []
-            | otherwise -> do
-                ls <- takeLines src
-                return $ l : ls
-
-takeLines' :: Int -> Source -> IO [S.ByteString]
-takeLines' a b = reverse <$> takeLines'' [] a b
-
-takeLines'' :: [S.ByteString] -> Int -> Source -> IO [S.ByteString]
-takeLines'' lines maxLines src
-    | length lines > maxLines = error "Too many lines in mime/multipart header"
-    | otherwise = do
-        res <- takeLine src
-        case res of
-            Nothing -> return lines
-            Just l
-                | S.null l -> return lines
-                | otherwise -> takeLines'' (l:lines) maxLines src
+            | S.null l -> return lines
+            | otherwise -> takeLines'' (l:lines) lineLength maxLines src
 
 data Source = Source (IO S.ByteString) (IORef S.ByteString)
 
@@ -381,53 +446,6 @@ readSource (Source f ref) = do
 leftover :: Source -> S.ByteString -> IO ()
 leftover (Source _ ref) bs = writeIORef ref bs
 
-parsePieces :: BackEnd y
-            -> S.ByteString
-            -> IO S.ByteString
-            -> (Either Param (File y) -> IO ())
-            -> IO ()
-parsePieces sink bound rbody add =
-    mkSource rbody >>= loop
-  where
-    loop src = do
-        _boundLine <- takeLine src
-        res' <- takeLines src
-        unless (null res') $ do
-            let ls' = map parsePair res'
-            let x = do
-                    cd <- lookup contDisp ls'
-                    let ct = lookup contType ls'
-                    let attrs = parseAttrs cd
-                    name <- lookup "name" attrs
-                    return (ct, name, lookup "filename" attrs)
-            case x of
-                Just (mct, name, Just filename) -> do
-                    let ct = fromMaybe "application/octet-stream" mct
-                        fi0 = FileInfo filename ct ()
-                    ((wasFound, _fileSize), y) <- sinkTillBound' bound name fi0 sink src Nothing
-                    add $ Right (name, fi0 { fileContent = y })
-                    when wasFound (loop src)
-                Just (_ct, name, Nothing) -> do
-                    let seed = id
-                    let iter front bs = return $ front . (:) bs
-                    ((wasFound, _fileSize), front) <- sinkTillBound bound iter seed src Nothing
-                    let bs = S.concat $ front []
-                    let x' = (name, bs)
-                    add $ Left x'
-                    when wasFound (loop src)
-                _ -> do
-                    -- ignore this part
-                    let seed = ()
-                        iter () _ = return ()
-                    ((wasFound, _fileSize), ()) <- sinkTillBound bound iter seed src Nothing
-                    when wasFound (loop src)
-      where
-        contDisp = mk $ S8.pack "Content-Disposition"
-        contType = mk $ S8.pack "Content-Type"
-        parsePair s =
-            let (x, y) = breakDiscard 58 s -- colon
-             in (mk $ x, S.dropWhile (== 32) y) -- space
-
 parsePiecesEx :: ParseRequestBodyOptions
               -> BackEnd y
               -> S.ByteString
@@ -439,8 +457,9 @@ parsePiecesEx o sink bound rbody add =
   where
     loop :: Int -> Int -> Int -> Int64 -> Source -> IO ()
     loop numParms numFiles parmSize filesSize src = do
-        _boundLine <- takeLine src
-        res' <- takeLines' (prboMaxHeaderLines o) src
+        _boundLine <- takeLine (prboMaxHeaderLineLength o) src
+        res' <- takeLines' (prboMaxHeaderLineLength o)
+            (prboMaxHeaderLines o) src
         unless (null res') $ do
             let ls' = map parsePair res'
             let x = do
@@ -451,10 +470,15 @@ parsePiecesEx o sink bound rbody add =
                     return (ct, name, lookup "filename" attrs)
             case x of
                 Just (mct, name, Just filename) -> do
-                    when (S.length name > prboKeyLength o) $
-                        error "Filename is too long"
-                    when (numFiles >= prboMaxNumFiles o) $
-                        error "Maximum number of files exceeded"
+                    case prboKeyLength o of
+                        Just maxKeyLength ->
+                            when (S.length name > maxKeyLength) $
+                                error "Filename is too long"
+                        Nothing -> return ()
+                    case prboMaxNumFiles o of
+                        Just maxFiles -> when (numFiles >= maxFiles) $
+                            error "Maximum number of files exceeded"
+                        Nothing -> return ()
                     let ct = fromMaybe "application/octet-stream" mct
                         fi0 = FileInfo filename ct ()
                         fs = catMaybes [ prboMaxFileSize o
@@ -465,17 +489,22 @@ parsePiecesEx o sink bound rbody add =
                     add $ Right (name, fi0 { fileContent = y })
                     when wasFound $ loop numParms (numFiles + 1) parmSize newFilesSize src
                 Just (_ct, name, Nothing) -> do
-                    when (S.length name > prboKeyLength o) $
-                        error "Parameter name is too long"
+                    case prboKeyLength o of
+                        Just maxKeyLength ->
+                            when (S.length name > maxKeyLength) $
+                                error "Parameter name is too long"
+                        Nothing -> return ()
                     let seed = id
                     let iter front bs = return $ front . (:) bs
-                    ((wasFound, _fileSize), front) <- sinkTillBound bound iter seed src $
-                        Just . fromIntegral . prboMaxParmsValueSize $ o
+                    ((wasFound, _fileSize), front) <- sinkTillBound bound iter seed src
+                        (fromIntegral <$> prboMaxParmsSize o)
                     let bs = S.concat $ front []
                     let x' = (name, bs)
                     let newParmSize = parmSize + S.length name + S.length bs
-                    when (newParmSize > prboMaxParmsValueSize o) $
-                        error "Maximum size of parameters exceeded"
+                    case prboMaxParmsSize o of
+                        Just maxParmSize -> when (newParmSize > maxParmSize) $
+                            error "Maximum size of parameters exceeded"
+                        Nothing -> return ()
                     add $ Left x'
                     when wasFound $ loop (numParms + 1) numFiles
                         newParmSize filesSize src
@@ -528,8 +557,8 @@ sinkTillBound' :: S.ByteString
                -> Source
                -> Maybe Int64
                -> IO ((Bool, Int64), y)
-sinkTillBound' bound name fi sink src max = do
-    (next, final) <- wrapTillBound bound src max
+sinkTillBound' bound name fi sink src max' = do
+    (next, final) <- wrapTillBound bound src max'
     y <- sink name fi next
     b <- final
     return (b, y)
@@ -540,7 +569,7 @@ wrapTillBound :: S.ByteString -- ^ bound
               -> Source
               -> Maybe Int64
               -> IO (IO S.ByteString, IO (Bool, Int64)) -- ^ Bool indicates if the bound was found
-wrapTillBound bound src max = do
+wrapTillBound bound src max' = do
     ref <- newIORef $ WTBWorking id
     sref <- newIORef (0 :: Int64)
     return (go ref sref, final ref sref)
@@ -561,8 +590,8 @@ wrapTillBound bound src max = do
                 bs <- readSource src
                 cur <- atomicModifyIORef sref $ \ cur ->
                     let new = cur + fromIntegral (S.length bs) in (new, new)
-                case max of
-                    Just max' | cur > max' -> error "Maximum size exceeded"
+                case max' of
+                    Just max'' | cur > max'' -> error "Maximum size exceeded"
                     _ -> return ()
                 if S.null bs
                     then do
@@ -598,8 +627,8 @@ sinkTillBound :: S.ByteString
               -> Source
               -> Maybe Int64
               -> IO ((Bool, Int64), x)
-sinkTillBound bound iter seed0 src max = do
-    (next, final) <- wrapTillBound bound src max
+sinkTillBound bound iter seed0 src max' = do
+    (next, final) <- wrapTillBound bound src max'
     let loop seed = do
             bs <- next
             if S.null bs

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -431,7 +431,8 @@ parsePiecesEx o sink bound rbody add =
                         error "Maximum number of files exceeded"
                     let ct = fromMaybe "application/octet-stream" mct
                         fi0 = FileInfo filename ct ()
-                        fs = catMaybes [ prboMaxFileSize o, prboMaxFilesSize o ]
+                        fs = catMaybes [ prboMaxFileSize o
+                                       , subtract filesSize <$> prboMaxFilesSize o ]
                         mfs = if fs == [] then Nothing else Just $ minimum fs
                     ((wasFound, fileSize), y) <- sinkTillBound' bound name fi0 sink src mfs
                     let newFilesSize = filesSize + fileSize

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -131,6 +131,10 @@ caseParseRequestBody = do
     SRequest req4 bod4 <- toRequest'' ctype2 content2
     (parseRequestBodyEx (def { prboMaxHeaderLines = 1 } ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
+  it "exceeding header line size" $ do
+    SRequest req4 bod4 <- toRequest'' ctype2 content4
+    (parseRequestBodyEx def lbsBackEnd req4) `shouldThrow` anyErrorCall
+
   where
     content2 =
          "--AaB03x\n"
@@ -152,6 +156,16 @@ caseParseRequestBody = do
          "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
       <> "Content-Disposition: form-data; name=\"yaml\"; filename=\"README\"\r\n"
       <> "Content-Type: application/octet-stream\r\n\r\n"
+      <> "Photo blog using Hack.\n\r\n"
+      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
+    content4 =
+         "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+      <> "Content-Disposition: form-data; name=\"yaml\"; filename=\"README\"\r\n"
+      <> "Content-Type: application/octet-stream\r\n\r\n"
+      <> "Photo blog using Hack.\n\r\n"
+      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+      <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmie\"\r\n"
+      <> "Content-Type: application/octet-stream=TOOLONG=" <> S8.replicate 8192 '=' <> "\r\n\r\n"
       <> "Photo blog using Hack.\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
 

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -137,6 +137,19 @@ caseParseRequestBody = do
     SRequest req4 bod4 <- toRequest'' ctype2 content4
     (parseRequestBodyEx def lbsBackEnd req4) `shouldThrow` anyErrorCall
 
+  it "Testing parseRequestBodyEx with application/x-www-form-urlencoded" $ do
+    let content = "thisisalongparameterkey=andthisbeanevenlongerparametervaluehelloworldhowareyou"
+    let ctype = "application/x-www-form-urlencoded"
+    SRequest req _bod <- toRequest'' ctype content
+    result <- parseRequestBodyEx def lbsBackEnd req
+    result `shouldBe` ([( "thisisalongparameterkey"
+                        , "andthisbeanevenlongerparametervaluehelloworldhowareyou" )], [])
+  it "exceeding max parm value size with x-www-form-urlencoded mimetype" $ do
+    let content = "thisisalongparameterkey=andthisbeanevenlongerparametervaluehelloworldhowareyou"
+    let ctype = "application/x-www-form-urlencoded"
+    SRequest req _bod <- toRequest'' ctype content
+    (parseRequestBodyEx (def { prboMaxParmsValueSize = 10 }) lbsBackEnd req) `shouldThrow` anyErrorCall
+
   where
     content2 =
          "--AaB03x\n"

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -121,7 +121,9 @@ caseParseRequestBody = do
 
   it "exceeding total file size" $ do
     SRequest req4 bod4 <- toRequest'' ctype3 content3
-    (parseRequestBodyEx (def { prboMaxFilesSize = Just 2 } ) lbsBackEnd req4) `shouldThrow` anyErrorCall
+    (parseRequestBodyEx (def { prboMaxFilesSize = Just 20 } ) lbsBackEnd req4) `shouldThrow` anyErrorCall
+    SRequest req5 bod5 <- toRequest'' ctype3 content5
+    (parseRequestBodyEx (def { prboMaxFilesSize = Just 20 } ) lbsBackEnd req5) `shouldThrow` anyErrorCall
 
   it "exceeding max parm value size" $ do
     SRequest req4 bod4 <- toRequest'' ctype2 content2
@@ -166,6 +168,16 @@ caseParseRequestBody = do
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
       <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmie\"\r\n"
       <> "Content-Type: application/octet-stream=TOOLONG=" <> S8.replicate 8192 '=' <> "\r\n\r\n"
+      <> "Photo blog using Hack.\n\r\n"
+      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
+    content5 =
+         "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+      <> "Content-Disposition: form-data; name=\"yaml\"; filename=\"README\"\r\n"
+      <> "Content-Type: application/octet-stream\r\n\r\n"
+      <> "Photo blog using Hack.\n\r\n"
+      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+      <> "Content-Disposition: form-data; name=\"yaml2\"; filename=\"MEADRE\"\r\n"
+      <> "Content-Type: application/octet-stream\r\n\r\n"
       <> "Photo blog using Hack.\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
 

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -113,7 +113,6 @@ Library
                    , zlib
                    , aeson
                    , iproute
-                   , data-default
 
   if os(windows)
       cpp-options:   -DWINDOWS
@@ -183,7 +182,6 @@ test-suite spec
                    , cookie
                    , time
                    , case-insensitive
-                   , data-default
     ghc-options:     -Wall
     default-language:          Haskell2010
 

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -113,6 +113,7 @@ Library
                    , zlib
                    , aeson
                    , iproute
+                   , data-default
 
   if os(windows)
       cpp-options:   -DWINDOWS
@@ -182,6 +183,7 @@ test-suite spec
                    , cookie
                    , time
                    , case-insensitive
+                   , data-default
     ghc-options:     -Wall
     default-language:          Haskell2010
 

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.15.2
+Version:             3.0.16.0
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Okay, here is my first attempt at fixing issue #560 .

Unfortunately, because the Network.HTTP.Types.parseSimpleQuery function does not allow to limit the number of parameters etc., I've only added a generic restriction on total non-parameter size.

I've also added a way to limit the number of files, the length of the filenames, the size of an individual file, and the total filesize. The number of header files in each mime entry can also be limited, but I'll still have to do another patch to limit individual line length.

Some refining is probably still necessary, but I'd be interested to hear if the general approach is ok.

Unfortunately, I had to duplicate a bit of code to keep the code compatible interface wise...
