### PR TITLE
Using http-types 0.9.1 only

### DIFF
--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -23,10 +23,6 @@ import Network.Wai.Handler.Warp.Header
 import Network.Wai.Handler.Warp.PackInt
 import Numeric (showInt)
 
-#ifndef MIN_VERSION_http_types
-#define MIN_VERSION_http_types(x,y,z) 1
-#endif
-
 -- $setup
 -- >>> import Test.QuickCheck
 
@@ -116,17 +112,10 @@ checkRange (H.ByteRangeSuffix count)   size = (max 0 (size - count), size - 1)
 
 ----------------------------------------------------------------
 
-contentRange :: H.HeaderName
-#if MIN_VERSION_http_types(0,9,0)
-contentRange = H.hContentRange
-#else
-contentRange = "Content-Range"
-#endif
-
 -- | @contentRangeHeader beg end total@ constructs a Content-Range 'H.Header'
 -- for the range specified.
 contentRangeHeader :: Integer -> Integer -> Integer -> H.Header
-contentRangeHeader beg end total = (contentRange, range)
+contentRangeHeader beg end total = (H.hContentRange, range)
   where
     range = B.pack
       -- building with ShowS
@@ -138,13 +127,6 @@ contentRangeHeader beg end total = (contentRange, range)
       ( '/'
       : showInt total "")
 
-acceptRange :: H.HeaderName
-#if MIN_VERSION_http_types(0,9,0)
-acceptRange = H.hAcceptRanges
-#else
-acceptRange = "Accept-Ranges"
-#endif
-
 addContentHeaders :: H.ResponseHeaders -> Integer -> Integer -> Integer -> H.ResponseHeaders
 addContentHeaders hs off len size
   | len == size = hs'
@@ -152,7 +134,7 @@ addContentHeaders hs off len size
                   in ctrng:hs'
   where
     !lengthBS = packIntegral len
-    !hs' = (H.hContentLength, lengthBS) : (acceptRange,"bytes") : hs
+    !hs' = (H.hContentLength, lengthBS) : (H.hAcceptRanges,"bytes") : hs
 
 -- |
 --

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -6,13 +6,12 @@ module Network.Wai.Handler.Warp.File (
     RspFileInfo(..)
   , conditionalRequest
   , addContentHeadersForFilePart
-  , parseByteRanges
+  , H.parseByteRanges
   ) where
 
 import Control.Applicative ((<|>))
 import Data.Array ((!))
-import qualified Data.ByteString as B hiding (pack)
-import qualified Data.ByteString.Char8 as B (pack, readInteger)
+import qualified Data.ByteString.Char8 as B (pack)
 import Data.ByteString (ByteString)
 import Data.Maybe (fromMaybe)
 import Network.HTTP.Date
@@ -99,7 +98,7 @@ unconditional reqidx size = case reqidx ! fromEnum ReqRange of
 ----------------------------------------------------------------
 
 parseRange :: ByteString -> Integer -> RspFileInfo
-parseRange rng size = case parseByteRanges rng of
+parseRange rng size = case H.parseByteRanges rng of
     Nothing    -> WithoutBody H.requestedRangeNotSatisfiable416
     Just []    -> WithoutBody H.requestedRangeNotSatisfiable416
     Just (r:_) -> let (!beg, !end) = checkRange r size
@@ -114,33 +113,6 @@ checkRange :: H.ByteRange -> Integer -> (Integer, Integer)
 checkRange (H.ByteRangeFrom   beg)     size = (beg, size - 1)
 checkRange (H.ByteRangeFromTo beg end) size = (beg,  min (size - 1) end)
 checkRange (H.ByteRangeSuffix count)   size = (max 0 (size - count), size - 1)
-
--- | Parse the value of a Range header into a 'H.ByteRanges'.
-parseByteRanges :: B.ByteString -> Maybe H.ByteRanges
-parseByteRanges bs1 = do
-    bs2 <- stripPrefix "bytes=" bs1
-    (r, bs3) <- range bs2
-    ranges (r:) bs3
-  where
-    range bs2 = do
-        (i, bs3) <- B.readInteger bs2
-        if i < 0 -- has prefix "-" ("-0" is not valid, but here treated as "0-")
-            then Just (H.ByteRangeSuffix (negate i), bs3)
-            else do
-                bs4 <- stripPrefix "-" bs3
-                case B.readInteger bs4 of
-                    Just (j, bs5) | j >= i -> Just (H.ByteRangeFromTo i j, bs5)
-                    _ -> Just (H.ByteRangeFrom i, bs4)
-    ranges front bs3
-        | B.null bs3 = Just (front [])
-        | otherwise = do
-            bs4 <- stripPrefix "," bs3
-            (r, bs5) <- range bs4
-            ranges (front . (r:)) bs5
-
-    stripPrefix x y
-        | x `B.isPrefixOf` y = Just (B.drop (B.length x) y)
-        | otherwise = Nothing
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/File.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/File.hs
@@ -6,12 +6,11 @@ module Network.Wai.Handler.Warp.HTTP2.File (
     RspFileInfo(..)
   , conditionalRequest
   , addContentHeadersForFilePart
-  , parseByteRanges
+  , H.parseByteRanges
   ) where
 
 import Control.Applicative ((<|>))
-import qualified Data.ByteString as B hiding (pack)
-import qualified Data.ByteString.Char8 as B (pack, readInteger)
+import qualified Data.ByteString.Char8 as B (pack)
 import Data.ByteString (ByteString)
 import Data.Maybe (fromMaybe)
 import Network.HTTP.Date
@@ -104,7 +103,7 @@ unconditional reqtbl size = case getHeaderValue tokenRange reqtbl of
 
 {-# INLINE parseRange #-}
 parseRange :: ByteString -> Integer -> RspFileInfo
-parseRange rng size = case parseByteRanges rng of
+parseRange rng size = case H.parseByteRanges rng of
     Nothing    -> WithoutBody H.requestedRangeNotSatisfiable416
     Just []    -> WithoutBody H.requestedRangeNotSatisfiable416
     Just (r:_) -> let (!beg, !end) = checkRange r size
@@ -120,34 +119,6 @@ checkRange :: H.ByteRange -> Integer -> (Integer, Integer)
 checkRange (H.ByteRangeFrom   beg)     size = (beg, size - 1)
 checkRange (H.ByteRangeFromTo beg end) size = (beg,  min (size - 1) end)
 checkRange (H.ByteRangeSuffix count)   size = (max 0 (size - count), size - 1)
-
-{-# INLINE parseByteRanges #-}
--- | Parse the value of a Range header into a 'H.ByteRanges'.
-parseByteRanges :: B.ByteString -> Maybe H.ByteRanges
-parseByteRanges bs1 = do
-    bs2 <- stripPrefix "bytes=" bs1
-    (r, bs3) <- range bs2
-    ranges (r:) bs3
-  where
-    range bs2 = do
-        (i, bs3) <- B.readInteger bs2
-        if i < 0 -- has prefix "-" ("-0" is not valid, but here treated as "0-")
-            then Just (H.ByteRangeSuffix (negate i), bs3)
-            else do
-                bs4 <- stripPrefix "-" bs3
-                case B.readInteger bs4 of
-                    Just (j, bs5) | j >= i -> Just (H.ByteRangeFromTo i j, bs5)
-                    _ -> Just (H.ByteRangeFrom i, bs4)
-    ranges front bs3
-        | B.null bs3 = Just (front [])
-        | otherwise = do
-            bs4 <- stripPrefix "," bs3
-            (r, bs5) <- range bs4
-            ranges (front . (r:)) bs5
-
-    stripPrefix x y
-        | x `B.isPrefixOf` y = Just (B.drop (B.length x) y)
-        | otherwise = Nothing
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/HTTP2/File.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/File.hs
@@ -22,10 +22,6 @@ import Numeric (showInt)
 import Network.HPACK
 import Network.HPACK.Token
 
-#ifndef MIN_VERSION_http_types
-#define MIN_VERSION_http_types(x,y,z) 1
-#endif
-
 -- $setup
 -- >>> import Test.QuickCheck
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -18,10 +18,6 @@ module Network.Wai.Handler.Warp.Response (
 #define MIN_VERSION_base(x,y,z) 1
 #endif
 
-#ifndef MIN_VERSION_http_types
-#define MIN_VERSION_http_types(x,y,z) 1
-#endif
-
 import Blaze.ByteString.Builder.HTTP (chunkedTransferEncoding, chunkedTransferTerminator)
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
@@ -50,9 +46,7 @@ import Data.Streaming.Blaze (newBlazeRecv, reuseBufferStrategy)
 import Data.Version (showVersion)
 import Data.Word8 (_cr, _lf)
 import qualified Network.HTTP.Types as H
-#if MIN_VERSION_http_types(0,9,0)
 import qualified Network.HTTP.Types.Header as H
-#endif
 import Network.Wai
 import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
@@ -411,11 +405,7 @@ hasBody s = sc /= 204
 ----------------------------------------------------------------
 
 addTransferEncoding :: H.ResponseHeaders -> H.ResponseHeaders
-#if MIN_VERSION_http_types(0,9,0)
 addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
-#else
-addTransferEncoding hdrs = ("transfer-encoding", "chunked") : hdrs
-#endif
 
 addDate :: IO D.GMTDate -> IndexedHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
 addDate getdate rspidxhdr hdrs = case rspidxhdr ! fromEnum ResDate of

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -43,7 +43,7 @@ Library
                    , case-insensitive          >= 0.2
                    , containers
                    , ghc-prim
-                   , http-types                >= 0.8.5
+                   , http-types                >= 0.9.1
                    , iproute                   >= 1.3.1
                    , http2                     >= 1.6      && < 1.7
                    , simple-sendfile           >= 0.2.7    && < 0.3


### PR DESCRIPTION
10 months have passed since http-types v0.9.1 is released.
It's time to remove the support old http-types to clean up the code.
See https://github.com/yesodweb/wai/issues/439.