### PR TITLE
Leading vs. trailing edges for Control.Debounce

### DIFF
--- a/auto-update/ChangeLog.md
+++ b/auto-update/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for auto-update
 
+## 0.2.0
+
+* Add control of activation on leading vs. trailing edges for Control.Debounce
+  [#756](https://github.com/yesodweb/wai/pull/756)
+
 ## 0.1.5
 
 * Using the Strict and StrictData language extensions for GHC >8.

--- a/auto-update/ChangeLog.md
+++ b/auto-update/ChangeLog.md
@@ -1,6 +1,6 @@
 # ChangeLog for auto-update
 
-## 0.2.0
+## 0.1.6
 
 * Add control of activation on leading vs. trailing edges for Control.Debounce
   [#756](https://github.com/yesodweb/wai/pull/756)

--- a/auto-update/Control/Debounce.hs
+++ b/auto-update/Control/Debounce.hs
@@ -11,6 +11,7 @@
 -- printString <- 'mkDebounce' 'defaultDebounceSettings'
 --                  { 'debounceAction' = putStrLn "Running action"
 --                  , 'debounceFreq' = 5000000 -- 5 seconds
+--                  , 'debounceEdge' = 'Trailing' -- Trigger on the trailing edge
 --                  }
 -- @
 --
@@ -25,70 +26,34 @@
 -- @since 0.1.2
 module Control.Debounce
     ( -- * Type
-      DebounceSettings
+      DI.DebounceSettings
     , defaultDebounceSettings
       -- * Accessors
-    , debounceFreq
-    , debounceAction
+    , DI.debounceFreq
+    , DI.debounceAction
+    , DI.debounceEdge
+    , DI.DebounceEdge(..)
       -- * Creation
     , mkDebounce
     ) where
 
-import           Control.Concurrent      (forkIO, threadDelay)
-import           Control.Concurrent.MVar (newEmptyMVar, takeMVar, tryPutMVar)
-import           Control.Exception       (SomeException, handle, mask_)
-import           Control.Monad           (forever, void)
-
--- | Settings to control how debouncing should work.
---
--- This should be constructed using 'defaultDebounceSettings' and record
--- update syntax, e.g.:
---
--- @
--- let settings = 'defaultDebounceSettings' { 'debounceAction' = flushLog }
--- @
---
--- @since 0.1.2
-data DebounceSettings = DebounceSettings
-    { debounceFreq   :: Int
-    -- ^ Microseconds lag required between subsequence calls to the debounced
-    -- action.
-    --
-    -- Default: 1 second (1000000)
-    --
-    -- @since 0.1.2
-    , debounceAction :: IO ()
-    -- ^ Action to be performed.
-    --
-    -- Note: all exceptions thrown by this action will be silently discarded.
-    --
-    -- Default: does nothing.
-    --
-    -- @since 0.1.2
-    }
+import           Control.Concurrent      (newEmptyMVar, threadDelay)
+import qualified Control.Debounce.Internal as DI
 
 -- | Default value for creating a 'DebounceSettings'.
 --
 -- @since 0.1.2
-defaultDebounceSettings :: DebounceSettings
-defaultDebounceSettings = DebounceSettings
-    { debounceFreq = 1000000
-    , debounceAction = return ()
+defaultDebounceSettings :: DI.DebounceSettings
+defaultDebounceSettings = DI.DebounceSettings
+    { DI.debounceFreq = 1000000
+    , DI.debounceAction = return ()
+    , DI.debounceEdge = DI.Leading
     }
 
--- | Generate an action which will trigger the debounced action to be
--- performed. The action will either be performed immediately, or after the
--- current cooldown period has expired.
+-- | Generate an action which will trigger the debounced action to be performed.
 --
 -- @since 0.1.2
-mkDebounce :: DebounceSettings -> IO (IO ())
-mkDebounce (DebounceSettings freq action) = do
-    baton <- newEmptyMVar
-    mask_ $ void $ forkIO $ forever $ do
-        takeMVar baton
-        ignoreExc action
-        threadDelay freq
-    return $ void $ tryPutMVar baton ()
-
-ignoreExc :: IO () -> IO ()
-ignoreExc = handle $ \(_ :: SomeException) -> return ()
+mkDebounce :: DI.DebounceSettings -> IO (IO ())
+mkDebounce settings = do
+  baton <- newEmptyMVar
+  DI.mkDebounce baton threadDelay settings

--- a/auto-update/Control/Debounce.hs
+++ b/auto-update/Control/Debounce.hs
@@ -56,4 +56,4 @@ defaultDebounceSettings = DI.DebounceSettings
 mkDebounce :: DI.DebounceSettings -> IO (IO ())
 mkDebounce settings = do
   baton <- newEmptyMVar
-  DI.mkDebounce baton threadDelay settings
+  DI.mkDebounceInternal baton threadDelay settings

--- a/auto-update/Control/Debounce.hs
+++ b/auto-update/Control/Debounce.hs
@@ -11,7 +11,7 @@
 -- printString <- 'mkDebounce' 'defaultDebounceSettings'
 --                  { 'debounceAction' = putStrLn "Running action"
 --                  , 'debounceFreq' = 5000000 -- 5 seconds
---                  , 'debounceEdge' = 'trailingEdge' -- Trigger on the trailing edge
+--                  , 'debounceEdge' = 'DI.trailingEdge' -- Trigger on the trailing edge
 --                  }
 -- @
 --
@@ -32,8 +32,8 @@ module Control.Debounce
     , DI.debounceFreq
     , DI.debounceAction
     , DI.debounceEdge
-    , leadingEdge
-    , trailingEdge
+    , DI.leadingEdge
+    , DI.trailingEdge
       -- * Creation
     , mkDebounce
     ) where
@@ -48,7 +48,7 @@ defaultDebounceSettings :: DI.DebounceSettings
 defaultDebounceSettings = DI.DebounceSettings
     { DI.debounceFreq = 1000000
     , DI.debounceAction = return ()
-    , DI.debounceEdge = leadingEdge
+    , DI.debounceEdge = DI.leadingEdge
     }
 
 -- | Generate an action which will trigger the debounced action to be performed.
@@ -58,14 +58,3 @@ mkDebounce :: DI.DebounceSettings -> IO (IO ())
 mkDebounce settings = do
   baton <- newEmptyMVar
   DI.mkDebounceInternal baton threadDelay settings
-
--- | Perform the action immediately, and then begin a cooldown period.
--- If the trigger happens again during the cooldown, wait until the end of the cooldown
--- and then perform the action again, then enter a new cooldown period.
-leadingEdge :: DI.DebounceEdge
-leadingEdge = DI.Leading
-
--- | Start a cooldown period and perform the action when the period ends. If another trigger
--- happens during the cooldown, it has no effect.
-trailingEdge :: DI.DebounceEdge
-trailingEdge = DI.Trailing

--- a/auto-update/Control/Debounce.hs
+++ b/auto-update/Control/Debounce.hs
@@ -11,7 +11,7 @@
 -- printString <- 'mkDebounce' 'defaultDebounceSettings'
 --                  { 'debounceAction' = putStrLn "Running action"
 --                  , 'debounceFreq' = 5000000 -- 5 seconds
---                  , 'debounceEdge' = 'Trailing' -- Trigger on the trailing edge
+--                  , 'debounceEdge' = 'trailingEdge' -- Trigger on the trailing edge
 --                  }
 -- @
 --
@@ -32,7 +32,8 @@ module Control.Debounce
     , DI.debounceFreq
     , DI.debounceAction
     , DI.debounceEdge
-    , DI.DebounceEdge(..)
+    , leadingEdge
+    , trailingEdge
       -- * Creation
     , mkDebounce
     ) where
@@ -47,7 +48,7 @@ defaultDebounceSettings :: DI.DebounceSettings
 defaultDebounceSettings = DI.DebounceSettings
     { DI.debounceFreq = 1000000
     , DI.debounceAction = return ()
-    , DI.debounceEdge = DI.Leading
+    , DI.debounceEdge = leadingEdge
     }
 
 -- | Generate an action which will trigger the debounced action to be performed.
@@ -57,3 +58,14 @@ mkDebounce :: DI.DebounceSettings -> IO (IO ())
 mkDebounce settings = do
   baton <- newEmptyMVar
   DI.mkDebounceInternal baton threadDelay settings
+
+-- | Perform the action immediately, and then begin a cooldown period.
+-- If the trigger happens again during the cooldown, wait until the end of the cooldown
+-- and then perform the action again, then enter a new cooldown period.
+leadingEdge :: DI.DebounceEdge
+leadingEdge = DI.Leading
+
+-- | Start a cooldown period and perform the action when the period ends. If another trigger
+-- happens during the cooldown, it has no effect.
+trailingEdge :: DI.DebounceEdge
+trailingEdge = DI.Trailing

--- a/auto-update/Control/Debounce/Internal.hs
+++ b/auto-update/Control/Debounce/Internal.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Control.Debounce.Internal (
+  DebounceSettings(..)
+  , DebounceEdge(..)
+  , mkDebounce
+  ) where
+
+import           Control.Concurrent      (forkIO)
+import           Control.Concurrent.MVar (takeMVar, tryPutMVar, tryTakeMVar, MVar)
+import           Control.Exception       (SomeException, handle, mask_)
+import           Control.Monad           (forever, void, when)
+import           Data.Maybe              (isJust)
+
+-- | Settings to control how debouncing should work.
+--
+-- This should be constructed using 'defaultDebounceSettings' and record
+-- update syntax, e.g.:
+--
+-- @
+-- let settings = 'defaultDebounceSettings' { 'debounceAction' = flushLog }
+-- @
+--
+-- @since 0.1.2
+data DebounceSettings = DebounceSettings
+    { debounceFreq   :: Int
+    -- ^ Microseconds lag required between subsequence calls to the debounced
+    -- action.
+    --
+    -- Default: 1 second (1000000)
+    --
+    -- @since 0.1.2
+    , debounceAction :: IO ()
+    -- ^ Action to be performed.
+    --
+    -- Note: all exceptions thrown by this action will be silently discarded.
+    --
+    -- Default: does nothing.
+    --
+    -- @since 0.1.2
+    , debounceEdge :: DebounceEdge
+    -- ^ Whether to perform the action on the leading edge or trailing edge of
+    -- the timeout.
+    --
+    -- Default: Leading.
+    --
+    -- @since 0.2.0
+    }
+
+data DebounceEdge =
+  Leading
+  -- ^ The action will either be performed immediately, or after the current cooldown period has expired.
+  | Trailing
+  -- ^ The action will be performed at the end of the current cooldown period.
+  | LeadingAndTrailing
+  -- ^ The action is performed on the leading edge. It's also performed on the trailing edge if
+  -- the debounced function was invoked again during the cooldown.
+  deriving (Show, Eq)
+
+mkDebounce :: MVar () -> (Int -> IO ()) -> DebounceSettings -> IO (IO ())
+mkDebounce baton delayFn (DebounceSettings freq action edge) = do
+    mask_ $ void $ forkIO $ forever $ do
+        takeMVar baton
+        if edge `elem` [Leading, LeadingAndTrailing] then ignoreExc action >> runDelay False baton
+        else runDelay True baton
+
+    return $ void $ tryPutMVar baton ()
+
+  where runDelay hasDelayedInitialActivation baton = do
+            delayFn freq
+
+            case edge of
+                Trailing -> do
+                    firedDuringInterval <- isJust <$> tryTakeMVar baton
+                    when (firedDuringInterval || hasDelayedInitialActivation) $ ignoreExc action
+                Leading ->
+                    -- We already fired at the beginning of the interval so do nothing
+                    return ()
+                LeadingAndTrailing -> do
+                    firedDuringInterval <- isJust <$> tryTakeMVar baton
+                    when firedDuringInterval $ ignoreExc action
+
+ignoreExc :: IO () -> IO ()
+ignoreExc = handle $ \(_ :: SomeException) -> return ()

--- a/auto-update/Control/Debounce/Internal.hs
+++ b/auto-update/Control/Debounce/Internal.hs
@@ -83,22 +83,16 @@ mkDebounceInternal baton delayFn (DebounceSettings freq action edge) = do
     mask_ $ void $ forkIO $ forever $ do
         takeMVar baton
         case edge of
-          Leading -> ignoreExc action >> runDelay
-          Trailing -> runDelay
+          Leading -> do
+            ignoreExc action
+            delayFn freq
+          Trailing -> do
+            delayFn freq
+            -- Empty the baton of any other activations during the interval
+            void $ tryTakeMVar baton
+            ignoreExc action
 
     return $ void $ tryPutMVar baton ()
-
-  where runDelay = do
-            delayFn freq
-
-            case edge of
-                Trailing -> do
-                    -- Empty the baton of any other activations during the interval
-                    void $ tryTakeMVar baton
-                    ignoreExc action
-                Leading ->
-                    -- We already fired at the beginning of the interval so do nothing
-                    return ()
 
 ignoreExc :: IO () -> IO ()
 ignoreExc = handle $ \(_ :: SomeException) -> return ()

--- a/auto-update/Control/Debounce/Internal.hs
+++ b/auto-update/Control/Debounce/Internal.hs
@@ -25,8 +25,7 @@ import           Data.Maybe              (isJust)
 -- @since 0.1.2
 data DebounceSettings = DebounceSettings
     { debounceFreq   :: Int
-    -- ^ Microseconds lag required between subsequence calls to the debounced
-    -- action.
+    -- ^ Length of the debounce timeout period in microseconds.
     --
     -- Default: 1 second (1000000)
     --
@@ -48,18 +47,22 @@ data DebounceSettings = DebounceSettings
     -- @since 0.1.6
     }
 
--- | Setting to control whether the action happens at the leading or trailing
+-- | Setting to control whether the action happens at the leading and/or trailing
 -- edge of the timeout.
 --
 -- @since 0.1.6
 data DebounceEdge =
   Leading
-  -- ^ The action will either be performed immediately, or after the current cooldown period has expired.
-  | Trailing
-  -- ^ The action will be performed at the end of the current cooldown period.
+  -- ^ Perform the action immediately, and then begin a cooldown period.
+  -- If trigger happens again during the cooldown, wait until the end of the cooldown and then
+  -- perform the action again /plus/ enter a new cooldown period.
   | LeadingAndTrailing
-  -- ^ The action is performed on the leading edge. It's also performed on the trailing edge if
-  -- the debounced function was invoked again during the cooldown.
+  -- ^ Perform the action immediately, and then begin a cooldown period.
+  -- If trigger happens again during the cooldown, wait until the end of the cooldown and then
+  -- perform the action again but /do not/ enter a new cooldown period.
+  | Trailing
+  -- ^ Start a cooldown period and perform the action when the period ends. If another trigger
+  -- happens during the cooldown, it has no effect.
   deriving (Show, Eq)
 
 mkDebounceInternal :: MVar () -> (Int -> IO ()) -> DebounceSettings -> IO (IO ())

--- a/auto-update/auto-update.cabal
+++ b/auto-update/auto-update.cabal
@@ -1,5 +1,5 @@
 name:                auto-update
-version:             0.2.0
+version:             0.1.6
 synopsis:            Efficiently run periodic, on-demand actions
 description:         API docs and the README are available at <http://www.stackage.org/package/auto-update>.
 homepage:            https://github.com/yesodweb/wai

--- a/auto-update/auto-update.cabal
+++ b/auto-update/auto-update.cabal
@@ -1,5 +1,5 @@
 name:                auto-update
-version:             0.1.5
+version:             0.2.0
 synopsis:            Efficiently run periodic, on-demand actions
 description:         API docs and the README are available at <http://www.stackage.org/package/auto-update>.
 homepage:            https://github.com/yesodweb/wai
@@ -17,6 +17,7 @@ library
   ghc-options:         -Wall
   exposed-modules:     Control.AutoUpdate
                        Control.Debounce
+                       Control.Debounce.Internal
                        Control.Reaper
   other-modules:       Control.AutoUpdate.Util
   build-depends:       base >= 4 && < 5
@@ -26,11 +27,12 @@ library
 
 -- Test suite is currently not robust enough, gives too many false negatives.
 
--- test-suite spec
---   main-is:         Spec.hs
---   other-modules:   Control.AutoUpdateSpec
---                    Control.ReaperSpec
---   hs-source-dirs:  test
---   type:            exitcode-stdio-1.0
---   build-depends:   base, auto-update, hspec
---   default-language:    Haskell2010
+test-suite spec
+  main-is:         Spec.hs
+  other-modules:   Control.AutoUpdateSpec
+                   Control.DebounceSpec
+                   Control.ReaperSpec
+  hs-source-dirs:  test
+  type:            exitcode-stdio-1.0
+  build-depends:   base, auto-update, exceptions, hspec, retry, HUnit
+  default-language:    Haskell2010

--- a/auto-update/test/Control/AutoUpdateSpec.hs
+++ b/auto-update/test/Control/AutoUpdateSpec.hs
@@ -1,34 +1,35 @@
 module Control.AutoUpdateSpec (spec) where
 
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Data.IORef
+import Control.AutoUpdate
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_, forM_)
-import Control.AutoUpdate
+import Data.IORef
+import Test.Hspec
+import Test.Hspec.QuickCheck
 
 spec :: Spec
-spec = do
-    prop "incrementer" $ \st' -> do
-        let st = abs st' `mod` 10000
-        ref <- newIORef 0
-        next <- mkAutoUpdate defaultUpdateSettings
-            { updateAction = atomicModifyIORef ref $ \i ->
-                let i' = succ i in i' `seq` (i', i')
-            , updateSpawnThreshold = st
-            , updateFreq = 10000
-            }
+spec = return ()
+  -- do
+  --   prop "incrementer" $ \st' -> do
+  --       let st = abs st' `mod` 10000
+  --       ref <- newIORef 0
+  --       next <- mkAutoUpdate defaultUpdateSettings
+  --           { updateAction = atomicModifyIORef ref $ \i ->
+  --               let i' = succ i in i' `seq` (i', i')
+  --           , updateSpawnThreshold = st
+  --           , updateFreq = 10000
+  --           }
 
-        forM_ [1..st + 1] $ \i -> do
-            j <- next
-            j `shouldBe` i
+  --       forM_ [1..st + 1] $ \i -> do
+  --           j <- next
+  --           j `shouldBe` i
 
-        replicateM_ 50 $ do
-            i <- next
-            i `shouldBe` st + 2
+  --       replicateM_ 50 $ do
+  --           i <- next
+  --           i `shouldBe` st + 2
 
-        threadDelay 60000
-        last1 <- readIORef ref
-        threadDelay 20000
-        last2 <- readIORef ref
-        last2 `shouldBe` last1
+  --       threadDelay 60000
+  --       last1 <- readIORef ref
+  --       threadDelay 20000
+  --       last2 <- readIORef ref
+  --       last2 `shouldBe` last1

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -15,7 +15,7 @@ spec :: Spec
 spec = describe "mkDebounce" $ do
     describe "Leading edge" $ do
         it "works for a single event" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce Leading
+            (ref, debounced, baton, returnFromWait) <- getDebounce leadingEdge
 
             debounced
             waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
@@ -33,7 +33,7 @@ spec = describe "mkDebounce" $ do
             readIORef ref >>= (`shouldBe` 2)
 
         it "works for multiple events" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce Leading
+            (ref, debounced, baton, returnFromWait) <- getDebounce leadingEdge
 
             debounced
             waitForBatonToBeTaken baton
@@ -47,7 +47,7 @@ spec = describe "mkDebounce" $ do
 
     describe "Trailing edge" $ do
         it "works for a single event" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce Trailing
+            (ref, debounced, baton, returnFromWait) <- getDebounce trailingEdge
 
             debounced
             pause
@@ -65,7 +65,7 @@ spec = describe "mkDebounce" $ do
             waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
 
         it "works for multiple events" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce Trailing
+            (ref, debounced, baton, returnFromWait) <- getDebounce trailingEdge
 
             debounced
             waitForBatonToBeTaken baton
@@ -75,37 +75,6 @@ spec = describe "mkDebounce" $ do
 
             returnFromWait
             waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
-
-    describe "Leading or trailing edge" $ do
-        it "works for a single event" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce LeadingAndTrailing
-
-            debounced
-            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
-
-            returnFromWait
-            pause
-            readIORef ref >>= (`shouldBe` 1)
-
-            -- Try another round
-            debounced
-            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
-
-            returnFromWait
-            pause
-            readIORef ref >>= (`shouldBe` 2)
-
-        it "works for multiple events" $ do
-            (ref, debounced, baton, returnFromWait) <- getDebounce LeadingAndTrailing
-
-            debounced
-            waitForBatonToBeTaken baton
-            debounced
-
-            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
-
-            returnFromWait
-            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
 
 
 -- | Make a controllable delay function
@@ -117,7 +86,7 @@ getWaitAction = do
     return (waitAction, returnFromWait)
 
 -- | Get a debounce system with access to the internals for testing
-getDebounce :: DebounceEdge -> IO (IORef Int, IO (), MVar (), IO ())
+getDebounce :: DI.DebounceEdge -> IO (IORef Int, IO (), MVar (), IO ())
 getDebounce edge = do
   ref :: IORef Int <- newIORef 0
   let action = modifyIORef ref (+ 1)

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Control.DebounceSpec (spec) where
+
+import Control.Concurrent
+import Control.Debounce
+import qualified Control.Debounce.Internal as DI
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.IO.Class
+import Control.Retry
+import Data.IORef
+import Test.HUnit.Lang
+import Test.Hspec
+
+spec :: Spec
+spec = describe "mkDebounce" $ do
+    describe "Leading edge" $ do
+        it "works for a single event" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce Leading
+
+            debounced
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            returnFromWait
+            pause
+            readIORef ref >>= (`shouldBe` 1)
+
+            -- Try another round
+            debounced
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
+
+            returnFromWait
+            pause
+            readIORef ref >>= (`shouldBe` 2)
+
+        it "works for multiple events" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce Leading
+
+            debounced
+            waitForBatonToBeTaken baton
+            debounced
+            pause
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            returnFromWait
+            pause
+            readIORef ref >>= (`shouldBe` 2)
+
+    describe "Trailing edge" $ do
+        it "works for a single event" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce Trailing
+
+            debounced
+            pause
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 0)
+
+            returnFromWait
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            -- Try another round
+            debounced
+            pause
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            returnFromWait
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
+
+        it "works for multiple events" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce Trailing
+
+            debounced
+            waitForBatonToBeTaken baton
+            debounced
+            pause
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 0)
+
+            returnFromWait
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+    describe "Leading or trailing edge" $ do
+        it "works for a single event" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce LeadingAndTrailing
+
+            debounced
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            returnFromWait
+            pause
+            readIORef ref >>= (`shouldBe` 1)
+
+            -- Try another round
+            debounced
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
+
+            returnFromWait
+            pause
+            readIORef ref >>= (`shouldBe` 2)
+
+        it "works for multiple events" $ do
+            (ref, debounced, baton, returnFromWait) <- getDebounce LeadingAndTrailing
+
+            debounced
+            waitForBatonToBeTaken baton
+            debounced
+
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 1)
+
+            returnFromWait
+            waitUntil 5 $ readIORef ref >>= (`shouldBe` 2)
+
+
+-- | Make a controllable delay function
+getWaitAction :: IO (p -> IO (), IO ())
+getWaitAction = do
+    waitVar <- newEmptyMVar
+    let waitAction _ = takeMVar waitVar
+    let returnFromWait = putMVar waitVar ()
+    return (waitAction, returnFromWait)
+
+-- | Get a debounce system with access to the internals for testing
+getDebounce :: DebounceEdge -> IO (IORef Int, IO (), MVar (), IO ())
+getDebounce edge = do
+  ref :: IORef Int <- newIORef 0
+  let action = modifyIORef ref (+ 1)
+
+  (waitAction, returnFromWait) <- getWaitAction
+
+  baton <- newEmptyMVar
+
+  debounced <- DI.mkDebounce baton waitAction defaultDebounceSettings {
+    debounceFreq = 5000000 -- unused
+    , debounceAction = action
+    , debounceEdge = edge
+    }
+
+  return (ref, debounced, baton, returnFromWait)
+
+-- | Pause briefly (100ms)
+pause :: IO ()
+pause = threadDelay 100000
+
+waitForBatonToBeTaken :: MVar () -> IO ()
+waitForBatonToBeTaken baton = waitUntil 5 $ tryReadMVar baton >>= (`shouldBe` Nothing)
+
+-- | Wait up to n seconds for an actual to complete without throwing an HUnitFailure
+waitUntil :: (MonadIO m, MonadMask m) => Int -> m a -> m ()
+waitUntil n action = recovering policy [handler] (\_status -> void action)
+  where policy = constantDelay 1000 <> limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds
+        handler _status = Handler (\(HUnitFailure {}) -> return True)
+
+main :: IO ()
+main = hspec spec

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -144,7 +144,7 @@ waitForBatonToBeTaken baton = waitUntil 5 $ tryReadMVar baton >>= (`shouldBe` No
 -- | Wait up to n seconds for an actual to complete without throwing an HUnitFailure
 waitUntil :: Int -> IO a -> IO ()
 waitUntil n action = recovering policy [handler] (\_status -> void action)
-  where policy = constantDelay 1000 <> limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds
+  where policy = constantDelay 1000 `mappend` limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds
         handler _status = Handler (\(HUnitFailure {}) -> return True)
 
 main :: IO ()

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -126,7 +126,7 @@ getDebounce edge = do
 
   baton <- newEmptyMVar
 
-  debounced <- DI.mkDebounce baton waitAction defaultDebounceSettings {
+  debounced <- DI.mkDebounceInternal baton waitAction defaultDebounceSettings {
     debounceFreq = 5000000 -- unused
     , debounceAction = action
     , debounceEdge = edge
@@ -141,7 +141,7 @@ pause = threadDelay 100000
 waitForBatonToBeTaken :: MVar () -> IO ()
 waitForBatonToBeTaken baton = waitUntil 5 $ tryReadMVar baton >>= (`shouldBe` Nothing)
 
--- | Wait up to n seconds for an actual to complete without throwing an HUnitFailure
+-- | Wait up to n seconds for an action to complete without throwing an HUnitFailure
 waitUntil :: Int -> IO a -> IO ()
 waitUntil n action = recovering policy [handler] (\_status -> void action)
   where policy = constantDelay 1000 `mappend` limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -6,7 +6,6 @@ import Control.Debounce
 import qualified Control.Debounce.Internal as DI
 import Control.Monad
 import Control.Monad.Catch
-import Control.Monad.IO.Class
 import Control.Retry
 import Data.IORef
 import Test.HUnit.Lang
@@ -143,7 +142,7 @@ waitForBatonToBeTaken :: MVar () -> IO ()
 waitForBatonToBeTaken baton = waitUntil 5 $ tryReadMVar baton >>= (`shouldBe` Nothing)
 
 -- | Wait up to n seconds for an actual to complete without throwing an HUnitFailure
-waitUntil :: (MonadIO m, MonadMask m) => Int -> m a -> m ()
+waitUntil :: Int -> IO a -> IO ()
 waitUntil n action = recovering policy [handler] (\_status -> void action)
   where policy = constantDelay 1000 <> limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds
         handler _status = Handler (\(HUnitFailure {}) -> return True)

--- a/auto-update/test/Control/ReaperSpec.hs
+++ b/auto-update/test/Control/ReaperSpec.hs
@@ -1,37 +1,39 @@
 module Control.ReaperSpec (spec) where
 
-import Control.Reaper
 import Control.Concurrent
+import Control.Reaper
+import Data.IORef
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Data.IORef
 
-type Item = (Int, IORef Int)
-
-action = mkListAction $ \(i, ref) -> do
-    modifyIORef ref succ
-    return $ if i > 1
-             then Just (pred i, ref)
-             else Nothing
 
 spec :: Spec
-spec = prop "works" $ \is -> do
-    reaper <- mkReaper defaultReaperSettings
-        { reaperAction = action
-        , reaperDelay = 1000
-        }
+spec = return ()
+--   prop "works" $ \is -> do
+--     reaper <- mkReaper defaultReaperSettings
+--         { reaperAction = action
+--         , reaperDelay = 1000
+--         }
 
-    let mkTestCase i = do
-            ref <- newIORef 0
-            let expected = (abs i `mod` 10) + 1
-            reaperAdd reaper (expected, ref)
-            return (expected, ref)
-    testCases <- mapM mkTestCase is
+--     let mkTestCase i = do
+--             ref <- newIORef 0
+--             let expected = (abs i `mod` 10) + 1
+--             reaperAdd reaper (expected, ref)
+--             return (expected, ref)
+--     testCases <- mapM mkTestCase is
 
-    let test (expected, ref) = do
-            actual <- readIORef ref
-            actual `shouldBe` (expected :: Int)
-    threadDelay 100000
-    mapM_ test testCases
-    [] <- reaperRead reaper
-    return ()
+--     let test (expected, ref) = do
+--             actual <- readIORef ref
+--             actual `shouldBe` (expected :: Int)
+--     threadDelay 100000
+--     mapM_ test testCases
+--     [] <- reaperRead reaper
+--     return ()
+
+-- type Item = (Int, IORef Int)
+
+-- action = mkListAction $ \(i, ref) -> do
+--     modifyIORef ref succ
+--     return $ if i > 1
+--              then Just (pred i, ref)
+--              else Nothing


### PR DESCRIPTION
Okay @snoyberg , took a stab at #745 . What do you think?

- [X] Bumped the version number
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
