### PR TITLE
Add docs example to setInstallShutdownHandler

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -286,6 +286,16 @@ getGracefulShutdownTimeout = settingsGracefulShutdownTimeout
 -- handler. The handler should call the first argument,
 -- which closes the listen socket, at shutdown.
 --
+-- Example usage:
+--
+-- @
+-- settings :: IO () -> 'Settings'
+-- settings shutdownAction = 'setInstallShutdownHandler' shutdownHandler 'defaultSettings'
+--   __where__
+--     shutdownHandler closeSocket =
+--       void $ 'System.Posix.Signals.installHandler' 'System.Posix.Signals.sigTERM' ('System.Posix.Signals.Catch' $ shutdownAction >> closeSocket) 'Nothing'
+-- @
+--
 -- Default: does not install any code.
 --
 -- Since 3.0.1


### PR DESCRIPTION
- add usage exmple to `setInstallShutdownHandler` docs

I've spent some time recently trying to figure out how to use `setInstallShutdownHandler`. I've also found that it is a quite frequent question on the internet. 

The confusing part is that you don't call lambda argument (which closes socket) directly, and should use signal handler instead. On the other hand, this is exactly what the docs said. After some considerations, I thought that wording in the docs is fine, but it lacks an example.