### PR TITLE
746 setonexception not called

### DIFF
--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for wai
 
+## 3.2.3
+
+* setOnException wasn't called [#770](https://github.com/yesodweb/wai/pull/770)
+
 ## 3.2.2.1
 
 * Fix missing reexport of `getRequestBodyChunk` [#753](https://github.com/yesodweb/wai/issues/753)

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,5 +1,5 @@
 Name:                wai
-Version:             3.2.2.1
+Version:             3.2.3
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
                      .


### PR DESCRIPTION
This fixes https://github.com/yesodweb/wai/issues/746

Checked with the repo https://github.com/k-bx/servant-custommonad-logging by doing:

```
$ cd waitls-onexception-bug
$ stack build && stack run
```

and running:

```
$ curl --insecure -i https://localhost:8000/api/error-out
HTTP/2 500                       
date: Sat, 28 Sep 2019 09:48:43 GMT
server: Warp/3.3.2                                            
content-type: text/plain; charset=utf-8          
                         
Something went wrong%                                                
```

Now seeing output:

```
Allocating scarce resource
Cleaning up
Error: caught an exception: Erroring out
CallStack (from HasCallStack):
  error, called at src/Main.hs:33:12 in main:Main. Call stack: CallStack (from HasCallStack):
  onExceptionAct, called at src/Main.hs:37:29 in main:Main
```

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)