### PR TITLE
Convert ResourceVanished error to ConnectionClosedByPeer exception an…

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -43,7 +43,7 @@ module Network.Wai.Handler.WarpTLS (
     ) where
 
 import Control.Applicative ((<|>))
-import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException, handleJust)
+import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException, SomeException(..), handleJust)
 import qualified Control.Exception as E
 import Control.Monad (void, guard)
 import qualified Data.ByteString as S

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -43,7 +43,7 @@ module Network.Wai.Handler.WarpTLS (
     ) where
 
 import Control.Applicative ((<|>))
-import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException, SomeException(..), handleJust)
+import Control.Exception (Exception, throwIO, bracket, finally, handle, fromException, try, IOException, onException, handleJust)
 import qualified Control.Exception as E
 import Control.Monad (void, guard)
 import qualified Data.ByteString as S
@@ -52,6 +52,7 @@ import Data.Default.Class (def)
 import qualified Data.IORef as I
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)
+import GHC.IO.Exception (IOErrorType(..))
 import Network.Socket (Socket, close, withSocketsDo, SockAddr, accept)
 #if MIN_VERSION_network(3,1,1)
 import Network.Socket (gracefulClose)
@@ -64,7 +65,7 @@ import qualified Network.TLS.SessionManager as SM
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
-import System.IO.Error (isEOFError)
+import System.IO.Error (isEOFError, ioeGetErrorType)
 
 ----------------------------------------------------------------
 
@@ -368,8 +369,12 @@ httpOverTls TLSSettings{..} _set s bs0 params = do
       , TLS.backendSend  = sendAll' s
       , TLS.backendRecv  = recvN
       }
-    sendAll' sock bs = sendAll sock bs `E.catch` \(SomeException _) ->
-        throwIO ConnectionClosedByPeer
+    sendAll' sock bs = E.handleJust
+      (\ e -> if ioeGetErrorType e == ResourceVanished
+        then Just ConnectionClosedByPeer
+        else Nothing)
+      throwIO
+      $ sendAll sock bs
     conn ctx writeBuf ref isH2 = Connection {
         connSendMany         = TLS.sendData ctx . L.fromChunks
       , connSendAll          = sendall


### PR DESCRIPTION
…d refine the catching

Hi everyone. At @typeable, we have a big web application, one of its components is a web API served by a warp+wai+servant server. Every request takes a lot of time to be resolved due to connections to multiple external interfaces. If I close the http client (for example killing curl or closing the browser), `warp` returns an error like `Network.Socket.sendBuf: resource vanished (Broken pipe)`.

The reason is that the function `socketConnection`, in the `Network.Wai.Handler.Warp.Run` module, calls the `sendAll` function (from the `Network.Socket.ByteString` module) but the remote http client has already closed the connection.

I tried to create a simple example to reproduce this error, without success.
It might be related to https://github.com/yesodweb/wai/issues/196 or some bad interactions between warp+wai and the servant application. I have to admit that I still don't know the reason.

Anyway, inspired by this old issue https://github.com/yesodweb/wai/issues/421, I think it would be good to catch the `IOException` with error type `ResourceVanished` and throw a `ConnectionClosedByPeer`, like has been done in the `Network.Wai.Handler.WarpTLS` module.

I also refined the exception catching for both the `warp` and `warp-tls` package like was suggested here https://github.com/yesodweb/wai/commit/91d054635b35bfc1a7c7022cda9255365f231ffd#r12752366.

What do you think?