### PR TITLE
ForceSSL: remove redundant import.

### DIFF
--- a/wai-extra/Network/Wai/Middleware/ForceSSL.hs
+++ b/wai-extra/Network/Wai/Middleware/ForceSSL.hs
@@ -17,8 +17,6 @@ import Data.Monoid (mempty)
 import Data.Monoid ((<>))
 import Network.HTTP.Types (hLocation, methodGet, status301, status307)
 
-import Data.Word8 (_colon)
-
 -- | For requests that don't appear secure, redirect to https
 --
 -- Since 3.0.7


### PR DESCRIPTION
Data.Word8 is not used anymore.