### PR TITLE
Atomically recv() wrt. capturing errno

### DIFF
--- a/warp/cbits/warp.c
+++ b/warp/cbits/warp.c
@@ -1,0 +1,15 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+
+#include <stdio.h>
+
+#include "warp.h"
+
+ssize_t warp_recv(int fd, void* buf, size_t len, int flags) {
+  ssize_t bytes = recv(fd, buf, len, flags);
+  if (bytes == -1) {
+    return -errno;
+  }
+  return bytes;
+}

--- a/warp/cbits/warp.h
+++ b/warp/cbits/warp.h
@@ -1,0 +1,6 @@
+#ifndef WARP_H
+#define WARP_H
+
+ssize_t warp_recv(int fd, void* buf, size_t len, int flags);
+
+#endif

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -102,6 +102,9 @@ Library
                      Paths_warp
   Ghc-Options:       -Wall
 
+  C-Sources:         cbits/warp.c
+  Include-Dirs:      cbits
+
   if flag(warp-debug)
       Cpp-Options:   -DWARP_DEBUG
   if (os(linux) || os(freebsd) || os(darwin)) && flag(allow-sendfilefd)


### PR DESCRIPTION
Hi there, consider this a (basic) question with some code attached.

Concurrent Haskell code that manually checks `errno` after a foreign call seems broken to me, since `errno` it is shared among all threads on an OS thread (though I believe GHC does carry it around in the TSO for migrating threads).

For example, the code in `recvloop` reads:

```haskell
do bytes <- c_recv
   -- (1)
   if bytes == -1
     then do
       -- (2)
       errno <- getErrno
       if errno == eAGAIN
         then loop
         else throw errno
   else success
```   

It's possible that between `(1)` and `(2)`, some other foreign call is scheduled and clobbers our `errno`.

So, in this patch I've simply swapped out `recv` for a custom version that returns `-errno` instead of `-1` on error. That way, the foreign call "atomically" captures `errno` since no Haskell thread can be sneakily scheduled on the same OS thread between `(1)` and `(2)` below, both in C:

```c
my_recv() {
  result := recv()
  // (1)
  if (result == -1) {
    // (2)
    return -errno
  } else {
    return result
  }
```

Am I right about this? Thanks for looking.