### PR TITLE
Add rewriteRoot middleware

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Rewrite.hs
+++ b/wai-extra/Network/Wai/Middleware/Rewrite.hs
@@ -27,6 +27,7 @@ module Network.Wai.Middleware.Rewrite
       -- ** Recommended functions
     , rewriteWithQueries
     , rewritePureWithQueries
+    , rewriteRoot
 
       -- ** Deprecated
     , rewrite
@@ -262,6 +263,19 @@ rewriteWithQueries convert app req sendResponse = do
 rewritePureWithQueries :: (PathsAndQueries -> H.RequestHeaders -> PathsAndQueries)
                        -> Middleware
 rewritePureWithQueries convert app req = app $ rewriteRequestPure convert req
+
+-- | Rewrite root requests (/) to a specified path
+--
+-- Note that /index.html/ in example below should already be a valid route.
+--
+-- @
+--     rewriteRoot "index.html" :: Middleware
+-- @
+rewriteRoot :: Text -> Middleware
+rewriteRoot root = rewritePureWithQueries onlyRoot
+  where
+    onlyRoot ([], q) _ = ([root], q)
+    onlyRoot paths _ = paths
 
 --------------------------------------------------
 -- * Modifying 'Request's directly


### PR DESCRIPTION
Added a small convenience function to rewrite a request to root. It is common enough that other web servers often include it.

I often use it when serving index.html (which includes single page app) as a static file out of my 'static' directory in a servant application.

I did not update changelog or do version bump, since such a small addition, but happy to do so if desired.