### PR TITLE
warp: Use -h option to actually bind to the host

### DIFF
--- a/wai-app-static/ChangeLog.md
+++ b/wai-app-static/ChangeLog.md
@@ -1,3 +1,9 @@
+## 3.1.6.3
+
+* The executable warp obeys `-h` option properly for host
+now. Previously this used to invoke the help option. That can be
+reached via `--help` as before.
+
 ## 3.1.6.2
 
 * Drop dependency on blaze-builder

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -93,7 +93,7 @@ args = Args
 -- Since 2.0.1
 runCommandLine :: (Args -> Middleware) -> IO ()
 runCommandLine middleware = do
-    args@Args {..} <- execParser $ info (helper <*> args) fullDesc
+    args@Args {..} <- execParser $ info (helperOption <*> args) fullDesc
     let mime' = map (pack *** S8.pack) mime
     let mimeMap = Map.fromList mime' `Map.union` defaultMimeMap
     docroot' <- canonicalizePath docroot
@@ -110,3 +110,8 @@ runCommandLine middleware = do
         { ssIndices = if noindex then [] else mapMaybe (toPiece . pack) index
         , ssGetMimeType = return . mimeByExt mimeMap defaultMimeType . fromPiece . fileName
         }
+    where
+      helperOption :: Parser (a -> a)
+      helperOption =
+        abortOption ShowHelpText $
+        mconcat [long "help", help "Show this help text", hidden]

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.6.2
+version:         3.1.6.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

`warp` executable advertises this in it's help:
```
~/g/wai (master) $ warp --help
Usage: warp [-d|--docroot DOCROOT] [-i|--index INDEX] [-p|--port PORT]
            [-n|--noindex] [-q|--quiet] [-v|--verbose] [-m|--mime MIME]
            [-h|--host HOST]

Available options:
  -h,--help                Show this help text
  -d,--docroot DOCROOT     directory containing files to serve
  -i,--index INDEX         index files to serve when a directory is required
  -m,--mime MIME           extra file extension/mime type mappings
  -h,--host HOST           interface to bind to, special values: *, *4, *6
```

Note how `-h` option is same for both `--help` and `--host`. Given that the one of the major aim of `warp` is to bind on a particular host and post, I have chosen to have `-h` option for `host` instead of help message. ( The existing behavior right now for `-h` was showing help message which has been changed in this PR).