### PR TITLE
adding setAltSvc.

### DIFF
--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -75,6 +75,7 @@ module Network.Wai.Handler.Warp (
   , setGracefulCloseTimeout1
   , setGracefulCloseTimeout2
   , setMaxTotalHeaderLength
+  , setAltSvc
     -- ** Getters
   , getPort
   , getHost
@@ -449,6 +450,13 @@ setGracefulShutdownTimeout time y = y { settingsGracefulShutdownTimeout = time }
 setMaxTotalHeaderLength :: Int -> Settings -> Settings
 setMaxTotalHeaderLength maxTotalHeaderLength settings = settings
   { settingsMaxTotalHeaderLength = maxTotalHeaderLength }
+
+
+-- | Setting the header value of Alternative Services (AltSvc:).
+--
+-- Since 3.3.11
+setAltSvc :: ByteString -> Settings -> Settings
+setAltSvc altsvc settings = settings { settingsAltSvc = Just altsvc }
 
 -- | Explicitly pause the slowloris timeout.
 --

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Response.hs
@@ -48,7 +48,8 @@ fromResponse settings ii req rsp = do
     !isHead = requestMethod req == H.methodHead
     !reqhdr = requestHeaders req
     !svr    = S.settingsServerName settings
-    add date server rsphdr = (H.hDate, date) : (H.hServer, server) : rsphdr
+    add date server rsphdr = R.addAltSvc settings $
+        (H.hDate, date) : (H.hServer, server) : rsphdr
     -- fixme: not adding svr if already exists
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -130,8 +130,14 @@ data Settings = Settings
       -- Since 3.3.5
     , settingsMaxTotalHeaderLength :: Int
       -- ^ Determines the maximum header size that Warp will tolerate when using HTTP/1.x.
-      -- 
+      --
       -- Since 3.3.8
+    , settingsAltSvc :: Maybe ByteString
+      -- ^ Specify the header value of Alternative Services (AltSvc:).
+      --
+      -- Default: Nothing
+      --
+      -- Since 3.3.11
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -171,6 +177,7 @@ defaultSettings = Settings
     , settingsGracefulCloseTimeout1 = 0
     , settingsGracefulCloseTimeout2 = 2000
     , settingsMaxTotalHeaderLength = 50 * 1024
+    , settingsAltSvc = Nothing
     }
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an


### PR DESCRIPTION
I'm now implementing WarpQUIC. To access contents provided by WarpQUIC via Firefox nightly, the `AltSvc:` header is necessary:

```
Alt-Svc: h3-27=":4433"
```

This PR adds `setAltSvc` to specify such a value if necessary.