### PR TITLE
Feature/remove auth headers from logger

### DIFF
--- a/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
@@ -115,6 +115,8 @@ requestHeadersToJSON :: RequestHeaders -> Value
 requestHeadersToJSON = toJSON . map hToJ where
   -- Redact cookies
   hToJ ("Cookie", _) = toJSON ("Cookie" :: Text, "-RDCT-" :: Text)
+  -- Redact tokens
+  hToJ ("Authorization", _) = toJSON ("Authorization" :: Text, "-RDCT-" :: Text)
   hToJ hd = headerToJSON hd
 
 responseHeadersToJSON :: [Header] -> Value

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.29
+Version:             3.1.0
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

Was using JWT's in a personal project and realized it was logging all of them when they'd make a request. I have a workaround in the app, but figured this was potentially an easy change if you wanted something like that in here.