### PR TITLE
Deprecate requestBody

### DIFF
--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.2.2
+
+* Deprecate `requestBody` in favor of the more clearly named `getRequestBodyChunk`. [#726](https://github.com/yesodweb/wai/pull/726)
+
 ## 3.2.1.2
 
 * Remove dependency on blaze-builder [#683](https://github.com/yesodweb/wai/pull/683)

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -33,6 +33,8 @@ include:
 [wai-test] <http://hackage.haskell.org/package/wai-test>
 
 -}
+-- Ignore deprecations, because this module needs to use the deprecated requestBody to construct a response.
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 module Network.Wai
     (
       -- * Types
@@ -325,7 +327,7 @@ strictRequestBody req =
     loop id
   where
     loop front = do
-        bs <- requestBody req
+        bs <- getRequestBodyChunk req
         if B.null bs
             then return $ front LI.Empty
             else loop (front . LI.Chunk bs)
@@ -339,7 +341,7 @@ lazyRequestBody req =
     loop
   where
     loop = unsafeInterleaveIO $ do
-        bs <- requestBody req
+        bs <- getRequestBodyChunk req
         if B.null bs
             then return LI.Empty
             else do

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -17,6 +17,7 @@ import           Data.List                    (intercalate)
 
 -- | Information on the request sent by the client. This abstracts away the
 -- details of the underlying implementation.
+{-# DEPRECATED requestBody "requestBody's name is misleading because it only gets a partial chunk of the body. Use getRequestBodyChunk instead." #-}
 data Request = Request {
   -- | Request method such as GET.
      requestMethod        :: H.Method
@@ -62,7 +63,7 @@ data Request = Request {
   -- | Parsed query string information.
   ,  queryString          :: H.Query
   -- | Get the next chunk of the body. Returns 'B.empty' when the
-  -- body is fully consumed.
+  -- body is fully consumed. Since 3.2.2, this is deprecated in favor of 'getRequestBodyChunk'.
   ,  requestBody          :: IO B.ByteString
   -- | A location for arbitrary data to be shared by applications and middleware.
   ,  vault                 :: Vault
@@ -89,6 +90,13 @@ data Request = Request {
   ,  requestHeaderUserAgent :: Maybe B.ByteString
   }
   deriving (Typeable)
+
+-- | Get the next chunk of the body. Returns 'B.empty' when the
+-- body is fully consumed.
+--
+-- @since 3.2.2
+getRequestBodyChunk :: Request -> IO B.ByteString
+getRequestBodyChunk = requestBody
 
 instance Show Request where
     show Request{..} = "Request {" ++ intercalate ", " [a ++ " = " ++ b | (a,b) <- fields] ++ "}"

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,5 +1,5 @@
 Name:                wai
-Version:             3.2.1.2
+Version:             3.2.2
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
                      .


### PR DESCRIPTION
Closes #669

This implements the deprecation proposed in #669.

One thing to check: is a non-breaking version bump OK? I don't consider this a breaking change, but iirc the PVP does because people could be building with -Werror.

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->