### PR TITLE
unsetting http?_proxy for testing.

### DIFF
--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -7,6 +7,7 @@ import           Control.Exception
 import           Network.HTTP.Types
 import           Network.Socket
 import           Network.Wai
+import           System.Environment
 import           System.IO
 import           System.IO.Silently
 import           System.Process
@@ -16,6 +17,9 @@ import           Network.Wai.Handler.Warp.WithApplication
 
 spec :: Spec
 spec = do
+  runIO $ do
+      unsetEnv "http_proxy"
+      unsetEnv "https_proxy"
   describe "withApplication" $ do
     it "runs a wai Application while executing the given action" $ do
       let mkApp = return $ \ _request respond -> respond $ responseLBS ok200 [] "foo"


### PR DESCRIPTION
If we set the "http_proxy" env var, `curl` connects to it instead of localhost, resulting test failures. This patch ensures that `curl` does not use proxies.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->