### PR TITLE
wai-extra: Fix Network.Wai.Test.request always sending an empty request body 

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.0.29.1
 
-* Fix `Network.Wai.request` always sending an empty request body [#794](https://github.com/yesodweb/wai/pull/794)
+* Fix `Network.Wai.Test.request` always sending an empty request body [#794](https://github.com/yesodweb/wai/pull/794)
 
 ## 3.0.29
 

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.29.1
+
+* Fix `Network.Wai.request` always sending an empty request body [#794](https://github.com/yesodweb/wai/pull/794)
+
 ## 3.0.29
 
 * Export `Network.Wai.EventSource.eventStreamAppRaw` [#786](https://github.com/yesodweb/wai/pull/786)

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -99,6 +99,10 @@ runSession session app = ST.evalStateT (runReaderT session app) initState
 data SRequest = SRequest
     { simpleRequest :: Request
     , simpleRequestBody :: L.ByteString
+    -- ^ Request body that will override the one set in 'simpleRequest'.
+    --
+    -- This is usually simpler than setting the body as a stateful IO-action
+    -- in 'simpleRequest'.
     }
 data SResponse = SResponse
     { simpleStatus :: H.Status
@@ -174,6 +178,8 @@ extractSetCookieFromSResponse response = do
        (Map.fromList [(Cookie.setCookieName c, c) | c <- newClientCookies ]))
   return response
 
+-- | Similar to 'request', but allows setting the request body as a plain
+-- 'L.ByteString'.
 srequest :: SRequest -> Session SResponse
 srequest (SRequest req bod) = do
     refChunks <- liftIO $ newIORef $ L.toChunks bod

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.29
+Version:             3.0.29.1
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

When trying to find out why request bodies went missing in our test suite, I noticed that `request` just calls `srequest` with an empty request body. This drops the existing body, which is not the behaviour I expected.

The first commit updates the tests to catch the problem:

```
  srequest
    returns the response body    of an echo app
  request
    returns the status code      of an echo app on default request
    returns the response body    of an echo app FAILED [1]
    returns the response headers of an echo app

Failures:

  test/Network/Wai/TestSpec.hs:98:7:
  1) Network.Wai.Test.request returns the response body    of an echo app
       expected: "request body"
        but got: ""

  To rerun use: --match "/Network.Wai.Test/request/returns the response body    of an echo app/"
```

I'm not sure if anyone is relying on the current behaviour, so please let me know if just increasing the patch number is no enough.
 