### PR TITLE
Network.Wai.Test: Add support for source locations to assertion primitives

### DIFF
--- a/wai-extra/.ghci
+++ b/wai-extra/.ghci
@@ -1,1 +1,2 @@
 :set -itest -optP-include -optPdist/build/autogen/cabal_macros.h
+:set -XOverloadedStrings

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.30
+
+* `Network.Wai.Test`: Add support source locations to assertion primitives [#812](https://github.com/yesodweb/wai/pull/812)
+
 ## 3.0.29.2
 
 * flush SSE headers early [#804](https://github.com/yesodweb/wai/pull/804)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.29.2
+Version:             3.0.30
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:
@@ -116,6 +116,8 @@ Library
                    , aeson
                    , iproute
                    , http2
+                   , HUnit
+                   , call-stack
 
   if os(windows)
       cpp-options:   -DWINDOWS


### PR DESCRIPTION
In addition, this will result in more readable test failures.

Before:
---
![before](https://user-images.githubusercontent.com/461132/93438026-e96b7b80-f8f6-11ea-9aae-04525929855a.png)
---
After:
---
![after](https://user-images.githubusercontent.com/461132/93438049-f1c3b680-f8f6-11ea-99b5-19c3829e21ae.png)



---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->