### PR TITLE
The time manger does not close sockets to prevent "Bad file descriptor"

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Recv.hs
+++ b/warp/Network/Wai/Handler/Warp/Recv.hs
@@ -96,6 +96,9 @@ spell init0 siz0 recv recvBuf
                 siz' = siz - len
             loop bss' siz'
 
+-- The timeout manager may close the socket.
+-- In that case, an error of "Bad file descriptor" occurs.
+-- We ignores it because we expect TimeoutThread.
 receive :: Socket -> BufferPool -> Recv
 receive sock pool = E.handle handler $ withBufferPool pool $ \ (ptr, size) -> do
 #if MIN_VERSION_network(3,1,0)

--- a/warp/Network/Wai/Handler/Warp/Recv.hs
+++ b/warp/Network/Wai/Handler/Warp/Recv.hs
@@ -17,7 +17,9 @@ import Foreign.C.Types
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import GHC.Conc (threadWaitRead)
+import qualified GHC.IO.Exception as E
 import Network.Socket (Socket)
+import qualified System.IO.Error as E
 #if MIN_VERSION_network(3,1,0)
 import Network.Socket (withFdSocket)
 #else
@@ -95,7 +97,7 @@ spell init0 siz0 recv recvBuf
             loop bss' siz'
 
 receive :: Socket -> BufferPool -> Recv
-receive sock pool = withBufferPool pool $ \ (ptr, size) -> do
+receive sock pool = E.handle handler $ withBufferPool pool $ \ (ptr, size) -> do
 #if MIN_VERSION_network(3,1,0)
   withFdSocket sock $ \fd -> do
 #elif MIN_VERSION_network(3,0,0)
@@ -105,6 +107,11 @@ receive sock pool = withBufferPool pool $ \ (ptr, size) -> do
 #endif
     let size' = fromIntegral size
     fromIntegral <$> receiveloop fd ptr size'
+  where
+    handler :: E.IOException -> IO ByteString
+    handler e
+      | E.ioeGetErrorType e == E.InvalidArgument = return ""
+      | otherwise                                = E.throwIO e
 
 receiveBuf :: Socket -> RecvBuf
 receiveBuf sock buf0 siz0 = do

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -311,7 +311,7 @@ fork set mkConn addr app counter ii = settingsFork set $ \unmask ->
            -- above ensures the connection is closed.
            when goingon $ serveConnection conn ii th addr transport set app
       where
-        register = T.registerKillThread (timeoutManager ii) (return ())
+        register = T.registerKillThread (timeoutManager ii) (connClose conn)
         cancel   = T.cancel
 
     onOpen adr    = increase counter >> settingsOnOpen  set adr


### PR DESCRIPTION
This should fix #739. To log exceptions from applications, I think `setOnException` should be used.

With this patch, 

```
threadWait: invalid argument (Bad file descriptor)
```

becomes

```
Thread killed by timeout manager
```

Please read #739 to know how to test.

@snoyberg I don't expect that this PR will be merged soon. Rather, I would like to discuss what behavior is reasonable.
