### PR TITLE
Network.Wai.Test: Re-enable support for source locations + turn WaiTestFailure into a pattern synonym

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.0.32
+
+* Fix the GHC 7.10 build [#813](https://github.com/yesodweb/wai/pull/813)
+
 ## 3.0.31
 
 * Undo WaiTestFailure change in previous release

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -3,6 +3,9 @@
 ## 3.0.32
 
 * Fix the GHC 7.10 build [#813](https://github.com/yesodweb/wai/pull/813)
+* `Network.Wai.Test`: Turn `WaiTestFailure` into a pattern synonym for
+  `HUnitFailure` and re-enable support for source locations
+  [#814](https://github.com/yesodweb/wai/pull/814)
 
 ## 3.0.31
 

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Network.Wai.Test
     ( -- * Session
       Session

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.0.31
+Version:             3.0.32
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -107,7 +107,6 @@ Library
                    , containers
                    , base64-bytestring
                    , word8
-                   , deepseq
                    , streaming-commons         >= 0.2
                    , unix-compat
                    , cookie
@@ -116,6 +115,7 @@ Library
                    , aeson
                    , iproute
                    , http2
+                   , HUnit
                    , call-stack
 
   if os(windows)


### PR DESCRIPTION
This PR includes https://github.com/yesodweb/wai/pull/813 (thanks @RyanGlScott).

---
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->