### PR TITLE
URL now seems to be squatted by spam redirector

### DIFF
--- a/wai-app-static/WaiAppStatic/Listing.hs
+++ b/wai-app-static/WaiAppStatic/Listing.hs
@@ -22,7 +22,7 @@ import qualified Text.Blaze.Html.Renderer.Utf8 as HU
 
 -- | Provides a default directory listing, suitable for most apps.
 --
--- Code below taken from Happstack: <http://patch-tag.com/r/mae/happstack/snapshot/current/content/pretty/happstack-server/src/Happstack/Server/FileServe/BuildingBlocks.hs>
+-- Code below taken from Happstack: <https://github.com/Happstack/happstack-server/blob/87e6c01a65c687d06c61345430a112fc9a444a95/src/Happstack/Server/FileServe/BuildingBlocks.hs>
 defaultListing :: Listing
 defaultListing pieces (Folder contents) = do
     let isTop = null pieces || map Just pieces == [toPiece ""]


### PR DESCRIPTION
Noticed the URL reference for `WaiAppStatic.Listing.defaultListing` was redirecting to some rather dodgy sites.

Updated URL to point to the file on Happstack GH repo instead, pinned to most recent SHA change to the file (happens to coincide with `blaze-html 0.5` release) prior to this comment being added here on `2012-05-22`.
