### PR TITLE
wai-app-static: make cabal file indentation consistent

### DIFF
--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -102,7 +102,7 @@ test-suite runtests
                    , temporary
                    , mockery
                    -- , containers
-  ghc-options:   -Wall
+    ghc-options:   -Wall
 
 source-repository head
   type:     git


### PR DESCRIPTION
This fixes hackage import on guix: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=35743

Presumably cabal parses the file successfully as is, but it seems like a
good change anyway.

(I haven't found a clear documentation of the valid cabal syntax -- my understanding is that there should be a haskell-like layout rule which this seems in violation of, but also that the cabal format is defined by the cabal implementation. Would be happy for clarification and happy to try to fix the guix parser if it's clearly wrong here.)

> Before submitting your PR, check that you've:

I'm not sure version number bumping applies to a change like this. Happy to make any required changes though.