### PR TITLE
Add Github issue and PR templates, plus contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!---
+
+### Bug Reports
+
+Reporting a bug? If relevant, we recommend including:
+
+* Your OS name and version
+* The versions of tools you're using (e.g. `stack`, `ghc`).
+* The versions of dependencies you're using
+
+For your convenience, we recommend pasting this script into bash and uploading the output [as a gist](https://gist.github.com/).
+
+```
+command -v sw_vers && sw_vers # OS X only
+command -v uname && uname -a # Kernel version
+command -v stack && stack --version
+command -v stack && stack ghc -- --version
+command -v stack && stack list-dependencies
+```
+
+* Also, is there anything custom or unusual about your setup? i.e. new or prerelease versions of GHC, Stack, etc.
+
+* Finally, if possible, please reproduce the error in a small script, or if necessary create a new Github repo with the smallest possible reproducing case. [Stack's scripting support](https://docs.haskellstack.org/en/stable/GUIDE/#script-interpreter) might be useful for creating your reproduction example.
+
+### Support
+
+Please direct support questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/yesod+haskell) or the [Yesod Google Group](https://groups.google.com/forum/#!forum/yesodweb). If you don't get a response there, or you suspect there may be a bug in Wai causing your problem, you're welcome to ask here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Before submitting your PR, check that you've:
+
+- [ ] Bumped the version number
+- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
+- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
+
+After submitting your PR:
+
+- [ ] Update the Changelog.md file with a link to your PR
+- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
+
+<!---Thanks so much for contributing! :)
+
+_If these checkboxes don't apply to your PR, you can delete them_-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thanks for your interest in contributing to Wai! This file has some tips for developing Wai and getting a pull request accepted.
+
+## Development
+
+Wai is a mega-repo that contains many Haskell packages, each in a different directory. All the subprojects can be developed with Stack, using `stack <command> <subproject>`, e.g.
+
+* `stack build mime-types`
+* `stack test auto-update`
+* `stack haddock warp`
+
+If you'd like to test your changes in a full-fledged Wai app, you can use Stack to build against it, e.g.:
+
+```
+packages:
+- '/path/to/this/repo/wai'
+```
+
+## Coding Guidelines
+
+### Safety
+
+Avoid partial functions. Even if you know the partial function is safe in your instance, partial functions require more reasoning from the programmer and are not resilient to refactoring. For the rare cases where a partial function is appropriate, a custom `error` should be used.
+
+### Style 
+
+Keep coding style consistent with the rest of the file, but don't worry about style too much otherwise. PRs changing code style are viewed skeptically.
+
+### Dependencies
+
+Avoid adding unnecessary dependencies. If a dependency provides only a minor convenience for your implementation, it's probably better to skip it.
+
+If you do add a new dependency, try to support a wide range of versions of it.
+
+### Backwards Compatibility
+
+Backwards incompatible changes are viewed skeptically—best to ask in an issue to see if a particular backwards incompatible change would be approved. If possible keep backwards compatibility by adding new APIs and deprecating old ones.
+
+Keep backwards compatibility with old versions of dependencies when possible.
+
+## PR Guidelines
+
+### PR Scope
+
+As much as possible, keep separate changes in separate PRs.
+
+### Testing
+
+Tests are recommended, but not required.
+
+### Documentation
+
+All public APIs must be documented. Documenting private functions is optional, but may be nice depending on their complexity. Example documentation:
+
+```
+-- | Generate an action which will either read from an automatically
+-- updated value, or run the update action in the current thread.
+--
+-- ==== __Examples__
+--
+-- > getTime <- mkAutoUpdate defaultUpdateSettings
+--
+-- @since 0.1.0
+mkAutoUpdate :: UpdateSettings a -> IO (IO a)
+```
+
+Examples are recommended, but not required, in documentation. Marking new APIs with `@since <version number>` is required.
+
+### Versioning
+
+Wai packages roughly follow the Haskell Package Versioning Policy style of A.B.C.[D] (MAJOR.MAJOR.MINOR.[PATCH])
+
+* A - Used for massive changes in the library. (Example: 1.2.3.4 becomes 2.0.0)
+* B - Used for smaller breaking changes, like removing, renaming, or changing behavior of existing public API. (Example: 1.2.3.4 becomes 1.3.0)
+* C - Used for new public APIs (Example: 1.2.3.4 becomes 1.2.4)
+* D - Used for bug fixes (Example: 1.2.3.4 becomes 1.2.3.5).
+	* D is optional in the version number, so 2.0.0 is a valid version.
+
+Documentation changes don't require a new version.
+
+If you feel there is ambiguity to a change (e.g. fixing a bug in a function, when people may be relying on the old broken behavior), you can ask in an issue or pull request.
+
+Unlike in the Package Versioning Policy, deprecations are not counted as MAJOR changes.
+
+In some cases, dropping compatibility with a major version of a dependency (e.g. changing from transformers >= 0.3 to transformers >= 0.4), is considered a breaking change.
+
+### Changelog
+
+After you submit a PR, update the subproject's Changelog.md file with the new version number and a link to your PR. If your PR does not need to bump the version number, include the change in an "Unreleased" section at the top.
+
+### Releases
+
+Releases should be done as soon as possible after a pull request is merged—don't be shy about reminding us to make a release if we forget.


### PR DESCRIPTION
Hi, I recently made a PR adding Github issue/PR templates, plus basic contributor guidelines to Yesod (See yesodweb/yesod#1450 and yesodweb/yesod#1451). This is that PR slightly adapted for Wai.

I don't contribute to Wai that much, so some guidelines could be different for it, or this PR may be unnecessary entirely.