### PR TITLE
Add OverloadedStrings to default-extensions in test-suite

### DIFF
--- a/wai-extra/test/Network/Wai/Middleware/ApprootSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/ApprootSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.ApprootSpec
     ( main
     , spec

--- a/wai-extra/test/Network/Wai/Middleware/ForceSSLSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/ForceSSLSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.ForceSSLSpec
     ( main
     , spec

--- a/wai-extra/test/Network/Wai/Middleware/RoutedSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/RoutedSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.RoutedSpec
     ( main
     , spec

--- a/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.Middleware.StripHeadersSpec
     ( main
     , spec

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.ParseSpec (main, spec) where
 
 import           Test.Hspec

--- a/wai-extra/test/Network/Wai/RequestSpec.hs
+++ b/wai-extra/test/Network/Wai/RequestSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.RequestSpec
     ( main
     , spec

--- a/wai-extra/test/Network/Wai/TestSpec.hs
+++ b/wai-extra/test/Network/Wai/TestSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Network.Wai.TestSpec (main, spec) where
 
 import           Control.Monad (void)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -205,6 +205,7 @@ test-suite spec
                    , time
                    , case-insensitive
     ghc-options:     -Wall
+    default-extensions:        OverloadedStrings
     default-language:          Haskell2010
 
 source-repository head


### PR DESCRIPTION
Busy adding tests for gzip middleware in preparation for some refactoring and adding overloadedstrings to the test suite seemed quite obvious.
