### PR TITLE
Allow people to manage session state between calls to runSession.

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.20.0
+
+* runSessionWith (runSession variant that gives access to ClientState) [#629](https://github.com/yesodweb/wai/pull/629)
+
 ## 3.0.19.1
 
 * All loggers follow the autoFlush setting [#604](https://github.com/yesodweb/wai/pull/604)

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 3.0.20.0
 
-* runSessionWith (runSession variant that gives access to ClientCookies) [#629](https://github.com/yesodweb/wai/pull/629)
+* runSessionWith (runSession variant that gives access to ClientState) [#629](https://github.com/yesodweb/wai/pull/629)
 
 ## 3.0.19.1
 

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 3.0.20.0
 
-* runSessionWith (runSession variant that gives access to ClientState) [#629](https://github.com/yesodweb/wai/pull/629)
+* runSessionWith (runSession variant that gives access to ClientCookies) [#629](https://github.com/yesodweb/wai/pull/629)
 
 ## 3.0.19.1
 

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -5,7 +5,7 @@ module Network.Wai.Test
     ( -- * Session
       Session
     , runSession
-    , runSessionWith, ClientState(..), initState
+    , runSessionWith, initState
       -- * Client Cookies
     , ClientCookies
     , getClientCookies
@@ -40,6 +40,7 @@ import Data.Monoid (mempty, mappend)
 
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
+import Network.Wai.Test.Internal
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import qualified Control.Monad.Trans.State as ST

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -105,12 +105,21 @@ deleteClientCookie cookieName =
   modifyClientCookies
     (Map.delete cookieName)
 
+-- |
+--
+-- Since 3.0.20.0
 initState :: ClientState
 initState = ClientState Map.empty
 
 runSession :: Session a -> Application -> IO a
 runSession session app = ST.evalStateT (runReaderT session app) initState
 
+-- | Like 'runSession', but if allows you to hand in cookies and get
+-- the updated cookies back.  One use case for this is writing tests
+-- that address the application under test alternatingly through rest
+-- api and through db handle.
+--
+-- Since 3.0.20.0
 runSessionWith :: ClientState -> Session a -> Application -> IO (a, ClientState)
 runSessionWith st session app = ST.runStateT (runReaderT session app) st
 

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -5,7 +5,7 @@ module Network.Wai.Test
     ( -- * Session
       Session
     , runSession
-    , runSessionWith, initState
+    , runSessionWith
       -- * Client Cookies
     , ClientCookies
     , getClientCookies
@@ -40,7 +40,6 @@ import Data.Monoid (mempty, mappend)
 
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
-import Network.Wai.Test.Internal
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import qualified Control.Monad.Trans.State as ST
@@ -121,8 +120,9 @@ runSession session app = ST.evalStateT (runReaderT session app) initState
 -- api and through db handle.
 --
 -- Since 3.0.20.0
-runSessionWith :: ClientState -> Session a -> Application -> IO (a, ClientState)
-runSessionWith st session app = ST.runStateT (runReaderT session app) st
+runSessionWith :: ClientCookies -> Session a -> Application -> IO (a, ClientCookies)
+runSessionWith cookies session app = (\(result, cookies') -> (result, clientCookies cookies')) <$>
+  ST.runStateT (runReaderT session app) (ClientState cookies)
 
 data SRequest = SRequest
     { simpleRequest :: Request

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -5,6 +5,7 @@ module Network.Wai.Test
     ( -- * Session
       Session
     , runSession
+    , runSessionWith, ClientState(..), initState
       -- * Client Cookies
     , ClientCookies
     , getClientCookies
@@ -109,6 +110,9 @@ initState = ClientState Map.empty
 
 runSession :: Session a -> Application -> IO a
 runSession session app = ST.evalStateT (runReaderT session app) initState
+
+runSessionWith :: ClientState -> Session a -> Application -> IO (a, ClientState)
+runSessionWith st session app = ST.runStateT (runReaderT session app) st
 
 data SRequest = SRequest
     { simpleRequest :: Request
@@ -337,4 +341,3 @@ assertClientCookieValue s cookieName cookieValue = do
           ]
         )
         (Cookie.setCookieValue c == cookieValue)
-

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -5,7 +5,7 @@ module Network.Wai.Test
     ( -- * Session
       Session
     , runSession
-    , runSessionWith
+    , runSessionWith, initState
       -- * Client Cookies
     , ClientCookies
     , getClientCookies
@@ -40,6 +40,7 @@ import Data.Monoid (mempty, mappend)
 
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
+import Network.Wai.Test.Internal
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
 import qualified Control.Monad.Trans.State as ST
@@ -120,9 +121,8 @@ runSession session app = ST.evalStateT (runReaderT session app) initState
 -- api and through db handle.
 --
 -- Since 3.0.20.0
-runSessionWith :: ClientCookies -> Session a -> Application -> IO (a, ClientCookies)
-runSessionWith cookies session app = (\(result, cookies') -> (result, clientCookies cookies')) <$>
-  ST.runStateT (runReaderT session app) (ClientState cookies)
+runSessionWith :: ClientState -> Session a -> Application -> IO (a, ClientState)
+runSessionWith st session app = ST.runStateT (runReaderT session app) st
 
 data SRequest = SRequest
     { simpleRequest :: Request

--- a/wai-extra/Network/Wai/Test/Internal.hs
+++ b/wai-extra/Network/Wai/Test/Internal.hs
@@ -1,5 +1,35 @@
 module Network.Wai.Test.Internal where
 
+import Network.Wai
+import qualified Control.Monad.Trans.State as ST
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Web.Cookie as Cookie
+import Data.ByteString (ByteString)
+
+type Session = ReaderT Application (ST.StateT ClientState IO)
+
+-- |
+--
+-- Since 3.0.6
+type ClientCookies = Map ByteString Cookie.SetCookie
+
 data ClientState = ClientState
     { clientCookies :: ClientCookies
     }
+
+-- |
+--
+-- Since 3.0.20.0
+initState :: ClientState
+initState = ClientState Map.empty
+
+-- | Like 'runSession', but if allows you to hand in cookies and get
+-- the updated cookies back.  One use case for this is writing tests
+-- that address the application under test alternatingly through rest
+-- api and through db handle.
+--
+-- Since 3.0.20.0
+runSessionWith :: ClientState -> Session a -> Application -> IO (a, ClientState)
+runSessionWith st session app = ST.runStateT (runReaderT session app) st

--- a/wai-extra/Network/Wai/Test/Internal.hs
+++ b/wai-extra/Network/Wai/Test/Internal.hs
@@ -1,0 +1,5 @@
+module Network.Wai.Test.Internal where
+
+data ClientState = ClientState
+    { clientCookies :: ClientCookies
+    }

--- a/wai-extra/Network/Wai/Test/Internal.hs
+++ b/wai-extra/Network/Wai/Test/Internal.hs
@@ -1,5 +1,0 @@
-module Network.Wai.Test.Internal where
-
-data ClientState = ClientState
-    { clientCookies :: ClientCookies
-    }

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.19.1
+Version:             3.0.20.0
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -148,6 +148,7 @@ Library
                      Network.Wai.Request
                      Network.Wai.UrlMap
                      Network.Wai.Test
+                     Network.Wai.Test.Internal
                      Network.Wai.EventSource
                      Network.Wai.EventSource.EventStream
   other-modules:     Network.Wai.Middleware.RequestLogger.Internal


### PR DESCRIPTION
We want to keep state between calls to runSession in our tests, but this is not possible without this patch because ClientState is not exported.

In our opinion this is fine for merging, but we are happy to follow any instructions that make it land.

thanks!