### PR TITLE
Use return rather than pure for GHC 7.8 compatibility

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Timeout.hs
+++ b/wai-extra/Network/Wai/Middleware/Timeout.hs
@@ -29,5 +29,5 @@ timeoutStatus status = timeoutAs $ responseLBS status [] ""
 -- @since 3.0.24.0@
 timeoutAs :: Response -> Int -> Middleware
 timeoutAs timeoutReponse seconds app req respond =
-    maybe (respond timeoutReponse) pure
+    maybe (respond timeoutReponse) return
         =<< Timeout.timeout (seconds * 1000000) (app req respond)


### PR DESCRIPTION
Introduced in wai-extra-3.0.24.0 this breaks building on 7.8.4.
I noticed that the Travis CI doesn't include 7.8.4 anymore so if it's not supported let me know.