### PR TITLE
Fix `stack bench`

### DIFF
--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -18,7 +18,7 @@ import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Storable
 
-import Gauge
+import Gauge.Main
 
 -- $setup
 -- >>> :set -XOverloadedStrings


### PR DESCRIPTION
This reverts commit 1b59c17ef742add39e7fb3b089644ca75aae80f8, which is titled as fixing the benchmark, but it actually breaks it when running it with `stack`, both at that very same commit and still in the latest HEAD.

That commit apparently requires a new version of the `gauge` package, so alternatively updating the `stack.yaml` to use `nightly-2018-01-21` also solves the issue. The newer `gauge` isn't yet available in any stackage LTS.