### PR TITLE
Fix GHC 7.10 build failure in wai-extra

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.32
+
+* Fix the GHC 7.10 build [#813](https://github.com/yesodweb/wai/pull/813)
+
 ## 3.0.31
 
 * Undo WaiTestFailure change in previous release

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Network.Wai.Test
     ( -- * Session
       Session

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.31
+Version:             3.0.32
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
`wai-extra-3.0.31` fails to build with GHC 7.10.3, as demonstrated in [this failing Travis build](https://travis-ci.org/github/ku-fpg/blank-canvas/jobs/728110964#L1377):

<details>

```
[ 4 of 32] Compiling Network.Wai.Test ( Network/Wai/Test.hs, interpreted )

Network/Wai/Test.hs:210:15:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertBool’:
      assertBool :: HasCallStack => String -> Bool -> Session ()

Network/Wai/Test.hs:213:17:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertString’:
      assertString :: HasCallStack => String -> Session ()

Network/Wai/Test.hs:216:18:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertFailure’:
      assertFailure :: HasCallStack => String -> Session ()

Network/Wai/Test.hs:223:22:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertContentType’:
      assertContentType :: HasCallStack =>
                           ByteString -> SResponse -> Session ()

Network/Wai/Test.hs:240:17:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertStatus’:
      assertStatus :: HasCallStack => Int -> SResponse -> Session ()

Network/Wai/Test.hs:250:15:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertBody’:
      assertBody :: HasCallStack =>
                    L8.ByteString -> SResponse -> Session ()

Network/Wai/Test.hs:258:23:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertBodyContains’:
      assertBodyContains :: HasCallStack =>
                            L8.ByteString -> SResponse -> Session ()

Network/Wai/Test.hs:268:17:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertHeader’:
      assertHeader :: HasCallStack =>
                      CI ByteString -> ByteString -> SResponse -> Session ()

Network/Wai/Test.hs:287:19:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertNoHeader’:
      assertNoHeader :: HasCallStack =>
                        CI ByteString -> SResponse -> Session ()

Network/Wai/Test.hs:301:29:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertClientCookieExists’:
      assertClientCookieExists :: HasCallStack =>
                                  String -> ByteString -> Session ()

Network/Wai/Test.hs:309:31:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertNoClientCookieExists’:
      assertNoClientCookieExists :: HasCallStack =>
                                    String -> ByteString -> Session ()

Network/Wai/Test.hs:317:28:
    Non type-variable argument
      in the constraint: ?callStack::GHC.Stack.CallStack
    (Use FlexibleContexts to permit this)
    In the type signature for ‘assertClientCookieValue’:
      assertClientCookieValue :: HasCallStack =>
                                 String -> ByteString -> ByteString -> Session ()
```
</details>

I opted to fix the issue by always enabling `FlexibleContexts`, even though newer versions of GHC technically do not require it.

-----

Before submitting your PR, check that you've:

- [X] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->