### PR TITLE
warp: add HTTP2 CONNECT support

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -83,13 +83,21 @@ hpackDecodeHeader hdrblk Context{..} = do
 {-# INLINE checkRequestHeader #-}
 checkRequestHeader :: ValueTable -> Bool
 checkRequestHeader reqvt
-  | getHeaderValue tokenStatus     reqvt /= Nothing     = False
-  | getHeaderValue tokenPath       reqvt == Nothing     = False
-  | getHeaderValue tokenMethod     reqvt == Nothing     = False
-  | getHeaderValue tokenAuthority  reqvt == Nothing     = False
-  | getHeaderValue tokenConnection reqvt /= Nothing     = False
-  | just (getHeaderValue tokenTE reqvt) (/= "trailers") = False
-  | otherwise                                           = True
+  | mStatus     /= Nothing      = False
+  | mMethod     == Nothing      = False
+  | mAuthority  == Nothing      = False
+  | mConnection /= Nothing      = False
+  | just mTE (/= "trailers")    = False
+  | just mMethod (== "CONNECT") = mPath == Nothing && mScheme == Nothing
+  | otherwise                   = mPath /= Nothing
+  where
+    mStatus     = getHeaderValue tokenStatus reqvt
+    mScheme     = getHeaderValue tokenScheme reqvt
+    mPath       = getHeaderValue tokenPath reqvt
+    mMethod     = getHeaderValue tokenMethod reqvt
+    mAuthority  = getHeaderValue tokenAuthority reqvt
+    mConnection = getHeaderValue tokenConnection reqvt
+    mTE         = getHeaderValue tokenTE reqvt
 
 {-# INLINE just #-}
 just :: Maybe a -> (a -> Bool) -> Bool


### PR DESCRIPTION
As per section 8.3 of HTTP2 spec, ":scheme" and ":path" should be
omitted and ":authority" is mandatory for HTTP2 CONNECT request.

Treat CONNECT request as a special case for headers check. And also
for CONNECT request, use ":authority" as unparsed path, so that
CONNECT method has consistent behavior compare to HTTP 1.0.

Closes #561