### PR TITLE
lenient UTF-8 decoding in JSON logging

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.0.24.2
+
+* Don't raise exceptions in `formatAsJSON` [#709](https://github.com/yesodweb/wai/pull/709)
+
 ## 3.0.24.1
 
 * Fix a "file not found" exception in wai-extra [#705](https://github.com/yesodweb/wai/pull/706)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.24.1
+Version:             3.0.24.2
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
I think `formatAsJSON` is more useful if it doesn't throw exceptions, even on invalid UTF-8.  This PR makes it insert the Unicode replacement character U+FFFD instead of raising an exception.  The changes in this PR meet my needs, but I can think of several other variations that would also:

- if we can't decode to UTF-8, don't log that piece of text
- log the `DecodeError`
- provide both versions
- parameterize on `OnDecodeError`

Do you like this version?  Would you prefer some other variant?  Is there a reason to prefer the exception-throwing version?

Before submitting your PR, check that you've:

- [X] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->