### PR TITLE
Document headers required for SSE through Nginx

### DIFF
--- a/wai-extra/Network/Wai/EventSource.hs
+++ b/wai-extra/Network/Wai/EventSource.hs
@@ -1,5 +1,10 @@
 {-|
     A WAI adapter to the HTML5 Server-Sent Events API.
+
+    If running through a proxy like Nginx you might need to add the
+    headers:
+
+    > [ ("X-Accel-Buffering", "no"), ("Cache-Control", "no-cache")]
 -}
 module Network.Wai.EventSource (
     ServerEvent(..),


### PR DESCRIPTION
Add documentation for HTTP headers required when running SSE behind Nginx. This is for instance required when running on AWS and probably for other proxy servers.

I was looking at updating the `app` example, but it is rather badly broken. Does it need to be removed or should I add it to the cabal file and fix it?