### PR TITLE
Fix the way the header length is determined

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.16.1
+
+* Fix the way the header length is checked (for limiting the max header length)
+
 ## 3.0.16.0
 
 * Add a new function "parseRequestBodyEx" that allows various size limits to be set.

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -425,7 +425,7 @@ takeLine maxlen src =
     go front = do
         bs <- readSource src
         case maxlen of
-            Just maxlen' -> when (S.length front + S.length bs > maxlen') $
+            Just maxlen' -> when (S.length front > maxlen') $
                 error "Header line length exceeds allowed maximum."
             Nothing -> return ()
         if S.null bs

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -639,7 +639,7 @@ wrapTillBound bound src max' = do
                         return $ front bs
                     else push $ front bs
       where
-        push bs =
+        push bs = do
             case findBound bound bs of
                 FoundBound before after -> do
                     let before' = killCRLF before

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -439,7 +439,12 @@ takeLine maxlen src =
                 then go $ front `S.append` x
                 else do
                     when (S.length y > 1) $ leftover src $ S.drop 1 y
-                    return $ Just $ killCR $ front `S.append` x
+                    let res = front `S.append` x
+                    case maxlen of
+                        Just maxlen' -> when (S.length res > maxlen') $
+                            error "Header line length exceeds allowed maximum."
+                        Nothing -> return ()
+                    return $ Just $ killCR $ res
 
 takeLines' :: Maybe Int -> Maybe Int -> Source -> IO [S.ByteString]
 takeLines' lineLength maxLines source =

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -104,38 +104,38 @@ caseParseRequestBody = do
     result3' `shouldBe` expected3
 
   it "parsing with memory limit" $ do
-    SRequest req4 bod4 <- toRequest'' ctype3 content3
+    SRequest req4 _bod4 <- toRequest'' ctype3 content3
     result4' <- parseRequestBodyEx ( setMaxRequestNumFiles 1 $ setMaxRequestKeyLength 14 def ) lbsBackEnd req4
     result4' `shouldBe` expected3
 
   it "exceeding number of files" $ do
-    SRequest req4 bod4 <- toRequest'' ctype3 content3
+    SRequest req4 _bod4 <- toRequest'' ctype3 content3
     (parseRequestBodyEx ( setMaxRequestNumFiles 0 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "exceeding parameter length" $ do
-    SRequest req4 bod4 <- toRequest'' ctype3 content3
+    SRequest req4 _bod4 <- toRequest'' ctype3 content3
     (parseRequestBodyEx ( setMaxRequestKeyLength 2 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "exceeding file size" $ do
-    SRequest req4 bod4 <- toRequest'' ctype3 content3
+    SRequest req4 _bod4 <- toRequest'' ctype3 content3
     (parseRequestBodyEx ( setMaxRequestFileSize 2 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "exceeding total file size" $ do
-    SRequest req4 bod4 <- toRequest'' ctype3 content3
+    SRequest req4 _bod4 <- toRequest'' ctype3 content3
     (parseRequestBodyEx ( setMaxRequestFilesSize 20 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
-    SRequest req5 bod5 <- toRequest'' ctype3 content5
+    SRequest req5 _bod5 <- toRequest'' ctype3 content5
     (parseRequestBodyEx ( setMaxRequestFilesSize 20 def ) lbsBackEnd req5) `shouldThrow` anyErrorCall
 
   it "exceeding max parm value size" $ do
-    SRequest req4 bod4 <- toRequest'' ctype2 content2
+    SRequest req4 _bod4 <- toRequest'' ctype2 content2
     (parseRequestBodyEx ( setMaxRequestParmsSize 10 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "exceeding max header lines" $ do
-    SRequest req4 bod4 <- toRequest'' ctype2 content2
+    SRequest req4 _bod4 <- toRequest'' ctype2 content2
     (parseRequestBodyEx ( setMaxHeaderLines 1 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "exceeding header line size" $ do
-    SRequest req4 bod4 <- toRequest'' ctype2 content4
+    SRequest req4 _bod4 <- toRequest'' ctype3 content4
     (parseRequestBodyEx ( setMaxHeaderLineLength 8190 def ) lbsBackEnd req4) `shouldThrow` anyErrorCall
 
   it "Testing parseRequestBodyEx with application/x-www-form-urlencoded" $ do
@@ -176,13 +176,14 @@ caseParseRequestBody = do
       <> "Photo blog using Hack.\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
     content4 =
---         "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
---      <> "Content-Disposition: form-data; name=\"alb\"; filename=\"README\"\r\n"
---      <> "Content-Type: application/octet-stream\r\n\r\n"
---      <> "Photo blog using Hack.\r\n\r\n"
          "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
-      <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmie\"\r\n"
-      <> "Content-Type: application/octet-stream=TOOLONG=" <> S8.replicate 8192 '=' <> "\r\n\r\n"
+      <> "Content-Disposition: form-data; name=\"alb\"; filename=\"README\"\r\n"
+      <> "Content-Type: application/octet-stream\r\n\r\n"
+      <> "Photo blog using Hack.\r\n\r\n"
+      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+      <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmi"
+      <> S8.replicate 8190 'e' <> "\"\r\n"
+      <> "Content-Type: application/octet-stream\r\n\r\n"
       <> "Photo blog using Hack.\r\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
     content5 =

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -177,13 +177,9 @@ caseParseRequestBody = do
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
     content4 =
          "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
-      <> "Content-Disposition: form-data; name=\"yaml\"; filename=\"README\"\r\n"
-      <> "Content-Type: application/octet-stream\r\n\r\n"
-      <> "Photo blog using Hack.\n\r\n"
-      <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
       <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmie\"\r\n"
       <> "Content-Type: application/octet-stream=TOOLONG=" <> S8.replicate 8192 '=' <> "\r\n\r\n"
-      <> "Photo blog using Hack.\n\r\n"
+      <> "Photo blog using Hack.\r\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
     content5 =
          "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -176,6 +176,10 @@ caseParseRequestBody = do
       <> "Photo blog using Hack.\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"
     content4 =
+--         "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
+--      <> "Content-Disposition: form-data; name=\"alb\"; filename=\"README\"\r\n"
+--      <> "Content-Type: application/octet-stream\r\n\r\n"
+--      <> "Photo blog using Hack.\r\n\r\n"
          "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
       <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmie\"\r\n"
       <> "Content-Type: application/octet-stream=TOOLONG=" <> S8.replicate 8192 '=' <> "\r\n\r\n"

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.16.0
+Version:             3.0.16.1
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Hi,
I'm really sorry, but during further testing of #563 I discovered a small but important bug that will cause the determined header length to be much bigger than the actual header length.