### PR TITLE
Add Middleware.Timeout

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.24.0
+
+* Add timeout middleware [#702](https://github.com/yesodweb/wai/pull/702).
+
 ## 3.0.23.0
 
 * Add rewriteRoot middleware [#697](https://github.com/yesodweb/wai/pull/697).

--- a/wai-extra/Network/Wai/Middleware/Timeout.hs
+++ b/wai-extra/Network/Wai/Middleware/Timeout.hs
@@ -1,0 +1,31 @@
+-- | Timeout requests
+--
+-- @since X.X.X@
+--
+module Network.Wai.Middleware.Timeout
+    ( timeout
+    , timeoutStatus
+    , timeoutAs
+    ) where
+
+import Network.HTTP.Types (Status, status503)
+import Network.Wai
+import qualified System.Timeout as Timeout
+
+-- | Time out the request after the given number of seconds
+--
+-- Timeouts respond with @'status503'@. See @'timeoutStatus'@ or @'timeoutAs'@
+-- to customize the behavior of the timed-out case.
+--
+timeout :: Int -> Middleware
+timeout = timeoutStatus status503
+
+-- | Time out with the given @'Status'@
+timeoutStatus :: Status -> Int -> Middleware
+timeoutStatus status = timeoutAs $ responseLBS status [] ""
+
+-- | Time out with the given @'Response'@
+timeoutAs :: Response -> Int -> Middleware
+timeoutAs timeoutReponse seconds app req respond =
+    maybe (respond timeoutReponse) pure
+        =<< Timeout.timeout (seconds * 1000000) (app req respond)

--- a/wai-extra/Network/Wai/Middleware/Timeout.hs
+++ b/wai-extra/Network/Wai/Middleware/Timeout.hs
@@ -1,7 +1,4 @@
 -- | Timeout requests
---
--- @since X.X.X@
---
 module Network.Wai.Middleware.Timeout
     ( timeout
     , timeoutStatus
@@ -17,14 +14,19 @@ import qualified System.Timeout as Timeout
 -- Timeouts respond with @'status503'@. See @'timeoutStatus'@ or @'timeoutAs'@
 -- to customize the behavior of the timed-out case.
 --
+-- @since 3.0.24.0@
 timeout :: Int -> Middleware
 timeout = timeoutStatus status503
 
 -- | Time out with the given @'Status'@
+--
+-- @since 3.0.24.0@
 timeoutStatus :: Status -> Int -> Middleware
 timeoutStatus status = timeoutAs $ responseLBS status [] ""
 
 -- | Time out with the given @'Response'@
+--
+-- @since 3.0.24.0@
 timeoutAs :: Response -> Int -> Middleware
 timeoutAs timeoutReponse seconds app req respond =
     maybe (respond timeoutReponse) pure

--- a/wai-extra/test/Network/Wai/Middleware/TimeoutSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/TimeoutSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.Wai.Middleware.TimeoutSpec
+    ( spec
+    ) where
+
+import Test.Hspec
+
+import Control.Concurrent (threadDelay)
+import Network.HTTP.Types (status200, status503, status504)
+import Network.Wai
+import Network.Wai.Middleware.Timeout
+import Network.Wai.Test
+
+spec :: Spec
+spec = do
+    describe "timeout" $ do
+        it "times out slow requests with 503" $ do
+            let app _req respond = do
+                    threadDelay $ 2 * 1000000
+                    respond $ responseLBS status200 [] ""
+
+            resp <- runApp $ timeout 1 app
+
+            simpleStatus resp `shouldBe` status503
+
+        it "does not time out fast requests" $ do
+            let app _req respond = respond $ responseLBS status200 [] ""
+
+            resp <- runApp $ timeout 3 app
+
+            simpleStatus resp `shouldBe` status200
+
+    describe "timeoutStatus" $ do
+        it "allows customizing the timeout response status" $ do
+            let app _req respond = do
+                    threadDelay $ 2 * 1000000
+                    respond $ responseLBS status200 [] ""
+
+            resp <- runApp $ timeoutStatus status504 1 app
+
+            simpleStatus resp `shouldBe` status504
+
+    describe "timeoutAs" $ do
+        it "allows customizing the timeout response" $ do
+            let app _req respond = do
+                    threadDelay $ 2 * 1000000
+                    respond $ responseLBS status200 [] ""
+                timeoutResponse = responseLBS status503 [("X-Timeout", "1")] ""
+
+            resp <- runApp $ timeoutAs timeoutResponse 1 app
+
+            simpleStatus resp `shouldBe` status503
+            simpleHeaders resp `shouldBe` [("X-Timeout", "1")]
+
+runApp :: Application -> IO SResponse
+runApp = runSession $ request defaultRequest

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.23.0
+Version:             3.0.24.0
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -148,6 +148,7 @@ Library
                      Network.Wai.Middleware.ForceDomain
                      Network.Wai.Middleware.ForceSSL
                      Network.Wai.Middleware.Routed
+                     Network.Wai.Middleware.Timeout
                      Network.Wai.Parse
                      Network.Wai.Request
                      Network.Wai.UrlMap
@@ -186,6 +187,7 @@ test-suite spec
                      Network.Wai.Middleware.ForceSSLSpec
                      Network.Wai.Middleware.RoutedSpec
                      Network.Wai.Middleware.StripHeadersSpec
+                     Network.Wai.Middleware.TimeoutSpec
                      WaiExtraSpec
     build-depends:   base                      >= 4        && < 5
                    , wai-extra


### PR DESCRIPTION
See #701.

Wraps the inner `respond` in `System.Timeout.timeout` with the given seconds
and, by default, responds `status503`. The main `timeout` is implemented in
terms of `timeoutStatus` for customizing only the response status, which is
itself implemented in terms of `timeoutAs`, for customizing the `Response`
entirely.

Some things I'm not sure of:

1. `timeout` is a bit of a bold name, but it seems in line with how all
   `Middleware`s name themselves: assuming a very narrow context
1. Is `timeoutStatus` useful, or is just `timeout`/`timeoutAs` enough?
1. If we keep `timeoutStatus`, should `timeoutAs` be named `timeoutResponse`,
   which feels more consistent?
1. Should we accept microseconds directly? Is there ever a use-case for a
   timeout smaller than one second? (it would be nice to not have to wait an
   entire second for each of the spec examples)

Any other tweaks or style changes, don't hesitate to let me know.