### PR TITLE
Fix spaceleak in sendResponse

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -136,6 +136,8 @@ sendResponse :: Settings
 sendResponse settings conn ii req reqidxhdr src response = do
     hs <- addServerAndDate hs0
     if hasBody s then do
+        -- Make sure we don't hang on to 'response' (avoid space leak)
+        ret' <- E.evaluate ret
         -- The response to HEAD does not have body.
         -- But to handle the conditional requests defined RFC 7232 and
         -- to generate appropriate content-length, content-range,
@@ -147,7 +149,7 @@ sendResponse settings conn ii req reqidxhdr src response = do
             Nothing         -> return ()
             Just realStatus -> logger req realStatus mlen
         T.tickle th
-        return ret
+        return ret'
       else do
         _ <- sendRsp conn ii ver s hs RspNoBody
         logger req s Nothing


### PR DESCRIPTION
Consider the following simple WAI application that uses `wai-conduit` to generate a streaming body:

``` haskell
{-# OPTIONS_GHC -fno-full-laziness #-}
module Main (main) where

import Data.ByteString.Builder (Builder, int32BE, word8)
import Data.Conduit
import Data.Int (Int32)
import Network.HTTP.Types
import Network.Wai.Handler.Warp (run)
import Network.Wai.Conduit

main :: IO ()
main = run 3000 $ \_req k -> k $ responseSource ok200 [] (testSource 1000000)

testSource :: Int32 -> Source IO (Flush Builder)
testSource 0  = return ()
testSource !i = do
    yield (Chunk $ int32BE i)
    yield (Chunk $ word8 10)
    yield Flush
    testSource (i - 1)
```

We'd expect this to run in constant space, but sadly it suffers from a space leak. In fact, it's another dreaded of-type-`Pipe` space leak :-( It seems I'm [spending a significant chunk of my time tracking those down lately](http://www.well-typed.com/blog/2016/09/sharing-conduit/)... I wish we had a better way to deal with these.

Anyway, the problem is not with the conduit per se; connecting it directly to a sink that writes all values to standard output runs in constant space. Nor is the problem in `wai-conduit`; manually executing the `StreamingBody` generated by `responseSource` works just fine. In the end I traced this down to a bug in `sendResponse` in `warp` itself; hopefully the commit is clear enough: we're hanging on to `response` longer than we need, which is causing the space leak. 

Though I realize that that is somewhat hand-wavy, once I realized that the problem was here I didn't investigate in more detail the exact nature of this spaceleak. Note however that for this test case, disabling full laziness is necessary even with the bugfix applied (without the bugfix there is a spaceleak with full laziness enabled or not).
