### PR TITLE
Import monoid to fix errors with latest optparse-applicative 0.13.*

### DIFF
--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -25,6 +25,7 @@ import Network.Mime (defaultMimeMap, mimeByExt, defaultMimeType)
 import WaiAppStatic.Types (ssIndices, toPiece, ssGetMimeType, fileName, fromPiece)
 import Data.Maybe (mapMaybe)
 import Control.Arrow (second)
+import Data.Monoid ((<>))
 
 data Args = Args
     { docroot :: FilePath


### PR DESCRIPTION
Apologies, not sure if this is the correct means of keep the compatibility with as much as possible.

`optparse-applicative` has just released a new version which no longer exports `<>`, which breaks `wai-app-static`.

https://github.com/pcapriotti/optparse-applicative/pull/216/files#diff-4191720afbea61cacc0c18ca54118978L52

Let me know if there's a more appropriate fix.