### PR TITLE
TLS parameters for sharing

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -24,6 +24,7 @@ module Network.Wai.Handler.WarpTLS (
     -- * Accessors
     , certFile
     , keyFile
+    , tlsCredentials
     , tlsLogging
     , tlsAllowedVersions
     , tlsCiphers
@@ -50,6 +51,7 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import Data.Default.Class (def)
 import qualified Data.IORef as I
+import Data.Maybe (isJust, fromJust)
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)
 import GHC.IO.Exception (IOErrorType(..))
@@ -158,6 +160,11 @@ data TLSSettings = TLSSettings {
     -- Default: Nothing
     --
     -- Since 3.2.4
+  , tlsCredentials :: Maybe TLS.Credentials
+    -- ^ Specifying 'TLS.Credentials' directly.  If this value is
+    --   specified, other fields such as 'certFile' are ignored.
+    --
+    --   Since 3.2.12
   }
 
 -- | Default 'TLSSettings'. Use this to create 'TLSSettings' with the field record name (aka accessors).
@@ -181,6 +188,7 @@ defaultTlsSettings = TLSSettings {
   , tlsServerHooks = def
   , tlsServerDHEParams = Nothing
   , tlsSessionManagerConfig = Nothing
+  , tlsCredentials = Nothing
   }
 
 -- taken from stunnel example in tls-extra
@@ -260,26 +268,31 @@ runTLS tset set app = withSocketsDo $
 
 ----------------------------------------------------------------
 
+loadCredentials :: TLSSettings -> IO TLS.Credentials
+loadCredentials TLSSettings{..}
+  | isJust tlsCredentials = return $ fromJust tlsCredentials
+loadCredentials TLSSettings{..} = case (certMemory, keyMemory) of
+    (Nothing, Nothing) -> do
+        cred <- either error id <$> TLS.credentialLoadX509Chain certFile chainCertFiles keyFile
+        return $ TLS.Credentials [cred]
+    (mcert, mkey) -> do
+        cert <- maybe (S.readFile certFile) return mcert
+        key <- maybe (S.readFile keyFile) return mkey
+        cred <- either error return $ TLS.credentialLoadX509ChainFromMemory cert chainCertsMemory key
+        return $ TLS.Credentials [cred]
+
 -- | Running 'Application' with 'TLSSettings' and 'Settings' using
 --   specified 'Socket'.
 runTLSSocket :: TLSSettings -> Settings -> Socket -> Application -> IO ()
 runTLSSocket tlsset@TLSSettings{..} set sock app = do
-    credential <- case (certMemory, keyMemory) of
-        (Nothing, Nothing) ->
-            either error id <$>
-            TLS.credentialLoadX509Chain certFile chainCertFiles keyFile
-        (mcert, mkey) -> do
-            cert <- maybe (S.readFile certFile) return mcert
-            key <- maybe (S.readFile keyFile) return mkey
-            either error return $
-              TLS.credentialLoadX509ChainFromMemory cert chainCertsMemory key
+    credentials <- loadCredentials tlsset
     mgr <- case tlsSessionManagerConfig of
       Nothing     -> return TLS.noSessionManager
       Just config -> SM.newSessionManager config
-    runTLSSocket' tlsset set credential mgr sock app
+    runTLSSocket' tlsset set credentials mgr sock app
 
-runTLSSocket' :: TLSSettings -> Settings -> TLS.Credential -> TLS.SessionManager -> Socket -> Application -> IO ()
-runTLSSocket' tlsset@TLSSettings{..} set credential mgr sock app =
+runTLSSocket' :: TLSSettings -> Settings -> TLS.Credentials -> TLS.SessionManager -> Socket -> Application -> IO ()
+runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock app =
     runSettingsConnectionMakerSecure set get app
   where
     get = getter tlsset set sock params
@@ -300,7 +313,7 @@ runTLSSocket' tlsset@TLSSettings{..} set credential mgr sock app =
           (if settingsHTTP2Enabled set then Just alpn else Nothing)
       }
     shared = def {
-        TLS.sharedCredentials    = TLS.Credentials [credential]
+        TLS.sharedCredentials    = credentials
       , TLS.sharedSessionManager = mgr
       }
     supported = def { -- TLS.Supported

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -52,7 +52,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import Data.Default.Class (def)
 import qualified Data.IORef as I
-import Data.Maybe (isJust, fromJust)
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)
 import GHC.IO.Exception (IOErrorType(..))
@@ -276,8 +275,7 @@ runTLS tset set app = withSocketsDo $
 ----------------------------------------------------------------
 
 loadCredentials :: TLSSettings -> IO TLS.Credentials
-loadCredentials TLSSettings{..}
-  | isJust tlsCredentials = return $ fromJust tlsCredentials
+loadCredentials TLSSettings{ tlsCredentials = Just creds } = return creds
 loadCredentials TLSSettings{..} = case (certMemory, keyMemory) of
     (Nothing, Nothing) -> do
         cred <- either error id <$> TLS.credentialLoadX509Chain certFile chainCertFiles keyFile
@@ -289,9 +287,8 @@ loadCredentials TLSSettings{..} = case (certMemory, keyMemory) of
         return $ TLS.Credentials [cred]
 
 getSessionManager :: TLSSettings -> IO TLS.SessionManager
-getSessionManager TLSSettings{..}
-  | isJust tlsSessionManager = return $ fromJust tlsSessionManager
-  | otherwise = case tlsSessionManagerConfig of
+getSessionManager TLSSettings{ tlsSessionManager = Just mgr } = return mgr
+getSessionManager TLSSettings{..} = case tlsSessionManagerConfig of
       Nothing     -> return TLS.noSessionManager
       Just config -> SM.newSessionManager config
 


### PR DESCRIPTION
I would like to share credentials and a session manager between warp-tls and warp-quic. For this purpose, I would like to add new config fields. If these values are `Nothing` (default), no behavior changed. If these values are `Just`, the values are used. This code is already tested in the real world.