### PR TITLE
Bumps fast-logger upper bound

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -25,5 +25,7 @@ image:
       executables:
         - warp
 extra-deps:
+- fast-logger-3.0.0
 - http2-2.0.0
 - network-byte-order-0.1.1.0
+- wai-logger-2.3.6

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -99,7 +99,7 @@ Library
                    , text                      >= 0.7
                    , case-insensitive          >= 0.2
                    , data-default-class
-                   , fast-logger               >= 2.4.5    && < 2.5
+                   , fast-logger               >= 2.4.5    && < 3.1
                    , wai-logger                >= 2.3.2    && < 2.4
                    , ansi-terminal
                    , resourcet                 >= 0.4.6    && < 1.3


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Bumps the `fast-logger` upper bounds to include `fast-logger-3.0.0`; not sure if this needs a version number bump.

I've tested locally with the `stack.yaml` updates included in this PR; not sure if it makes sense to merge the `fast-logger-3.0.0` and `wai-logger-2.3.6` `extra-deps`, though.