### PR TITLE
using strict language extensions.

### DIFF
--- a/auto-update/auto-update.cabal
+++ b/auto-update/auto-update.cabal
@@ -21,6 +21,8 @@ library
   other-modules:       Control.AutoUpdate.Util
   build-depends:       base >= 4 && < 5
   default-language:    Haskell2010
+  if impl(ghc >= 8)
+      default-extensions:  Strict StrictData
 
 -- Test suite is currently not robust enough, gives too many false negatives.
 

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -8,7 +8,7 @@ Maintainer:          michael@snoyman.com
 Homepage:            http://github.com/yesodweb/wai
 Category:            Web, Yesod
 Build-Type:          Simple
-Cabal-Version:       >=1.6
+Cabal-Version:       >= 1.10
 Stability:           Stable
 description:         SSLv1 and SSLv2 are obsoleted by IETF.
                      We should use TLS 1.2 (or TLS 1.1 or TLS 1.0 if necessary).
@@ -32,6 +32,9 @@ Library
   ghc-options:       -Wall
   if os(windows)
       Cpp-Options:   -DWINDOWS
+  if impl(ghc >= 8)
+      Default-Extensions:  Strict StrictData
+  Default-Language:     Haskell2010
 
 
 source-repository head

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -411,13 +411,13 @@ spec = do
     it "streaming echo #249" $ do
         countVar <- newTVarIO (0 :: Int)
         let app req f = f $ responseStream status200 [] $ \write _ -> do
-            let loop = do
+             let loop = do
                     bs <- getRequestBodyChunk req
                     unless (S.null bs) $ do
                         write $ byteString bs
                         atomically $ modifyTVar countVar (+ 1)
                         loop
-            loop
+             loop
         withApp defaultSettings app $ \port -> do
             (sock, _addr) <- getSocketTCP "127.0.0.1" port
             sendAll sock "POST / HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -8,7 +8,7 @@ Maintainer:          michael@snoyman.com
 Homepage:            http://github.com/yesodweb/wai
 Category:            Web, Yesod
 Build-Type:          Simple
-Cabal-Version:       >=1.8
+Cabal-Version:       >= 1.10
 Stability:           Stable
 description:         HTTP\/1.0, HTTP\/1.1 and HTTP\/2 are supported.
                      For HTTP\/2,  Warp supports direct and ALPN (in TLS)
@@ -112,6 +112,9 @@ Library
   else
       Build-Depends: unix
       Other-modules: Network.Wai.Handler.Warp.MultiMap
+  if impl(ghc >= 8)
+      Default-Extensions:  Strict StrictData
+  Default-Language:     Haskell2010
 
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0
@@ -122,6 +125,9 @@ Test-Suite doctest
                       , doctest >= 0.10.1
   if os(windows)
     Buildable: False
+  if impl(ghc >= 8)
+      Default-Extensions:  Strict StrictData
+  Default-Language:     Haskell2010
 
 Test-Suite spec
     Main-Is:         Spec.hs
@@ -223,6 +229,9 @@ Test-Suite spec
   if os(windows)
     Cpp-Options:   -DWINDOWS
     Build-Depends: time
+  if impl(ghc >= 8)
+      Default-Extensions:  Strict StrictData
+  Default-Language:     Haskell2010
 
 Benchmark parser
     Type:           exitcode-stdio-1.0
@@ -256,6 +265,9 @@ Benchmark parser
   if os(windows)
     Cpp-Options:   -DWINDOWS
     Build-Depends: time
+  if impl(ghc >= 8)
+      Default-Extensions:  Strict StrictData
+  Default-Language:     Haskell2010
 
 Source-Repository head
   Type:     git


### PR DESCRIPTION
This patch uses `Strict` and `StrictData` in wai, warp, warp-tls and auto-update.
I confirmed that this improves memory footprint.

@snoyberg Would you please explain why laziness is necessary for `requestBody`?