### PR TITLE
ForceSSL: preserve port number when redirecting to https.

### DIFF
--- a/wai-extra/Network/Wai/Middleware/ForceSSL.hs
+++ b/wai-extra/Network/Wai/Middleware/ForceSSL.hs
@@ -17,7 +17,6 @@ import Data.Monoid (mempty)
 import Data.Monoid ((<>))
 import Network.HTTP.Types (hLocation, methodGet, status301, status307)
 
-import qualified Data.ByteString as S
 import Data.Word8 (_colon)
 
 -- | For requests that don't appear secure, redirect to https
@@ -31,13 +30,10 @@ forceSSL app req sendResponse =
 
 redirectResponse :: Request -> Maybe Response
 redirectResponse req = do
-    (host, _) <- S.break (== _colon) <$> requestHeaderHost req
-
-    return $ responseBuilder status [(hLocation, location host)] mempty
-
+  host <- requestHeaderHost req
+  return $ responseBuilder status [(hLocation, location host)] mempty
   where
     location h = "https://" <> h <> rawPathInfo req <> rawQueryString req
-
     status
         | requestMethod req == methodGet = status301
         | otherwise = status307

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.17
+Version:             3.0.18
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Previously, the port number was dropped from the request's host header when redirecting a request to https.

Now, the port from the request's host header is kept as is.