### PR TITLE
wai-app-static: Document the root path representation of `Pieces`

### DIFF
--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -59,6 +59,8 @@ toPieces :: [Text] -> Maybe Pieces
 toPieces = mapM toPiece
 
 -- | Request coming from a user. Corresponds to @pathInfo@.
+--
+-- The root path is the empty list.
 type Pieces = [Piece]
 
 -- | Values for the max-age component of the cache-control response header.


### PR DESCRIPTION
trivial doc improvement 