### PR TITLE
Add lower bound on http-types (fixes #743)

### DIFF
--- a/stack-lts-6.yaml
+++ b/stack-lts-6.yaml
@@ -18,6 +18,7 @@ extra-deps:
 - psqueues-0.2.7.0@sha256:189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a,4757
 - basement-0.0.7@rev:0
 - http-client-0.5.13.1@rev:0
+- http-types-0.12.3@rev:0
 nix:
   enable: false
   packages:

--- a/stack-lts-9.yaml
+++ b/stack-lts-9.yaml
@@ -14,6 +14,7 @@ extra-deps:
 - streaming-commons-0.2.1.0@sha256:163af02944f374f316e35257c1afbffefd2c2852a85a151d1ea0ad22152cf28d,4990
 - wai-logger-2.3.2@sha256:7f5dbc72c0753bd3e0e73f8f542d9d159d1d70f8ff3a3ec16d0b74b500534fc6,1572
 - http-client-0.5.13.1@rev:0
+- http-types-0.12.3@rev:0
 nix:
   enable: false
   packages:

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -299,8 +298,6 @@ spec = do
                     [ "Hello World\nBye"
                     , "Hello World"
                     ]
-#if !WINDOWS
--- Too slow on Windows
         it "lots of chunks" $ do
             ifront <- I.newIORef id
             countVar <- newTVarIO (0 :: Int)
@@ -350,7 +347,6 @@ spec = do
                     [ "Hello World\nBye"
                     , "Hello World"
                     ]
-#endif
         it "timeout in request body" $ do
             ifront <- I.newIORef id
             let app req f = do
@@ -398,10 +394,6 @@ spec = do
                 timeout 100000 (msRead ms 10) >>= (`shouldBe` Just "1122334455")
                 msWrite ms "67890"
                 timeout 100000 (msRead ms 10) >>= (`shouldBe` Just "6677889900")
-
-#if !WINDOWS
--- No idea why this test is so unreliable on Windows
--- It fails in multiple ways on CI
     it "only one date and server header" $ do
         let app _ f = f $ responseLBS status200
                 [ ("server", "server")
@@ -435,7 +427,6 @@ spec = do
               check $ count >= 1
             bs <- safeRecv sock 4096
             S.takeWhile (/= 13) bs `shouldBe` "HTTP/1.1 200 OK"
-#endif
 
     it "streaming response with length" $ do
         let app _ f = f $ responseStream status200 [("content-length", "20")] $ \write _ -> do

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -42,7 +42,7 @@ Library
                    , case-insensitive          >= 0.2
                    , containers
                    , ghc-prim
-                   , http-types                >= 0.9.1
+                   , http-types                >= 0.11
                    , iproute                   >= 1.3.1
                    , http2                     >= 1.6      && < 1.7
                    , simple-sendfile           >= 0.2.7    && < 0.3

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -180,7 +180,7 @@ Test-Suite spec
     Hs-Source-Dirs:  test, .
     Type:            exitcode-stdio-1.0
 
-    Ghc-Options:     -Wall
+    Ghc-Options:     -Wall -threaded
     Build-Depends:   base >= 4.8 && < 5
                    , array
                    , auto-update


### PR DESCRIPTION
Looks like PR #741 added a usage of an identifier added to a newer version of http-types. Lower bound added, and updated the stack.yaml files. If CI passes, this should be good to merge. Fixes #743