### PR TITLE
shutdown instead of close.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -23,6 +23,9 @@ import Foreign.C.Error (Errno(..), eCONNABORTED)
 import GHC.IO.Exception (IOException(..))
 import qualified Network.HTTP2 as H2
 import Network.Socket (Socket, close, accept, withSocketsDo, SockAddr(SockAddrInet, SockAddrInet6), setSocketOption, SocketOption(..))
+#if MIN_VERSION_network(3,1,1)
+import Network.Socket (gracefulClose)
+#endif
 import qualified Network.Socket.ByteString as Sock
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
@@ -64,7 +67,11 @@ socketConnection s = do
         connSendMany = Sock.sendMany s
       , connSendAll = sendall
       , connSendFile = sendFile s writeBuf bufferSize sendall
+#if MIN_VERSION_network(3,1,1)
+      , connClose = gracefulClose s 5000
+#else
       , connClose = close s
+#endif
       , connFree = freeBuffer writeBuf
       , connRecv = receive s bufferPool
       , connRecvBuf = receiveBuf s


### PR DESCRIPTION
This patch lets Warp to use `shutdown` instead of `close`. 

Background: when Warp sends GOAWAY in HTTP/2, `close` is called immediately. The kernel of the browser sends TCP ACK regarding to GOAWAY, but the socket of the server is already closed. So, TCP RST is sent back from the server to the client.

"UNIX Network Programming" suggests to use `shutdown` with `SHUT_WR`. This makes sure that the TCP ACK is processed in the server properly and the socket is closed in the proper timing. Note that the combination of `Linger` and `close` does not help.

- I confirmed that this fixes two bugs which `h2spec` finds.
- This should fix #673.
- I confirmed that sockets are properly closed with `lsof -p` in the field.

Cc: @nh2