### PR TITLE
Consider quoted multipart form boundary markers

### DIFF
--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -331,6 +331,9 @@ parseContentType a = do
     semicolon = 59
     equals = 61
     space = 32
+    dq s = if S.length s > 2 && S.head s == 34 && S.last s == 34 -- quote
+                then S.tail $ S.init s
+                else s
     goAttrs front bs
         | S.null bs = front []
         | otherwise =
@@ -339,7 +342,7 @@ parseContentType a = do
     goAttr bs =
         let (k, v') = S.break (== equals) bs
             v = S.drop 1 v'
-         in (strip k, strip v)
+         in (strip k, dq $ strip v)
     strip = S.dropWhile (== space) . fst . S.breakEnd (/= space)
 
 -- | Parse the body of an HTTP request.

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -30,6 +30,7 @@ spec = do
             [ ("text/plain", "text/plain", [])
             , ("text/plain; charset=UTF-8 ", "text/plain", [("charset", "UTF-8")])
             , ("text/plain; charset=UTF-8 ; boundary = foo", "text/plain", [("charset", "UTF-8"), ("boundary", "foo")])
+            , ("text/plain; charset=UTF-8 ; boundary = \"quoted\"", "text/plain", [("charset", "UTF-8"), ("boundary", "quoted")])
             ]
     it "parseHttpAccept" caseParseHttpAccept
     describe "parseRequestBody" $ do


### PR DESCRIPTION
I didn't read you rulelist. Here is some code.