### PR TITLE
Remove reference to deprecated wai-test library

### DIFF
--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -30,8 +30,6 @@ include:
 
 [wai-extra] <http://hackage.haskell.org/package/wai-extra>
 
-[wai-test] <http://hackage.haskell.org/package/wai-test>
-
 -}
 -- Ignore deprecations, because this module needs to use the deprecated requestBody to construct a response.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->