### PR TITLE
Update slightly confusing description.

### DIFF
--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -10,7 +10,7 @@ Category:            Web, Yesod
 Build-Type:          Simple
 Cabal-Version:       >=1.6
 Stability:           Stable
-description:         Support for SSL is now obsoleted.
+description:         Support for SSL (but not TLS) is now obsoleted.
                      HTTP/2 can be negotiated by ALPN.
                      API docs and the README are available at
                      <http://www.stackage.org/package/warp-tls>.


### PR DESCRIPTION
As TLS is just a name for SSL to avoid a lawsuit from Netscape, and has no technical meaning in itself, I think the description should be qualified a bit.

At least this confused me, and I can see in the issues that others have been similarly confused.