### PR TITLE
Fix for #647 (Payload Too Large in WAI is 500 instead of 413)

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for wai-extra
 
+## 3.0.26
+
+* Throw 413 for too large payload
+* Throw 431 for too large headers
+  [#741](https://github.com/yesodweb/wai/pull/741)
+
 ## 3.0.25
 
 * Supporting `network` version 3.0.

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.25
+Version:             3.0.26
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:
@@ -115,6 +115,7 @@ Library
                    , zlib
                    , aeson
                    , iproute
+                   , http2
 
   if os(windows)
       cpp-options:   -DWINDOWS
@@ -202,6 +203,7 @@ test-suite spec
                    , cookie
                    , time
                    , case-insensitive
+                   , http2
     ghc-options:     -Wall
     default-language:          Haskell2010
 

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -4,6 +4,10 @@
   value of the `PORT` environment variable
   [#736](https://github.com/yesodweb/wai/pull/736)
 
+* Throw 413 for too large payload
+* Throw 431 for too large headers
+  [#741](https://github.com/yesodweb/wai/pull/741)
+
 ## 3.2.26
 
 * Support network package version 3

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.2.26
+Version:             3.2.27
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
- Instead of 'error "Header line length exceeds allowed maximum."'
  throw 'ConnectionError (UnknownErrorCode 431)
                          "Request Header Fields Too Large"'
- Instead of 'error "Maximum size exceeded"'
  throw 'ConnectionError (UnknownErrorCode 413) "Payload Too Large"'

I have :

- [X] Bumped the version number
- [X] Added Since declarations to the Haddock

