### PR TITLE
Relax HTTP2 headers check.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/HPACK.hs
@@ -93,7 +93,6 @@ checkRequestHeader reqvt
   | mScheme     == Nothing      = False
   | mPath       == Nothing      = False
   | mPath       == Just ""      = False
-  | mAuthority  == Nothing      = False
   | mConnection /= Nothing      = False
   | just mTE (/= "trailers")    = False
   | otherwise                   = True
@@ -102,7 +101,6 @@ checkRequestHeader reqvt
     mScheme     = getHeaderValue tokenScheme reqvt
     mPath       = getHeaderValue tokenPath reqvt
     mMethod     = getHeaderValue tokenMethod reqvt
-    mAuthority  = getHeaderValue tokenAuthority reqvt
     mConnection = getHeaderValue tokenConnection reqvt
     mTE         = getHeaderValue tokenTE reqvt
 


### PR DESCRIPTION
HTTP/2-draft17 (e.g., used in gRPC) does not mandate an `:authority` pseudo header.
In fact, this pseudo header MUST be omitted in some HTTP/1.1 translation
cases.

More details at https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8.1.2.3 .