### PR TITLE
export eventStreamAppRaw

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.29
+
+* Export `Network.Wai.EventSource.eventStreamAppRaw` [#786](https://github.com/yesodweb/wai/pull/786)
+
 ## 3.0.28
 
 * Add `Network.Wai.EventSource.eventStreamAppRaw` [#767](https://github.com/yesodweb/wai/pull/767)

--- a/wai-extra/Network/Wai/EventSource.hs
+++ b/wai-extra/Network/Wai/EventSource.hs
@@ -11,7 +11,8 @@
 module Network.Wai.EventSource (
     ServerEvent(..),
     eventSourceAppChan,
-    eventSourceAppIO
+    eventSourceAppIO,
+    eventStreamAppRaw
     ) where
 
 import           Data.Function (fix)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.28
+Version:             3.0.29
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
`eventStreamAppRaw` was added in https://github.com/yesodweb/wai/commit/c0e94e1aa8377d00ef2a6bcd808faae391f0310c but not exported.  This change exports it.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->