### PR TITLE
Add output formatter with details and headers

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.27
+
+* Add custom request log formatter which includes response headers [#762](https://github.com/yesodweb/wai/pull/762)
+
 ## 3.0.26.1
 
 * When available, supply the response size to custom loggers

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.26.1
+Version:             3.0.27
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
This adds a custom log output formatter which includes response headers. The motivation for this is that I'd like to be able to add arbitrary and request-specific data from my [Yesod] application to the log output, and it seems the best way to do this is to add that data to response headers.

Before submitting your PR, check that you've:

- [✔] Bumped the version number
- [✔] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [✔] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [✔] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->