### PR TITLE
Tidy up docstring of `MethodOverride` middleware

### DIFF
--- a/wai-extra/Network/Wai/Middleware/MethodOverride.hs
+++ b/wai-extra/Network/Wai/Middleware/MethodOverride.hs
@@ -5,12 +5,11 @@ module Network.Wai.Middleware.MethodOverride
 import Network.Wai
 import Control.Monad (join)
 
--- | Allows overriding of the HTTP request method via the _method query string
--- parameter.
+-- | Overriding of HTTP request method via `_method` query string parameter.
 --
--- This middleware only applies when the initial request method is POST. This
--- allow submitting of normal HTML forms, without worries of semantics
--- mismatches in the HTTP spec.
+-- This middleware only applies when the initial request method is POST.
+-- Allows submitting of normal HTML forms, without worries of semantic
+-- mismatches with the HTTP spec.
 methodOverride :: Middleware
 methodOverride app req =
     app req'


### PR DESCRIPTION
This tidies the grammar and brings the structure of the first sentence in line with that used elsewhere.

Not a _dramatic_ improvement, more as a mild decrease in surprise factor when browsing the documentation.