### PR TITLE
Configurable maximum header size for Warp

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.3.8
+
+* Maximum header size is configurable.
+  [#781](https://github.com/yesodweb/wai/pull/781)
+
 ## 3.3.7
 
 * InvalidArgument (Bad file descriptor) is ignored in `receive`.

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -74,6 +74,7 @@ module Network.Wai.Handler.Warp (
   , setGracefulShutdownTimeout
   , setGracefulCloseTimeout1
   , setGracefulCloseTimeout2
+  , setMaxTotalHeaderLength
     -- ** Getters
   , getPort
   , getHost
@@ -435,6 +436,13 @@ setServerPushLogger lgr y = y { settingsServerPushLogger = lgr }
 setGracefulShutdownTimeout :: Maybe Int
                            -> Settings -> Settings
 setGracefulShutdownTimeout time y = y { settingsGracefulShutdownTimeout = time }
+
+-- | Set the maximum header size that Warp will tolerate.
+--
+-- Since 3.3.8
+setMaxTotalHeaderLength :: Int -> Settings -> Settings
+setMaxTotalHeaderLength maxTotalHeaderLength settings = settings
+  { settingsMaxTotalHeaderLength = maxTotalHeaderLength }
 
 -- | Explicitly pause the slowloris timeout.
 --

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -437,7 +437,7 @@ setGracefulShutdownTimeout :: Maybe Int
                            -> Settings -> Settings
 setGracefulShutdownTimeout time y = y { settingsGracefulShutdownTimeout = time }
 
--- | Set the maximum header size that Warp will tolerate.
+-- | Set the maximum header size that Warp will tolerate when using HTTP/1.x.
 --
 -- Since 3.3.8
 setMaxTotalHeaderLength :: Int -> Settings -> Settings

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -128,6 +128,10 @@ data Settings = Settings
       -- Default: 2000.
       --
       -- Since 3.3.5
+    , settingsMaxTotalHeaderLength :: Int
+      -- ^ Determines the maximum header size that Warp will tolerate.
+      -- 
+      -- Since 3.3.8
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -166,6 +170,7 @@ defaultSettings = Settings
     , settingsGracefulShutdownTimeout = Nothing
     , settingsGracefulCloseTimeout1 = 0
     , settingsGracefulCloseTimeout2 = 2000
+    , settingsMaxTotalHeaderLength = 50 * 1024
     }
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -129,7 +129,7 @@ data Settings = Settings
       --
       -- Since 3.3.5
     , settingsMaxTotalHeaderLength :: Int
-      -- ^ Determines the maximum header size that Warp will tolerate.
+      -- ^ Determines the maximum header size that Warp will tolerate when using HTTP/1.x.
       -- 
       -- Since 3.3.8
     }


### PR DESCRIPTION
The rationale behind this is allowing Warp to support clients that aren't well-behaved in the sense that they send massive request paths (for example).

---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->