### PR TITLE
Guarantee atomicity of WINDOW_UPDATE increments.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -232,9 +232,12 @@ control FrameGoAway _ _ Context{controlQ} = do
 
 control FrameWindowUpdate header bs Context{connectionWindow} = do
     WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
-    !w <- (n +) <$> atomically (readTVar connectionWindow)
+    !w <- atomically $ do
+      w0 <- readTVar connectionWindow
+      let w1 = w0 + n
+      writeTVar connectionWindow w1
+      return w1
     when (isWindowOverflow w) $ E.throwIO $ ConnectionError FlowControlError "control window should be less than 2^31"
-    atomically $ writeTVar connectionWindow w
     return True
 
 control _ _ _ _ =
@@ -336,10 +339,13 @@ stream FrameContinuation FrameHeader{flags} frag ctx (Open (Continued rfrags siz
 
 stream FrameWindowUpdate header@FrameHeader{streamId} bs _ s Stream{streamWindow} = do
     WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
-    !w <- (n +) <$> atomically (readTVar streamWindow)
+    !w <- atomically $ do
+      w0 <- readTVar streamWindow
+      let w1 = w0 + n
+      writeTVar streamWindow w1
+      return w1
     when (isWindowOverflow w) $
         E.throwIO $ StreamError FlowControlError streamId
-    atomically $ writeTVar streamWindow w
     return s
 
 stream FrameRSTStream header bs ctx _ strm = do

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Receiver.hs
@@ -234,7 +234,7 @@ control FrameWindowUpdate header bs Context{connectionWindow} = do
     WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
     !w <- atomically $ do
       w0 <- readTVar connectionWindow
-      let w1 = w0 + n
+      let !w1 = w0 + n
       writeTVar connectionWindow w1
       return w1
     when (isWindowOverflow w) $ E.throwIO $ ConnectionError FlowControlError "control window should be less than 2^31"
@@ -341,7 +341,7 @@ stream FrameWindowUpdate header@FrameHeader{streamId} bs _ s Stream{streamWindow
     WindowUpdateFrame n <- guardIt $ decodeWindowUpdateFrame header bs
     !w <- atomically $ do
       w0 <- readTVar streamWindow
-      let w1 = w0 + n
+      let !w1 = w0 + n
       writeTVar streamWindow w1
       return w1
     when (isWindowOverflow w) $


### PR DESCRIPTION
The current code may lead to over-estimating the window size.
The over-estimation occurs as follows:
- the initial window state is W
- the receiver observes a window update and computes W+K in a first
  transaction
- the sender decrease the window by the payload size P, hence the window
  state is set to W-P
- the receiver writes W+K in the second transaction

This over-estimation carries over and may lead to unexpected GOAWAYs.