### PR TITLE
drop dependency on blaze-builder

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,7 @@ extra-deps:
 - psqueues-0.2.4.0
 - streaming-commons-0.2.0.0
 - wai-logger-2.3.2
+- http-client-0.5.10.0
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,7 +21,7 @@ extra-deps:
 - wai-logger-2.3.2
 - http-client-0.5.10
 - websockets-0.12.4.0
-- binary-0.9.0.0
+- binary-0.8.5.1
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,7 @@ extra-deps:
 - wai-logger-2.3.2
 - http-client-0.5.10
 - websockets-0.12.4.0
+- binary-0.9.0.0
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - streaming-commons-0.2.0.0
 - wai-logger-2.3.2
 - http-client-0.5.10
+- websockets-0.12.4.0
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - psqueues-0.2.4.0
 - streaming-commons-0.2.0.0
 - wai-logger-2.3.2
-- http-client-0.5.10.0
+- http-client-0.5.10
 nix:
   enable: false
   packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ flags:
   wai-extra:
     build-example: true
 extra-deps:
+- bsb-http-chunked-0
 - tls-session-manager-0.0.0.2
 - psqueues-0.2.4.0
 - streaming-commons-0.2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,6 +16,8 @@ flags:
 extra-deps:
 - tls-session-manager-0.0.0.2
 - psqueues-0.2.4.0
+- streaming-commons-0.2.0.0
+- wai-logger-2.3.2
 nix:
   enable: false
   packages:

--- a/wai-app-static/ChangeLog.md
+++ b/wai-app-static/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.1.6.2
+
+* Drop dependency on blaze-builder
+
 ## 3.1.6.1
 
 * Add `<>` import

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -34,7 +34,7 @@ import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Lazy.Char8 ()
 import Control.Monad.IO.Class (liftIO)
 
-import Blaze.ByteString.Builder (toByteString)
+import Data.ByteString.Builder (toLazyByteString)
 
 import Data.FileEmbed (embedFile)
 
@@ -262,7 +262,7 @@ staticAppPieces ss rawPieces req sendResponse = liftIO $ do
                 ] lbs
 
     response (Redirect pieces' mHash) = do
-            let loc = (ssMkRedirect ss) pieces' $ toByteString (H.encodePathSegments $ map fromPiece pieces')
+            let loc = ssMkRedirect ss pieces' $ L.toStrict $ toLazyByteString (H.encodePathSegments $ map fromPiece pieces')
             let qString = case mHash of
                   Just hash -> replace "etag" (Just hash) (W.queryString req)
                   Nothing   -> remove "etag" (W.queryString req)

--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -8,7 +8,7 @@ import WaiAppStatic.Types
 import Data.ByteString (ByteString)
 import Control.Arrow ((&&&), second)
 import Data.List
-import Blaze.ByteString.Builder (fromByteString)
+import Data.ByteString.Builder (byteString)
 import qualified Network.Wai as W
 import qualified Data.Map as Map
 import Data.Function (on)
@@ -50,7 +50,7 @@ toEntry :: (Piece, EmbeddedEntry) -> Either FolderName File
 toEntry (name, EEFolder{}) = Left name
 toEntry (name, EEFile bs) = Right File
     { fileGetSize = fromIntegral $ S.length bs
-    , fileToResponse = \s h -> W.responseBuilder s h $ fromByteString bs
+    , fileToResponse = \s h -> W.responseBuilder s h $ byteString bs
     , fileName = name
     , fileGetHash = return $ Just $ runHash bs
     , fileGetModified = Nothing
@@ -87,7 +87,7 @@ toEmbedded fps =
 bsToFile :: Piece -> ByteString -> File
 bsToFile name bs = File
     { fileGetSize = fromIntegral $ S.length bs
-    , fileToResponse = \s h -> W.responseBuilder s h $ fromByteString bs
+    , fileToResponse = \s h -> W.responseBuilder s h $ byteString bs
     , fileName = name
     , fileGetHash = return $ Just $ runHash bs
     , fileGetModified = Nothing

--- a/wai-app-static/WaiAppStatic/Storage/Embedded/TH.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/TH.hs
@@ -5,7 +5,7 @@ module WaiAppStatic.Storage.Embedded.TH(
   , mkSettings
 ) where
 
-import Blaze.ByteString.Builder.ByteString (insertByteString)
+import Data.ByteString.Builder.Extra (byteStringInsert)
 import Codec.Compression.GZip (compress)
 import Control.Applicative
 import Data.ByteString.Unsafe (unsafePackAddressLen)
@@ -130,7 +130,7 @@ embeddedToFile entry = File
         let h' = if embCompressed entry
                     then h ++ [("Content-Encoding", "gzip")]
                     else h
-         in W.responseBuilder s h' $ insertByteString $ embContent entry
+         in W.responseBuilder s h' $ byteStringInsert $ embContent entry
 
     -- Usually the fileName should just be the filename not the entire path,
     -- but we need the whole path to make the lookup within lookupMime

--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module WaiAppStatic.Types
     ( -- * Pieces
       Piece
@@ -25,7 +24,7 @@ import qualified Network.Wai as W
 import Data.ByteString (ByteString)
 import System.Posix.Types (EpochTime)
 import qualified Data.Text as T
-import Blaze.ByteString.Builder (Builder)
+import Data.ByteString.Builder (Builder)
 import Network.Mime (MimeType)
 
 -- | An individual component of a path, or of a filepath.

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.6.1
+version:         3.1.6.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -27,7 +27,7 @@ Flag print
 library
     build-depends:   base                      >= 4        && < 5
                    , wai                       >= 3.0      && < 3.3
-                   , bytestring                >= 0.9.1.4
+                   , bytestring                >= 0.10.4
                    , http-types                >= 0.7
                    , transformers              >= 0.2.2
                    , unix-compat               >= 0.2
@@ -37,7 +37,6 @@ library
                    , old-locale                >= 1.0.0.2
                    , file-embed                >= 0.0.3.1
                    , text                      >= 0.7
-                   , blaze-builder             >= 0.2.1.4
                    , cryptonite                >= 0.6
                    , memory                    >= 0.7
                    , http-date
@@ -74,7 +73,7 @@ Executable warp
                , wai-app-static
                , directory       >= 1.0
                , containers      >= 0.2
-               , bytestring      >= 0.9.1.4
+               , bytestring      >= 0.10.4
                , text            >= 0.7
                , mime-types      >= 0.1                && < 0.2
 

--- a/wai-conduit/ChangeLog.md
+++ b/wai-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.0.4
+
+* Drop dependency on blaze-builder
+
 ## 3.0.0.3
 
 * Support wai 3.2

--- a/wai-conduit/Network/Wai/Conduit.hs
+++ b/wai-conduit/Network/Wai/Conduit.hs
@@ -16,7 +16,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as S
 import Control.Monad (unless)
 import Network.HTTP.Types
-import Blaze.ByteString.Builder (Builder)
+import Data.ByteString.Builder (Builder)
 import Data.IORef
 import qualified Data.Conduit.List as CL
 

--- a/wai-conduit/wai-conduit.cabal
+++ b/wai-conduit/wai-conduit.cabal
@@ -18,6 +18,6 @@ library
                      , wai             >= 3.0    && < 3.3
                      , conduit
                      , transformers
-                     , bytestring
+                     , bytestring      >= 0.10.4
                      , http-types
   default-language:    Haskell2010

--- a/wai-conduit/wai-conduit.cabal
+++ b/wai-conduit/wai-conduit.cabal
@@ -1,5 +1,5 @@
 name:                wai-conduit
-version:             3.0.0.3
+version:             3.0.0.4
 synopsis:            conduit wrappers for WAI
 description:         API docs and the README are available at <http://www.stackage.org/package/wai-conduit>.
 homepage:            https://github.com/yesodweb/wai
@@ -20,5 +20,4 @@ library
                      , transformers
                      , bytestring
                      , http-types
-                     , blaze-builder
   default-language:    Haskell2010

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.22.1
+
+* Drop dependency on blaze-builder, requiring streaming-commons >= 0.2
+
 ## 3.0.22.0
 
 * Support for streaming-commons 0.2

--- a/wai-extra/Network/Wai/EventSource/EventStream.hs
+++ b/wai-extra/Network/Wai/EventSource/EventStream.hs
@@ -9,8 +9,7 @@ module Network.Wai.EventSource.EventStream (
     eventToBuilder
     ) where
 
-import Blaze.ByteString.Builder
-import Blaze.ByteString.Builder.Char8
+import Data.ByteString.Builder
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
 #endif
@@ -39,18 +38,18 @@ data ServerEvent
     Newline as a Builder.
 -}
 nl :: Builder
-nl = fromChar '\n'
+nl = char7 '\n'
 
 
 {-|
     Field names as Builder
 -}
 nameField, idField, dataField, retryField, commentField :: Builder
-nameField = fromString "event:"
-idField = fromString "id:"
-dataField = fromString "data:"
-retryField = fromString "retry:"
-commentField = fromChar ':'
+nameField = string7 "event:"
+idField = string7 "id:"
+dataField = string7 "data:"
+retryField = string7 "retry:"
+commentField = char7 ':'
 
 
 {-|
@@ -66,7 +65,7 @@ field l b = l `mappend` b `mappend` nl
 -}
 eventToBuilder :: ServerEvent -> Maybe Builder
 eventToBuilder (CommentEvent txt) = Just $ field commentField txt
-eventToBuilder (RetryEvent   n)   = Just $ field retryField (fromShow n)
+eventToBuilder (RetryEvent   n)   = Just $ field retryField (string8 . show $ n)
 eventToBuilder (CloseEvent)       = Nothing
 eventToBuilder (ServerEvent n i d)= Just $
     (name n $ evid i $ mconcat (map (field dataField) d)) `mappend` nl

--- a/wai-extra/Network/Wai/Handler/CGI.hs
+++ b/wai-extra/Network/Wai/Handler/CGI.hs
@@ -30,7 +30,7 @@ import qualified Data.CaseInsensitive as CI
 import Data.Monoid (mconcat, mempty, mappend)
 #endif
 
-import qualified Data.Streaming.ByteString.Builder as Blaze
+import qualified Data.Streaming.ByteString.Builder as Builder
 import Data.Function (fix)
 import Control.Monad (unless, void)
 
@@ -131,7 +131,7 @@ runGeneric vars inputH outputH xsendfile app = do
                 return ResponseReceived
             _ -> do
                 let (s, hs, wb) = responseToStream res
-                (blazeRecv, blazeFinish) <- Blaze.newBuilderRecv Blaze.defaultStrategy
+                (blazeRecv, blazeFinish) <- Builder.newBuilderRecv Builder.defaultStrategy
                 wb $ \b -> do
                     let sendBuilder builder = do
                             popper <- blazeRecv builder

--- a/wai-extra/Network/Wai/Handler/CGI.hs
+++ b/wai-extra/Network/Wai/Handler/CGI.hs
@@ -19,8 +19,8 @@ import Control.Arrow ((***))
 import Data.Char (toLower)
 import qualified System.IO
 import qualified Data.String as String
-import Blaze.ByteString.Builder (fromByteString, toLazyByteString, flush)
-import Blaze.ByteString.Builder.Char8 (fromChar, fromString)
+import Data.ByteString.Builder (byteString, toLazyByteString, char7, string8)
+import Data.ByteString.Builder.Extra (flush)
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import System.IO (Handle)
 import Network.HTTP.Types (Status (..), hRange, hContentType, hContentLength)
@@ -30,12 +30,7 @@ import qualified Data.CaseInsensitive as CI
 import Data.Monoid (mconcat, mempty, mappend)
 #endif
 
-#if MIN_VERSION_streaming_commons(0, 2, 0)
 import qualified Data.Streaming.ByteString.Builder as Blaze
-#else
-import qualified Data.Streaming.Blaze as Blaze
-#endif
-
 import Data.Function (fix)
 import Control.Monad (unless, void)
 
@@ -136,11 +131,7 @@ runGeneric vars inputH outputH xsendfile app = do
                 return ResponseReceived
             _ -> do
                 let (s, hs, wb) = responseToStream res
-#if MIN_VERSION_streaming_commons(0, 2, 0)
                 (blazeRecv, blazeFinish) <- Blaze.newBuilderRecv Blaze.defaultStrategy
-#else
-                (blazeRecv, blazeFinish) <- Blaze.newBlazeRecv Blaze.defaultStrategy
-#endif
                 wb $ \b -> do
                     let sendBuilder builder = do
                             popper <- blazeRecv builder
@@ -149,30 +140,30 @@ runGeneric vars inputH outputH xsendfile app = do
                                 unless (B.null bs) $ do
                                     outputH bs
                                     loop
-                    sendBuilder $ headers s hs `mappend` fromChar '\n'
+                    sendBuilder $ headers s hs `mappend` char7 '\n'
                     b sendBuilder (sendBuilder flush)
                 blazeFinish >>= maybe (return ()) outputH
                 return ResponseReceived
   where
     headers s hs = mconcat (map header $ status s : map header' (fixHeaders hs))
-    status (Status i m) = (fromByteString "Status", mconcat
-        [ fromString $ show i
-        , fromChar ' '
-        , fromByteString m
+    status (Status i m) = (byteString "Status", mconcat
+        [ string8 $ show i
+        , char7 ' '
+        , byteString m
         ])
-    header' (x, y) = (fromByteString $ CI.original x, fromByteString y)
+    header' (x, y) = (byteString $ CI.original x, byteString y)
     header (x, y) = mconcat
         [ x
-        , fromByteString ": "
+        , byteString ": "
         , y
-        , fromChar '\n'
+        , char7 '\n'
         ]
     sfBuilder s hs sf fp = mconcat
         [ headers s hs
-        , header $ (fromByteString sf, fromString fp)
-        , fromChar '\n'
-        , fromByteString sf
-        , fromByteString " not supported"
+        , header $ (byteString sf, string8 fp)
+        , char7 '\n'
+        , byteString sf
+        , byteString " not supported"
         ]
     fixHeaders h =
         case lookup hContentType h of

--- a/wai-extra/Network/Wai/Header.hs
+++ b/wai-extra/Network/Wai/Header.hs
@@ -14,5 +14,5 @@ contentLength hdrs = lookup H.hContentLength hdrs >>= readInt
 readInt :: S8.ByteString -> Maybe Integer
 readInt bs =
     case S8.readInteger bs of
-        Just (i, "") -> Just i
+        Just (i, rest) | S8.null rest -> Just i
         _ -> Nothing

--- a/wai-extra/Network/Wai/Middleware/Jsonp.hs
+++ b/wai-extra/Network/Wai/Middleware/Jsonp.hs
@@ -18,8 +18,8 @@ import Network.Wai
 import Network.Wai.Internal
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
-import Blaze.ByteString.Builder (copyByteString)
-import Blaze.ByteString.Builder.Char8 (fromChar)
+import Data.ByteString.Builder.Extra (byteStringCopy)
+import Data.ByteString.Builder (char7)
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mappend)
 #endif
@@ -60,10 +60,10 @@ jsonp app env sendResponse = do
         sendResponse $ case checkJSON hs of
             Nothing -> r
             Just hs' -> responseBuilder s hs' $
-                copyByteString c
-                `mappend` fromChar '('
+                byteStringCopy c
+                `mappend` char7 '('
                 `mappend` b
-                `mappend` fromChar ')'
+                `mappend` char7 ')'
     go c r =
         case checkJSON hs of
             Just hs' -> addCallback c s hs' wb
@@ -81,9 +81,9 @@ jsonp app env sendResponse = do
 
     addCallback cb s hs wb =
         wb $ \body -> sendResponse $ responseStream s hs $ \sendChunk flush -> do
-            sendChunk $ copyByteString cb `mappend` fromChar '('
+            sendChunk $ byteStringCopy cb `mappend` char7 '('
             _ <- body sendChunk flush
-            sendChunk $ fromChar ')'
+            sendChunk $ char7 ')'
 
 changeVal :: Eq a
           => a

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -20,7 +20,7 @@ module Network.Wai.Middleware.RequestLogger
     ) where
 
 import System.IO (Handle, hFlush, stdout)
-import qualified Blaze.ByteString.Builder as B
+import qualified Data.ByteString.Builder as B (Builder, byteString)
 import qualified Data.ByteString as BS
 import Data.ByteString.Char8 (pack)
 import Control.Monad (when)
@@ -130,7 +130,7 @@ customMiddlewareWithDetails cb getdate formatter app req sendResponse = do
     t1 <- getCurrentTime
     date <- liftIO getdate
     -- We use Nothing for the response size since we generally don't know it
-    builderIO <- newIORef $ B.fromByteString ""
+    builderIO <- newIORef $ B.byteString ""
     res' <- recordChunks builderIO res
     rspRcv <- sendResponse res'
     _ <- liftIO . cb .

--- a/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
@@ -2,7 +2,8 @@
 
 module Network.Wai.Middleware.RequestLogger.JSON (formatAsJSON) where
 
-import qualified Blaze.ByteString.Builder as BB
+import qualified Data.ByteString.Builder as BB (toLazyByteString)
+import Data.ByteString.Lazy (toStrict)
 import Data.Aeson
 import Data.CaseInsensitive (original)
 import Data.Monoid ((<>))
@@ -31,7 +32,7 @@ formatAsJSON date req status responseSize duration reqBody response =
         , "size"   .= responseSize
         , "body"   .=
           if statusCode status >= 400
-            then Just . decodeUtf8 . BB.toByteString $ response
+            then Just . decodeUtf8 . toStrict . BB.toLazyByteString $ response
             else Nothing
         ]
       , "time"     .= decodeUtf8 date

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -52,8 +52,7 @@ import qualified Data.Map as Map
 import qualified Web.Cookie as Cookie
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S8
-import Blaze.ByteString.Builder (toLazyByteString, toByteString)
-import qualified Blaze.ByteString.Builder as B
+import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Network.HTTP.Types as H
@@ -114,7 +113,7 @@ request = srequest . flip SRequest L.empty
 setPath :: Request -> S8.ByteString -> Request
 setPath req path = req {
     pathInfo = segments
-  , rawPathInfo = B.toByteString (H.encodePathSegments segments)
+  , rawPathInfo = (L8.toStrict . toLazyByteString) (H.encodePathSegments segments)
   , queryString = query
   , rawQueryString = (H.renderQuery True query)
   }
@@ -143,7 +142,7 @@ addCookiesToRequest req = do
   let cookiePairs = [ (Cookie.setCookieName c, Cookie.setCookieValue c)
                     | c <- map snd $ Map.toList cookiesForRequest
                     ]
-  let cookieValue = toByteString $ Cookie.renderCookies cookiePairs
+  let cookieValue = L8.toStrict . toLazyByteString $ Cookie.renderCookies cookiePairs
       addCookieHeader rest
         | null cookiePairs = rest
         | otherwise = ("Cookie", cookieValue) : rest

--- a/wai-extra/example/Main.hs
+++ b/wai-extra/example/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Blaze.ByteString.Builder.Char.Utf8 (fromString)
+import Data.ByteString.Builder (string8)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Chan
 import Control.Monad
@@ -27,15 +27,15 @@ eventChan :: Chan ServerEvent -> IO ()
 eventChan chan = forever $ do
     threadDelay 1000000
     time <- getPOSIXTime
-    writeChan chan (ServerEvent Nothing Nothing [fromString . show $ time])
+    writeChan chan (ServerEvent Nothing Nothing [string8 . show $ time])
 
 eventIO :: IO ServerEvent
 eventIO = do
     threadDelay 1000000
     time <- getPOSIXTime
-    return $ ServerEvent (Just $ fromString "io")
+    return $ ServerEvent (Just $ string8 "io")
                          Nothing
-                         [fromString . show $ time]
+                         [string8 . show $ time]
 
 main :: IO ()
 main = do

--- a/wai-extra/test/Network/Wai/TestSpec.hs
+++ b/wai-extra/test/Network/Wai/TestSpec.hs
@@ -16,12 +16,16 @@ import           Network.Wai.Test
 import           Network.HTTP.Types (status200)
 
 import qualified Data.ByteString.Lazy.Char8 as L8
-import           Blaze.ByteString.Builder (toByteString)
+import           Data.ByteString.Builder (Builder, toLazyByteString)
+import           Data.ByteString (ByteString)
 
 import qualified Web.Cookie as Cookie
 
 main :: IO ()
 main = hspec spec
+
+toByteString :: Builder -> ByteString
+toByteString = L8.toStrict . toLazyByteString
 
 spec :: Spec
 spec = do

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -88,7 +88,7 @@ flag build-example
 
 Library
   Build-Depends:     base                      >= 4.6 && < 5
-                   , bytestring                >= 0.10.2
+                   , bytestring                >= 0.10.4
                    , wai                       >= 3.0.3.0  && < 3.3
                    , old-locale                >= 1.0.0.2  && < 1.1
                    , time                      >= 1.1.4

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -170,6 +170,7 @@ executable example
                      , wai
                      , time
                      , http-types
+                     , bytestring
   else
     buildable: False
   default-language:    Haskell2010

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.22.0
+Version:             3.0.22.1
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:
@@ -88,20 +88,19 @@ flag build-example
 
 Library
   Build-Depends:     base                      >= 4.6 && < 5
-                   , bytestring                >= 0.9.1.4
+                   , bytestring                >= 0.10.2
                    , wai                       >= 3.0.3.0  && < 3.3
                    , old-locale                >= 1.0.0.2  && < 1.1
                    , time                      >= 1.1.4
                    , network                   >= 2.6.1.0
                    , directory                 >= 1.0.1
                    , transformers              >= 0.2.2
-                   , blaze-builder             >= 0.2.1.4  && < 0.5
                    , http-types                >= 0.7
                    , text                      >= 0.7
                    , case-insensitive          >= 0.2
                    , data-default-class
                    , fast-logger               >= 2.4.5    && < 2.5
-                   , wai-logger                >= 2.2.6    && < 2.4
+                   , wai-logger                >= 2.3.2    && < 2.4
                    , ansi-terminal
                    , resourcet                 >= 0.4.6    && < 1.3
                    , void                      >= 0.5
@@ -111,7 +110,7 @@ Library
                    , word8
                    , lifted-base               >= 0.1.2
                    , deepseq
-                   , streaming-commons
+                   , streaming-commons         >= 0.2
                    , unix-compat
                    , cookie
                    , vault
@@ -171,7 +170,6 @@ executable example
                      , wai
                      , time
                      , http-types
-                     , blaze-builder
   else
     buildable: False
   default-language:    Haskell2010
@@ -200,7 +198,6 @@ test-suite spec
                    , resourcet
                    , bytestring
                    , HUnit
-                   , blaze-builder
                    , cookie
                    , time
                    , case-insensitive

--- a/wai-handler-launch/ChangeLog.md
+++ b/wai-handler-launch/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.2.4
+
+* Drop dependency on blaze-builder, requiring streaming-commons >= 0.2
+
 ## 3.0.2.3
 
 * `process` package bump

--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -22,15 +22,15 @@ import Control.Monad (unless)
 import Control.Exception (throwIO)
 import Data.Function (fix)
 import qualified Data.ByteString as S
-import Blaze.ByteString.Builder (fromByteString, Builder, flush)
-import qualified Blaze.ByteString.Builder as Blaze
+import Data.ByteString.Builder (Builder, byteString)
+import qualified Data.ByteString.Builder.Extra as Builder (flush)
 #if WINDOWS
 import Foreign
 import Foreign.C.String
 #else
 import System.Process (rawSystem)
 #endif
-import Data.Streaming.Blaze (newBlazeRecv, defaultStrategy)
+import Data.Streaming.ByteString.Builder as B (newBuilderRecv, defaultStrategy)
 import qualified Data.Streaming.Zlib as Z
 
 ping :: IORef Bool -> Middleware
@@ -60,7 +60,7 @@ decode :: (Builder -> IO ()) -> IO ()
        -> StreamingBody
        -> IO ()
 decode sendInner flushInner streamingBody = do
-    (blazeRecv, blazeFinish) <- newBlazeRecv defaultStrategy
+    (blazeRecv, blazeFinish) <- newBuilderRecv defaultStrategy
     inflate <- Z.initInflate $ Z.WindowBits 31
     let send builder = blazeRecv builder >>= goBuilderPopper
         goBuilderPopper popper = fix $ \loop -> do
@@ -73,15 +73,15 @@ decode sendInner flushInner streamingBody = do
             case res of
                 Z.PRDone -> return ()
                 Z.PRNext bs -> do
-                    sendInner $ fromByteString bs
+                    sendInner $ byteString bs
                     loop
                 Z.PRError e -> throwIO e
-    streamingBody send (send flush)
+    streamingBody send (send Builder.flush)
     mbs <- blazeFinish
     case mbs of
         Nothing -> return ()
         Just bs -> Z.feedInflate inflate bs >>= goZlibPopper
-    Z.finishInflate inflate >>= sendInner . fromByteString
+    Z.finishInflate inflate >>= sendInner . byteString
 
 toInsert :: S.ByteString
 toInsert = "<script>setInterval(function(){var x;if(window.XMLHttpRequest){x=new XMLHttpRequest();}else{x=new ActiveXObject(\"Microsoft.XMLHTTP\");}x.open(\"GET\",\"/_ping?\" + (new Date()).getTime(),true);x.send();},60000)</script>"
@@ -91,7 +91,7 @@ addInsideHead :: (Builder -> IO ())
               -> StreamingBody
               -> IO ()
 addInsideHead sendInner flushInner streamingBody = do
-    (blazeRecv, blazeFinish) <- newBlazeRecv defaultStrategy
+    (blazeRecv, blazeFinish) <- newBuilderRecv defaultStrategy
     ref <- newIORef $ Just (S.empty, whole)
     streamingBody (inner blazeRecv ref) (flush blazeRecv ref)
     state <- readIORef ref
@@ -101,11 +101,11 @@ addInsideHead sendInner flushInner streamingBody = do
         Just bs -> push state bs
     case state of
         Nothing -> return ()
-        Just (held, _) -> sendInner $ fromByteString held `mappend` fromByteString toInsert
+        Just (held, _) -> sendInner $ byteString held `mappend` byteString toInsert
   where
     whole = "<head>"
 
-    flush blazeRecv ref = inner blazeRecv ref Blaze.flush
+    flush blazeRecv ref = inner blazeRecv ref Builder.flush
 
     inner blazeRecv ref builder = do
         state0 <- readIORef ref
@@ -117,23 +117,23 @@ addInsideHead sendInner flushInner streamingBody = do
                     else push state bs >>= loop
         loop state0
 
-    push Nothing x = sendInner (fromByteString x) >> return Nothing
+    push Nothing x = sendInner (byteString x) >> return Nothing
     push (Just (held, atFront)) x
         | atFront `S.isPrefixOf` x = do
             let y = S.drop (S.length atFront) x
-            sendInner $ fromByteString held
-              `mappend` fromByteString atFront
-              `mappend` fromByteString toInsert
-              `mappend` fromByteString y
+            sendInner $ byteString held
+              `mappend` byteString atFront
+              `mappend` byteString toInsert
+              `mappend` byteString y
             return Nothing
         | whole `S.isInfixOf` x = do
             let (before, rest) = S.breakSubstring whole x
             let after = S.drop (S.length whole) rest
-            sendInner $ fromByteString held
-              `mappend` fromByteString before
-              `mappend` fromByteString whole
-              `mappend` fromByteString toInsert
-              `mappend` fromByteString after
+            sendInner $ byteString held
+              `mappend` byteString before
+              `mappend` byteString whole
+              `mappend` byteString toInsert
+              `mappend` byteString after
             return Nothing
         | x `S.isPrefixOf` atFront = do
             let held' = held `S.append` x
@@ -141,7 +141,7 @@ addInsideHead sendInner flushInner streamingBody = do
             return $ Just (held', atFront')
         | otherwise = do
             let (held', atFront', x') = getOverlap whole x
-            sendInner $ fromByteString held `mappend` fromByteString x'
+            sendInner $ byteString held `mappend` byteString x'
             return $ Just (held', atFront')
 
 getOverlap :: S.ByteString -> S.ByteString -> (S.ByteString, S.ByteString, S.ByteString)
@@ -204,6 +204,7 @@ runHostPortUrl host port url app = do
           Warp.setHost (fromString host) $
           Warp.setBeforeMainLoop (putMVar ready ()) $
           Warp.defaultSettings
+    -}
     -- Run these threads concurrently; when either one terminates or
     -- raises an exception, the same happens to the other.
     fmap (either id id) $ race

--- a/wai-handler-launch/Network/Wai/Handler/Launch.hs
+++ b/wai-handler-launch/Network/Wai/Handler/Launch.hs
@@ -204,7 +204,6 @@ runHostPortUrl host port url app = do
           Warp.setHost (fromString host) $
           Warp.setBeforeMainLoop (putMVar ready ()) $
           Warp.defaultSettings
-    -}
     -- Run these threads concurrently; when either one terminates or
     -- raises an exception, the same happens to the other.
     fmap (either id id) $ race

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -18,7 +18,7 @@ Library
                    , warp                    >= 3.0     && < 3.3
                    , http-types              >= 0.7
                    , transformers            >= 0.2.2
-                   , bytestring              >= 0.10.2
+                   , bytestring              >= 0.10.4
                    , streaming-commons       >= 0.2
                    , async
 

--- a/wai-handler-launch/wai-handler-launch.cabal
+++ b/wai-handler-launch/wai-handler-launch.cabal
@@ -1,5 +1,5 @@
 Name:                wai-handler-launch
-Version:             3.0.2.3
+Version:             3.0.2.4
 Synopsis:            Launch a web app in the default browser.
 description:         API docs and the README are available at <http://www.stackage.org/package/wai-handler-launch>.
 License:             MIT
@@ -18,9 +18,8 @@ Library
                    , warp                    >= 3.0     && < 3.3
                    , http-types              >= 0.7
                    , transformers            >= 0.2.2
-                   , bytestring              >= 0.9.1.4
-                   , blaze-builder           >= 0.2.1.4 && < 0.5
-                   , streaming-commons
+                   , bytestring              >= 0.10.2
+                   , streaming-commons       >= 0.2
                    , async
 
     if os(windows)

--- a/wai-websockets/ChangeLog.md
+++ b/wai-websockets/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.1.2
+
+* Drop unused dependency on blaze-builder
+
 ## 3.0.1.1
 
 * Doc improvement

--- a/wai-websockets/wai-websockets.cabal
+++ b/wai-websockets/wai-websockets.cabal
@@ -1,5 +1,5 @@
 Name:                wai-websockets
-Version:             3.0.1.1
+Version:             3.0.1.2
 Synopsis:            Provide a bridge between WAI and the websockets package.
 License:             MIT
 License-file:        LICENSE
@@ -21,7 +21,6 @@ Library
   Build-Depends:     base               >= 3        && < 5
                    , bytestring         >= 0.9.1.4
                    , wai                >= 3.0      && < 3.3
-                   , blaze-builder      >= 0.2.1.4  && < 0.5
                    , case-insensitive   >= 0.2
                    , network            >= 2.2.1.5
                    , transformers       >= 0.2
@@ -41,7 +40,6 @@ Executable           wai-websockets-example
                    , wai-app-static
                    , bytestring
                    , case-insensitive
-                   , blaze-builder
                    , transformers
                    , network
                    , text

--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.2.1.2
+
+* Drop dependency on blaze-builder
+
 ## 3.2.1.1
 
 * Relax upper bound on bytestring-builder

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -91,7 +91,6 @@ import qualified Data.ByteString.Lazy.Internal as LI
 import           Data.ByteString.Lazy.Internal (defaultChunkSize)
 import           Data.ByteString.Lazy.Char8   ()
 import           Data.Function                (fix)
-import           Data.Monoid                  (mempty)
 import qualified Network.HTTP.Types           as H
 import           Network.Socket               (SockAddr (SockAddrInet))
 import           Network.Wai.Internal

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -83,8 +83,7 @@ module Network.Wai
     , modifyResponse
     ) where
 
-import           Blaze.ByteString.Builder     (Builder, fromLazyByteString)
-import           Blaze.ByteString.Builder     (fromByteString)
+import           Data.ByteString.Builder      (Builder, byteString, lazyByteString)
 import           Control.Monad                (unless)
 import qualified Data.ByteString              as B
 import qualified Data.ByteString.Lazy         as L
@@ -134,7 +133,7 @@ responseBuilder = ResponseBuilder
 -- | Creating 'Response' from 'L.ByteString'. This is a wrapper for
 --   'responseBuilder'.
 responseLBS :: H.Status -> H.ResponseHeaders -> L.ByteString -> Response
-responseLBS s h = ResponseBuilder s h . fromLazyByteString
+responseLBS s h = ResponseBuilder s h . lazyByteString
 
 -- | Creating 'Response' from a stream of values.
 --
@@ -148,9 +147,9 @@ responseLBS s h = ResponseBuilder s h . fromLazyByteString
 --     (putStrLn \"Allocating scarce resource\")
 --     (putStrLn \"Cleaning up\")
 --     $ respond $ responseStream status200 [] $ \\write flush -> do
---         write $ fromByteString \"Hello\\n\"
+--         write $ byteString \"Hello\\n\"
 --         flush
---         write $ fromByteString \"World\\n\"
+--         write $ byteString \"World\\n\"
 -- @
 --
 -- Note that in some cases you can use @bracket@ from inside @responseStream@
@@ -213,7 +212,7 @@ responseToStream (ResponseFile s h fp (Just part)) =
                 bs <- B.hGetSome handle defaultChunkSize
                 unless (B.null bs) $ do
                     let x = B.take remaining bs
-                    sendChunk $ fromByteString x
+                    sendChunk $ byteString x
                     loop $ remaining - B.length x
         loop $ fromIntegral $ filePartByteCount part
     )
@@ -224,7 +223,7 @@ responseToStream (ResponseFile s h fp Nothing) =
        withBody $ \sendChunk _flush -> fix $ \loop -> do
             bs <- B.hGetSome handle defaultChunkSize
             unless (B.null bs) $ do
-                sendChunk $ fromByteString bs
+                sendChunk $ byteString bs
                 loop
     )
 responseToStream (ResponseBuilder s h b) =

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -4,8 +4,8 @@ This module defines a generic web application interface. It is a common
 protocol between web servers and web applications.
 
 The overriding design principles here are performance and generality. To
-address performance, this library is built on top of the conduit and
-blaze-builder packages.  The advantages of conduits over lazy IO have been
+address performance, this library is built on top of the conduit package and
+bytestring's Builder type.  The advantages of conduits over lazy IO have been
 debated elsewhere and so will not be addressed here.  However, helper functions
 like 'responseLBS' allow you to continue using lazy IO if you so desire.
 
@@ -119,13 +119,13 @@ responseFile = ResponseFile
 --
 -- A2. No. If the ByteStrings are small, then they will be copied into a larger
 -- buffer, which should be a performance gain overall (less system calls). If
--- they are already large, then blaze-builder uses an InsertByteString
--- instruction to avoid copying.
+-- they are already large, then an insert operation is used
+-- to avoid copying.
 --
 -- Q3. Doesn't this prevent us from creating comet-style servers, since data
 -- will be cached?
 --
--- A3. You can force blaze-builder to output a ByteString before it is an
+-- A3. You can force a Builder to output a ByteString before it is an
 -- optimal size by sending a flush command.
 responseBuilder :: H.Status -> H.ResponseHeaders -> Builder -> Response
 responseBuilder = ResponseBuilder

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -5,7 +5,7 @@
 -- given for stability of these interfaces.
 module Network.Wai.Internal where
 
-import           Blaze.ByteString.Builder     (Builder)
+import           Data.ByteString.Builder      (Builder)
 import qualified Data.ByteString              as B hiding (pack)
 import           Data.Text                    (Text)
 import           Data.Typeable                (Typeable)

--- a/wai/test/Network/WaiSpec.hs
+++ b/wai/test/Network/WaiSpec.hs
@@ -4,7 +4,6 @@ import Test.Hspec
 import Test.Hspec.QuickCheck (prop)
 import Network.Wai
 import Data.IORef
-import Data.Monoid
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Builder (Builder, toLazyByteString, word8)

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -2,7 +2,8 @@ Name:                wai
 Version:             3.2.1.2
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
-description:         API docs and the README are available at <http://www.stackage.org/package/wai>.
+                     .
+                     API docs and the README are available at <http://www.stackage.org/package/wai>.
 License:             MIT
 License-file:        LICENSE
 Author:              Michael Snoyman
@@ -41,6 +42,7 @@ test-suite test
                   , hspec
                   , bytestring
     other-modules:  Network.WaiSpec
+    build-tool-depends: hspec-discover:hspec-discover
 
 source-repository head
   type:     git

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -20,7 +20,7 @@ Source-repository head
 
 Library
   Build-Depends:     base                      >= 4.8      && < 5
-                   , bytestring                >= 0.10.2
+                   , bytestring                >= 0.10.4
                    , network                   >= 2.2.1.5
                    , http-types                >= 0.7
                    , text                      >= 0.7

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,5 +1,5 @@
 Name:                wai
-Version:             3.2.1.1
+Version:             3.2.1.2
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
 description:         API docs and the README are available at <http://www.stackage.org/package/wai>.
@@ -20,8 +20,7 @@ Source-repository head
 
 Library
   Build-Depends:     base                      >= 4.8      && < 5
-                   , bytestring                >= 0.10
-                   , blaze-builder             >= 0.2.1.4  && < 0.5
+                   , bytestring                >= 0.10.2
                    , network                   >= 2.2.1.5
                    , http-types                >= 0.7
                    , text                      >= 0.7
@@ -40,7 +39,6 @@ test-suite test
     build-depends:  base >= 4.8 && < 5
                   , wai
                   , hspec
-                  , blaze-builder
                   , bytestring
     other-modules:  Network.WaiSpec
 

--- a/wai/webkit-sample/webkit-sample.hs
+++ b/wai/webkit-sample/webkit-sample.hs
@@ -5,7 +5,7 @@ import Network.Wai.Handler.Webkit
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as L
 import Data.Enumerator (consume, Iteratee)
-import Blaze.ByteString.Builder (fromLazyByteString)
+import Data.ByteString.Builder (lazyByteString)
 
 main :: IO ()
 main = putStrLn "http://localhost:3000/" >> run "Webkit Sample" app
@@ -27,4 +27,4 @@ postResponse :: L.ByteString -> Iteratee ByteString IO Response
 postResponse lbs = return $ ResponseBuilder
     status200
     [("Content-Type", "text/plain")]
-    (fromLazyByteString lbs)
+    (lazyByteString lbs)

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.2.18.2
+
+* Replace dependency on `blaze-builder` with `bsb-http-chunked`
+
 ## 3.2.18.1
 
 * Fix benchmark compilation [#681](https://github.com/yesodweb/wai/issues/681)

--- a/warp/Network/Wai/Handler/Warp/MultiMap.hs
+++ b/warp/Network/Wai/Handler/Warp/MultiMap.hs
@@ -15,6 +15,7 @@ import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as I
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup
+import Prelude -- Silence redundant import warnings
 
 import Network.Wai.Handler.Warp.Imports hiding ((<>), union, empty, insert)
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -13,7 +13,7 @@ module Network.Wai.Handler.Warp.Response (
   , addServer -- testing
   ) where
 
-import Blaze.ByteString.Builder.HTTP (chunkedTransferEncoding, chunkedTransferTerminator)
+import Data.ByteString.Builder.HTTP.Chunked (chunkedTransferEncoding, chunkedTransferTerminator)
 import qualified Control.Exception as E
 import Data.Array ((!))
 import qualified Data.ByteString as S

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -211,7 +211,7 @@ Test-Suite spec
                    , word8
                    , hashable
                    , http-date
-    Build-Tool-Depends: hspec-discover:hspec-discover
+    -- Build-Tool-Depends: hspec-discover:hspec-discover
   if impl(ghc < 8)
       Build-Depends: semigroups
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.2.18.1
+Version:             3.2.18.2
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE
@@ -37,7 +37,7 @@ Library
                    , array
                    , async
                    , auto-update               >= 0.1.3    && < 0.2
-                   , blaze-builder             >= 0.4
+                   , bsb-http-chunked                         < 0.1
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2
                    , containers
@@ -181,7 +181,7 @@ Test-Suite spec
     Build-Depends:   base >= 4.8 && < 5
                    , array
                    , auto-update
-                   , blaze-builder             >= 0.4
+                   , bsb-http-chunked                         < 0.1
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2
                    , ghc-prim
@@ -211,6 +211,7 @@ Test-Suite spec
                    , word8
                    , hashable
                    , http-date
+    Build-Tool-Depends: hspec-discover:hspec-discover
   if impl(ghc < 8)
       Build-Depends: semigroups
 


### PR DESCRIPTION
Dependency on `blaze-builder` is dropped where there's a straightforward way to do so. This PR adresses the packages `wai`, `wai-extra`, `wai-conduit` and `wai-handler-launch`.

* Version numbers are bumped, changelogs updated
* There are no API changes. Test suites all pass.
