### PR TITLE
Add the ability to load TLS credentials from IORefs

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.2.13
+
+* Config fields for retrieving TLS credentials from an IORef.
+  [#806](https://github.com/yesodweb/wai/pull/806)
+
 ## 3.2.12
 
 * A config field: tlsCredentials and tlsSessionManager.

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,6 +1,6 @@
-## 3.2.13
+## 3.3.0
 
-* Config fields for retrieving TLS credentials from an IORef.
+* Allow TLS credentials to be retrieved from an IORef.
   [#806](https://github.com/yesodweb/wai/pull/806)
 
 ## 3.2.12

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -91,7 +91,9 @@ data TLSSettings = TLSSettings {
     -- loaded from?
     --
     -- >>> certSettings defaultTlsSettings
+    -- tlsSettings "certificate.pem" "key.pem"
     -- 
+    -- @since 3.3.0
   , onInsecure :: OnInsecure
     -- ^ Do we allow insecure connections with this server as well?
     --
@@ -264,7 +266,7 @@ tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings {
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
--- @since 3.2.13
+-- @since 3.3.0
 tlsSettingsRef 
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> I.IORef (S.ByteString) -- ^ Reference to key bytes 
@@ -276,7 +278,7 @@ tlsSettingsRef cert key = defaultTlsSettings {
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
--- @since 3.2.13
+-- @since 3.3.0
 tlsSettingsChainRef 
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> [I.IORef S.ByteString] -- ^ Reference to chain certificate bytes

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -276,7 +276,7 @@ tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
--- Since ???
+-- @since 3.2.13
 tlsSettingsRef 
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> I.IORef (S.ByteString) -- ^ Reference to key bytes 
@@ -289,7 +289,7 @@ tlsSettingsRef cert key = defaultTlsSettings
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
--- Since ???
+-- @since 3.2.13
 tlsSettingsChainRef 
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> I.IORef [S.ByteString] -- ^ Reference to chain certificate bytes

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.2.13
+Version:             3.3.0
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.2.12
+Version:             3.2.13
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
This PR adds three new configuration fields to `TLSSettings` for retrieving the certificate bytes, chain certificate bytes, and key bytes from `IORef`s. This is potentially useful for scenarios where the certificate may need to change at runtime, e.g. if ACME is used. In theory, this would prevent an ACME implementation from having to terminate the server thread in order to call `runTLS` with new TLS credentials. However, there is currently no ACME implementation in Haskell (to my knowledge), so this is a somewhat speculative PR. 

