### PR TITLE
Add mjs mime type

### DIFF
--- a/mime-types/ChangeLog.md
+++ b/mime-types/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.0.9
+
+* Add mjs mime type
+
 ## 0.1.0.8
 
 * Add wasm mime type

--- a/mime-types/Network/Mime.hs
+++ b/mime-types/Network/Mime.hs
@@ -531,6 +531,7 @@ defaultMimeMap = Map.fromAscList [
     , ("mime", "message/rfc822")
     , ("mj2", "video/mj2")
     , ("mjp2", "video/mj2")
+    , ("mjs", "application/javascript")
     , ("mk3d", "video/x-matroska")
     , ("mka", "audio/x-matroska")
     , ("mks", "video/x-matroska")

--- a/mime-types/mime-types.cabal
+++ b/mime-types/mime-types.cabal
@@ -1,5 +1,5 @@
 name:                mime-types
-version:             0.1.0.8
+version:             0.1.0.9
 synopsis:            Basic mime-type handling types and functions
 description:         API docs and the README are available at <http://www.stackage.org/package/mime-types>.
 homepage:            https://github.com/yesodweb/wai


### PR DESCRIPTION
This PR adds default mime type for `.mjs` files. They are JavaScript modules, and browsers enforce strict MIME checking on them.