### PR TITLE
build a docker image with the warp executable

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -23,3 +23,9 @@ nix:
   packages:
   - fcgi
   - zlib
+image:
+  containers:
+    - base: "fpco/pid1"
+      name: "yesodweb/warp"
+      executables:
+        - warp


### PR DESCRIPTION
`stack image container` will now build a docker image suitable for
static file serving out of the box and with no additional futzing.

Two questions I have:
* could travis run `stack image container` to build a docker image for commits on `master`?
* does `yesodweb` have a docker repo this could use?

...or should this not be integrated with CI and just be available for users to create and host on their own (which is totally reasonable too)?