### PR TITLE
Cherry-Pick: Fix double `Last-Modified` header on static file requests

### DIFF
--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -187,7 +187,7 @@ serveFile StaticSettings {..} req file
                 | mdate == lastSent -> return NotModified
 
             -- Did not match, but we have a new last-modified header
-            (Just mdate, _) -> respond [("last-modified", formatHTTPDate mdate)]
+            (Just mdate, _) -> respond [("Last-Modified", formatHTTPDate mdate)]
 
             -- No modification time available
             (Nothing, _) -> respond []

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -13,7 +13,7 @@ import Control.Applicative ((<|>))
 import Data.Array ((!))
 import qualified Data.ByteString.Char8 as B (pack)
 import Data.ByteString (ByteString)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Network.HTTP.Date
 import qualified Network.HTTP.Types as H
 import qualified Network.HTTP.Types.Header as H
@@ -39,8 +39,9 @@ conditionalRequest :: I.FileInfo
                    -> RspFileInfo
 conditionalRequest finfo hs0 reqidx = case condition of
     nobody@(WithoutBody _) -> nobody
-    WithBody s _ off len   -> let !hs = (H.hLastModified,date) :
-                                        addContentHeaders hs0 off len size
+    WithBody s _ off len   -> let !hs = if isJust (lookup H.hLastModified hs0)
+                                          then addContentHeaders hs0 off len size
+                                          else (H.hLastModified,date) : addContentHeaders hs0 off len size
                               in WithBody s hs off len
   where
     !mtime = I.fileInfoTime finfo


### PR DESCRIPTION
The `Last-Modified` header is now allowed to be present multiple
times, see:
  https://stackoverflow.com/questions/4371328/are-duplicate-http-response-headers-acceptable

  "So, multiple headers with the same name is ok if the entire
   field-value is defined as a comma-separated list of values."
But `Last-Modified` is not a comma-separated list of values,
see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.29

This header being present twice in responses destroys caching,
at least in Chromium 59 and probably other browsers too.

If the header is present twice, it will leave the `Last-Modified`
column in the Chrome Dev Tools Network tab (you need to add this
column manually via a right-click on the table header) as empty,
and, independent of cache timeouts, will make a request on the next
page load.

(Interestingly, it will also make the request with both dates
separated by a comma, e.g.
  If-Modified-Since: Fri, 21 Jul 2017 15:01:56 GMT, Fri, 21 Jul 2017 15:01:56 GMT
which doesn't seem legal because `If-Modified-Since` isn't a
comma-separated list of values either,
see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25,
but that isn't really our problem; I've filed it as
https://bugs.chromium.org/p/chromium/issues/detail?id=747681.)

The problem was already fixed in commit
  8cc84636b6e38e4cf669eefc258e45221be24c5e
but the fix was undone again in commit
  7b1d0f22a681dfe59d0585dd629ddcb1c414810c
See #580.

Cherry-Picked-From: 8cc84636b6e38e4cf669eefc258e45221be24c5e
Cherry-Picked-By: Niklas Hambüchen <niklas@fpcomplete.com>