### PR TITLE
EventSource builder to enable recursive emitters

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.28
+
+* Add `Network.Wai.EventSource.eventStreamAppRaw` [#767](https://github.com/yesodweb/wai/pull/767)
+
 ## 3.0.27
 
 * Add custom request log formatter which includes response headers [#762](https://github.com/yesodweb/wai/pull/762)

--- a/wai-extra/Network/Wai/EventSource.hs
+++ b/wai-extra/Network/Wai/EventSource.hs
@@ -5,6 +5,8 @@
     headers:
 
     > [ ("X-Accel-Buffering", "no"), ("Cache-Control", "no-cache")]
+
+    There is a small example using these functions in the @example@ directory.
 -}
 module Network.Wai.EventSource (
     ServerEvent(..),

--- a/wai-extra/example/Main.hs
+++ b/wai-extra/example/Main.hs
@@ -37,6 +37,17 @@ eventIO = do
                          Nothing
                          [string8 . show $ time]
 
+eventRaw :: (ServerEvent -> IO ()) -> IO () -> IO ()
+eventRaw = handle 0
+    where
+        handle counter emit flush = do
+            threadDelay 1000000
+            emit $ ServerEvent (Just $ string8 "raw")
+                               Nothing
+                               [string8 . show $ counter]
+            flush
+            handle (counter + 1) emit flush
+
 main :: IO ()
 main = do
     chan <- newChan

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.27
+Version:             3.0.28
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Follow up to #765.

I am not tied to the name of this method. "Raw" seemed most inline with the current naming scheme (`IO` and `Chan` named after the type of their parameter) - in theory you could build them on top of this method, though I haven't done that in this PR since don't have a good setup to benchmark against any potential perf. regression and wanted to keep low risk. Also considered `eventSourceAppEmit` or `Emitter` as names.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)