### PR TITLE
Fix typos

### DIFF
--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -167,7 +167,7 @@ serveFile StaticSettings {..} req file
             -- Note: It would be arguably better to next check
             -- if-modified-since and return a 304 if that indicates a match as
             -- well. However, the circumstances under which such a situation
-            -- could arise would be very anomolous, and should likely warrant a
+            -- could arise would be very anomalous, and should likely warrant a
             -- new file being sent anyway.
             (Just hash, _) -> respond [("ETag", hash)]
 

--- a/wai-app-static/test/WaiAppStaticTest.hs
+++ b/wai-app-static/test/WaiAppStaticTest.hs
@@ -57,7 +57,7 @@ spec = do
         assertStatus 200 =<<
           request (setRawPathInfo defRequest path)
 
-    it "404 for non-existant files" $ webApp $
+    it "404 for non-existent files" $ webApp $
       assertStatus 404 =<<
         request (setRawPathInfo defRequest "doesNotExist")
 

--- a/wai-extra/Network/Wai/EventSource/EventStream.hs
+++ b/wai-extra/Network/Wai/EventSource/EventStream.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{- code adapted by Mathias Billman originaly from Chris Smith https://github.com/cdsmith/gloss-web -}
+{- code adapted by Mathias Billman originally from Chris Smith https://github.com/cdsmith/gloss-web -}
 
 {-|
     Internal module, usually you don't need to use it.

--- a/wai-websockets/server.lhs
+++ b/wai-websockets/server.lhs
@@ -101,7 +101,7 @@ stays alive on some browsers.
 >     conn <- WS.acceptRequest pending
 >     WS.forkPingThread conn 30
 
-When a client is succesfully connected, we read the first message. This should
+When a client is successfully connected, we read the first message. This should
 be in the format of "Hi! I am Jasper", where Jasper is the requested username.
 
 >     msg <- WS.receiveData conn

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -378,7 +378,7 @@ setProxyProtocolRequired y = y { settingsProxyProtocol = ProxyProtocolRequired }
 --
 -- WARNING: This is contrary to the PROXY protocol specification and
 -- using it can indicate a security problem with your
--- architecture if the web server is directly accessable
+-- architecture if the web server is directly accessible
 -- to the public, since it would allow easy IP address
 -- spoofing.  However, it can be useful in some cases,
 -- such as if a load balancer health check uses regular

--- a/warp/test/ResponseSpec.hs
+++ b/warp/test/ResponseSpec.hs
@@ -83,7 +83,7 @@ spec = do
         it "discards empty lines" $ do
             sanitizeHeaderValue "foo\r\n\r\nbar" `shouldBe` "foo\r\n bar"
 
-        context "when sanitizing single occurences of \n" $ do
+        context "when sanitizing single occurrences of \n" $ do
             it "replaces \n with \r\n" $ do
                 sanitizeHeaderValue "foo\n bar" `shouldBe` "foo\r\n bar"
 


### PR DESCRIPTION
Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.