### PR TITLE
Added ssUnhandledRequestHandler

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -49,6 +49,7 @@ defaultWebAppSettings root = StaticSettings
     , ssUseHash = True
     , ssAddTrailingSlash = False
     , ss404Handler = Nothing
+    , ssUnhandledRequestHandler = Nothing
     }
 
 -- | Settings optimized for a file server. More conservative caching will be
@@ -66,6 +67,7 @@ defaultFileServerSettings root = StaticSettings
     , ssUseHash = False
     , ssAddTrailingSlash = False
     , ss404Handler = Nothing
+    , ssUnhandledRequestHandler = Nothing
     }
 
 -- | Same as @defaultWebAppSettings@, but additionally uses a specialized

--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -150,4 +150,14 @@ data StaticSettings = StaticSettings
       --
       -- Since 3.1.3
     , ss404Handler :: Maybe W.Application
+
+      -- | Optional `W.Application` to be used in case of requests that cannot
+      -- be handled by wai-app-static, for example, @POST@, @PUT@, @DELETE@,
+      -- etc. requests. In absence of this configuration, wai-app-static will
+      -- respond wit a @405 Method Not Allowed@ error.
+      --
+      -- __IMPORTANT:__ Be careful of how this interacts with 'ss404Handler'
+      --
+      -- @since 3.1.8.0
+    , ssUnhandledRequestHandler :: Maybe W.Application
     }

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.7.2
+version:         3.1.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
wai-app-static used to summarily reject any request that
was not a GET or HEAD. This made it very difficult to use
it as a "middleware" of sorts in front of anything that was
expecting POST/PUT/DELETE requests, eg. a Scotty application.

ssUnhandledRequestHandler gives an optional  hook (similar to
ss404Handler) to allow wai-app-static to pass on non GET/HEAD
requests to another Wai application.

Fixes #819 



Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->