### PR TITLE
Add support for windows thread block hack and closeOnExec to TLS.

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -293,7 +293,12 @@ alpn xs
 
 getter :: TLS.TLSParams params => TLSSettings -> Socket -> params -> IO (IO (Connection, Transport), SockAddr)
 getter tlsset@TLSSettings{..} sock params = do
+#if WINDOWS
+    (s, sa) <- windowsThreadBlockHack $ accept sock
+#else
     (s, sa) <- accept sock
+#endif
+    setSocketCloseOnExec s
     return (mkConn tlsset s params, sa)
 
 mkConn :: TLS.TLSParams params => TLSSettings -> Socket -> params -> IO (Connection, Transport)

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.2.4.1
+Version:             3.2.4.2
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE
@@ -30,6 +30,9 @@ Library
                    , tls-session-manager           >= 0.0.0.1
   Exposed-modules:   Network.Wai.Handler.WarpTLS
   ghc-options:       -Wall
+  if os(windows)
+      Cpp-Options:   -DWINDOWS
+
 
 source-repository head
   type:     git

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -64,6 +64,9 @@ module Network.Wai.Handler.Warp.Internal (
   , Source
   , recvRequest
   , sendResponse
+    -- * Platform dependent helper functions
+  , setSocketCloseOnExec
+  , windowsThreadBlockHack
   ) where
 
 import Network.Wai.Handler.Warp.Buffer
@@ -79,3 +82,4 @@ import Network.Wai.Handler.Warp.SendFile
 import Network.Wai.Handler.Warp.Settings
 import Network.Wai.Handler.Warp.Timeout
 import Network.Wai.Handler.Warp.Types
+import Network.Wai.Handler.Warp.Windows

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -522,7 +522,11 @@ wrappedRecvN th istatus slowlorisSize readN bufsize = do
         when (S.length bs >= slowlorisSize || bufsize <= slowlorisSize) $ T.tickle th
     return bs
 
+-- | Set flag FileCloseOnExec flag on a socket (on Unix)
+--
 -- Copied from: https://github.com/mzero/plush/blob/master/src/Plush/Server/Warp.hs
+--
+-- @since 3.2.17
 setSocketCloseOnExec :: Socket -> IO ()
 #if WINDOWS
 setSocketCloseOnExec _ = return ()

--- a/warp/Network/Wai/Handler/Warp/Windows.hs
+++ b/warp/Network/Wai/Handler/Warp/Windows.hs
@@ -10,6 +10,9 @@ import Control.Concurrent
 
 import Network.Wai.Handler.Warp.Imports
 
+-- | Allow main socket listening thread to be interrupted on Windows platform
+--
+-- @since 3.2.17
 windowsThreadBlockHack :: IO a -> IO a
 windowsThreadBlockHack act = do
     var <- newEmptyMVar :: IO (MVar (Either SomeException a))

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.2.16
+Version:             3.2.17
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
(the exposed functions are exposed because
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

On Windows the TLS web server cannot be killed; this is especially problematic if you run it as windows service and it cannot be stopped by normal means. It seems that some things that are done when opening the normal `runSettings` from `warp` are not performed in `runTLS`. This patch sets CloseOnExec flag on the socket and uses the windows hack to let the thread to be killed.