### PR TITLE
Request logger detailed settings

### DIFF
--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -49,6 +49,7 @@ library
                    , zlib                      >= 0.5
                    , filepath
                    , wai-extra                 >= 3.0      && < 3.2
+                   , wai-extra                 >= 3.1      && < 3.2
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.4
 

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -48,7 +48,7 @@ library
                    , template-haskell          >= 2.7
                    , zlib                      >= 0.5
                    , filepath
-                   , wai-extra                 >= 3.1      && < 3.2
+                   , wai-extra                 >= 3.0      && < 3.2
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.4
 

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -48,7 +48,6 @@ library
                    , template-haskell          >= 2.7
                    , zlib                      >= 0.5
                    , filepath
-                   , wai-extra                 >= 3.0      && < 3.2
                    , wai-extra                 >= 3.1      && < 3.2
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.4

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.3
+
+* Add a `DetailedWithSettings` output format for `RequestLogger` that allows to hide requests and modify query parameters
+
 ## 3.1.2
 
 * Remove an extraneous dot from the error message for `defaultRequestSizeLimitSettings`

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.1.3
 
-* Add a `DetailedWithSettings` output format for `RequestLogger` that allows to hide requests and modify query parameters
+* Add a `DetailedWithSettings` output format for `RequestLogger` that allows to hide requests and modify query parameters [#826](https://github.com/yesodweb/wai/pull/826)
 
 ## 3.1.2
 

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -34,7 +34,7 @@ import Network.Wai
   )
 import System.Log.FastLogger
 import Network.HTTP.Types as H
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.Monoid (mconcat, (<>))
 import Data.Time (getCurrentTime, diffUTCTime, NominalDiffTime)
 import Network.Wai.Parse (sinkRequestBody, lbsBackEnd, fileName, Param, File
@@ -71,7 +71,7 @@ data OutputFormat
 -- `requestFilter` allows you to filter which requests are logged.
 data DetailedSettings = DetailedSettings
     { useColors :: Bool
-    , mModifyParams :: Maybe (Param -> Param)
+    , mModifyParams :: Maybe (Param -> Maybe Param)
     , mFilterRequests :: Maybe (Request -> Response -> Bool)
     }
 instance Default DetailedSettings where
@@ -346,7 +346,7 @@ detailedMiddleware' cb DetailedSettings{..} ansiColor ansiMethod ansiStatusCode 
       else do (unmodifiedPostParams, files) <- liftIO $ allPostParams body
               let postParams =
                     case mModifyParams of
-                      Just modifyParams -> map modifyParams unmodifiedPostParams
+                      Just modifyParams -> mapMaybe modifyParams unmodifiedPostParams
                       Nothing -> unmodifiedPostParams
               return $ collectPostParams (postParams, files)
 

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -12,6 +12,7 @@ module Network.Wai.Middleware.RequestLogger
     , autoFlush
     , destination
     , OutputFormat (..)
+    , DetailedSettings(..)
     , OutputFormatter
     , OutputFormatterWithDetails
     , OutputFormatterWithDetailsAndHeaders
@@ -51,25 +52,36 @@ import Network.Wai.Header (contentLength)
 import Data.Text.Encoding (decodeUtf8')
 
 -- | The logging format.
---
--- The Detailed format takes two parameters. The first is a `Bool` for whether to use ANSI colors.
+data OutputFormat
+  = Apache IPAddrSource
+  | Detailed DetailedSettings
+  | CustomOutputFormat OutputFormatter
+  | CustomOutputFormatWithDetails OutputFormatterWithDetails
+  | CustomOutputFormatWithDetailsAndHeaders OutputFormatterWithDetailsAndHeaders
 
--- The second is a `Maybe (Param -> Param)`, to allow you to pass a function to hide confidential
+-- | Settings for the `Detailed` `OutputFormat`.
+--
+-- `paramFilter` allows you to pass a function to hide confidential
 -- information (such as passwords) from the logs. If the second parameter is `Just`, then POST
 -- bodies are also hidden. For example:
 -- > myformat = Detailed True (Just hidePasswords)
 -- >   where hidePasswords p@(k,v) = if k = "password" then (k, "***REDACTED***") else p
 --
--- Default is `Detailed True Nothing`
-data OutputFormat
-  = Apache IPAddrSource
-  | Detailed Bool -- ^ use colors?
-             (Maybe (Param -> Param)) -- ^ @since 3.1.0
-  | CustomOutputFormat OutputFormatter
-  | CustomOutputFormatWithDetails OutputFormatterWithDetails
-  | CustomOutputFormatWithDetailsAndHeaders OutputFormatterWithDetailsAndHeaders
+-- `requestFilter` allows you to filter which requests are logged.
+data DetailedSettings = DetailedSettings
+    { useColors :: Bool
+    , mModifyParams :: Maybe (Param -> Param)
+    , mFilterRequests :: Maybe (Request -> Bool)
+    }
+instance Default DetailedSettings where
+    def = DetailedSettings
+        { useColors = True
+        , mModifyParams = Nothing
+        , mFilterRequests = Nothing
+        }
 
-type OutputFormatter = ZonedDate -> Request -> Status -> Maybe Integer -> LogStr
+type OutputFormatter
+  = ZonedDate -> Request -> Status -> Maybe Integer -> LogStr
 
 type OutputFormatterWithDetails
    = ZonedDate
@@ -124,7 +136,7 @@ data RequestLoggerSettings = RequestLoggerSettings
 
 instance Default RequestLoggerSettings where
     def = RequestLoggerSettings
-        { outputFormat = Detailed True Nothing
+        { outputFormat = Detailed def
         , autoFlush = True
         , destination = Handle stdout
         }
@@ -142,7 +154,7 @@ mkRequestLogger RequestLoggerSettings{..} = do
             getdate <- getDateGetter flusher
             apache <- initLogger ipsrc (LogCallback callback flusher) getdate
             return $ apacheMiddleware apache
-        Detailed useColors modifyParams -> detailedMiddleware callbackAndFlush useColors modifyParams
+        Detailed settings -> detailedMiddleware callbackAndFlush settings
         CustomOutputFormat formatter -> do
             getDate <- getDateGetter flusher
             return $ customMiddleware callbackAndFlush getDate formatter
@@ -237,14 +249,14 @@ logStdoutDev = unsafePerformIO $ mkRequestLogger def
 -- >   Accept: text/css,*/*;q=0.1
 -- >   Status: 304 Not Modified 0.010555s
 
-detailedMiddleware :: Callback -> Bool -> Maybe (Param -> Param) -> IO Middleware
-detailedMiddleware cb useColors mModifyParams =
+detailedMiddleware :: Callback -> DetailedSettings -> IO Middleware
+detailedMiddleware cb settings =
     let (ansiColor, ansiMethod, ansiStatusCode) =
-          if useColors
+          if useColors settings
             then (ansiColor', ansiMethod', ansiStatusCode')
             else (\_ t -> [t], (:[]), \_ t -> [t])
 
-    in return $ detailedMiddleware' cb mModifyParams ansiColor ansiMethod ansiStatusCode
+    in return $ detailedMiddleware' cb settings ansiColor ansiMethod ansiStatusCode
 
 ansiColor' :: Color -> BS.ByteString -> [BS.ByteString]
 ansiColor' color bs =
@@ -306,61 +318,64 @@ getRequestBody req = do
   return (req', body)
 
 detailedMiddleware' :: Callback
-                    -> Maybe (Param -> Param)
+                    -> DetailedSettings
                     -> (Color -> BS.ByteString -> [BS.ByteString])
                     -> (BS.ByteString -> [BS.ByteString])
                     -> (BS.ByteString -> BS.ByteString -> [BS.ByteString])
                     -> Middleware
-detailedMiddleware' cb mModifyParams ansiColor ansiMethod ansiStatusCode app req sendResponse = do
-    (req', body) <-
-        -- second tuple item should not be necessary, but a test runner might mess it up
-        case (requestBodyLength req, contentLength (requestHeaders req)) of
-            -- log the request body if it is small
-            (KnownLength len, _) | len <= 2048 -> getRequestBody req
-            (_, Just len)        | len <= 2048 -> getRequestBody req
-            _ -> return (req, [])
+detailedMiddleware' cb DetailedSettings{..} ansiColor ansiMethod ansiStatusCode app req sendResponse =
+  case mFilterRequests of
+    Just f | f req -> do
+      (req', body) <-
+          -- second tuple item should not be necessary, but a test runner might mess it up
+          case (requestBodyLength req, contentLength (requestHeaders req)) of
+              -- log the request body if it is small
+              (KnownLength len, _) | len <= 2048 -> getRequestBody req
+              (_, Just len)        | len <= 2048 -> getRequestBody req
+              _ -> return (req, [])
 
-    let reqbodylog _ = if null body || isJust mModifyParams
-                        then [""]
-                        else ansiColor White "  Request Body: " <> body <> ["\n"]
-        reqbody = concatMap (either (const [""]) reqbodylog . decodeUtf8') body
-    postParams <- if requestMethod req `elem` ["GET", "HEAD"]
-        then return []
-        else do (unmodifiedPostParams, files) <- liftIO $ allPostParams body
-                let postParams =
-                      case mModifyParams of
-                        Just modifyParams -> map modifyParams unmodifiedPostParams
-                        Nothing -> unmodifiedPostParams
-                return $ collectPostParams (postParams, files)
+      let reqbodylog _ = if null body || isJust mModifyParams
+                          then [""]
+                          else ansiColor White "  Request Body: " <> body <> ["\n"]
+          reqbody = concatMap (either (const [""]) reqbodylog . decodeUtf8') body
+      postParams <- if requestMethod req `elem` ["GET", "HEAD"]
+          then return []
+          else do (unmodifiedPostParams, files) <- liftIO $ allPostParams body
+                  let postParams =
+                        case mModifyParams of
+                          Just modifyParams -> map modifyParams unmodifiedPostParams
+                          Nothing -> unmodifiedPostParams
+                  return $ collectPostParams (postParams, files)
 
-    let getParams = map emptyGetParam $ queryString req
-        accept = fromMaybe "" $ lookup H.hAccept $ requestHeaders req
-        params = let par | not $ null postParams = [pack (show postParams)]
-                         | not $ null getParams  = [pack (show getParams)]
-                         | otherwise             = []
-                 in if null par then [""] else ansiColor White "  Params: " <> par <> ["\n"]
+      let getParams = map emptyGetParam $ queryString req
+          accept = fromMaybe "" $ lookup H.hAccept $ requestHeaders req
+          params = let par | not $ null postParams = [pack (show postParams)]
+                          | not $ null getParams  = [pack (show getParams)]
+                          | otherwise             = []
+                  in if null par then [""] else ansiColor White "  Params: " <> par <> ["\n"]
 
-    t0 <- getCurrentTime
-    app req' $ \rsp -> do
-        let isRaw =
-                case rsp of
-                    ResponseRaw{} -> True
-                    _ -> False
-            stCode = statusBS rsp
-            stMsg = msgBS rsp
-        t1 <- getCurrentTime
+      t0 <- getCurrentTime
+      app req' $ \rsp -> do
+          let isRaw =
+                  case rsp of
+                      ResponseRaw{} -> True
+                      _ -> False
+              stCode = statusBS rsp
+              stMsg = msgBS rsp
+          t1 <- getCurrentTime
 
-        -- log the status of the response
-        cb $ mconcat $ map toLogStr $
-            ansiMethod (requestMethod req) ++ [" ", rawPathInfo req, "\n"] ++
-            params ++ reqbody ++
-            ansiColor White "  Accept: " ++ [accept, "\n"] ++
-            if isRaw then [] else
-                ansiColor White "  Status: " ++
-                ansiStatusCode stCode (stCode <> " " <> stMsg) ++
-                [" ", pack $ show $ diffUTCTime t1 t0, "\n"]
+          -- log the status of the response
+          cb $ mconcat $ map toLogStr $
+              ansiMethod (requestMethod req) ++ [" ", rawPathInfo req, "\n"] ++
+              params ++ reqbody ++
+              ansiColor White "  Accept: " ++ [accept, "\n"] ++
+              if isRaw then [] else
+                  ansiColor White "  Status: " ++
+                  ansiStatusCode stCode (stCode <> " " <> stMsg) ++
+                  [" ", pack $ show $ diffUTCTime t1 t0, "\n"]
 
-        sendResponse rsp
+          sendResponse rsp
+    _ -> app req sendResponse
   where
     allPostParams body =
         case getRequestBodyType req of

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -55,7 +55,7 @@ import Data.Text.Encoding (decodeUtf8')
 data OutputFormat
   = Apache IPAddrSource
   | Detailed Bool -- ^ use colors?
-  | DetailedWithSettings DetailedSettings
+  | DetailedWithSettings DetailedSettings -- ^ @since 3.1.3
   | CustomOutputFormat OutputFormatter
   | CustomOutputFormatWithDetails OutputFormatterWithDetails
   | CustomOutputFormatWithDetailsAndHeaders OutputFormatterWithDetailsAndHeaders
@@ -70,6 +70,8 @@ data OutputFormat
 --
 -- `mFilterRequests` allows you to filter which requests are logged, based on
 -- the request and response.
+--
+-- @since 3.1.3
 data DetailedSettings = DetailedSettings
     { useColors :: Bool
     , mModifyParams :: Maybe (Param -> Maybe Param)

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -470,7 +470,7 @@ caseModifyPostParamsInLogs = do
     postOutputStart params = TE.encodeUtf8 $ T.toStrict $ "POST /\n  Params: " <> (T.pack . show $ params)
     postOutputEnd = TE.encodeUtf8 $ T.toStrict "s\n"
 
-    hidePasswords p@(k,_) = if k == "password" then (k, "***REDACTED***") else p
+    hidePasswords p@(k,_) = Just $ if k == "password" then (k, "***REDACTED***") else p
 
     debugApp format output req send = do
         iactual <- I.newIORef mempty

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -350,7 +350,7 @@ caseDebugRequestBody = do
         iactual <- I.newIORef mempty
         middleware <- mkRequestLogger def
             { destination = Callback $ \strs -> I.modifyIORef iactual $ (`mappend` strs)
-            , outputFormat = Detailed False Nothing
+            , outputFormat = Detailed $ DetailedSettings False Nothing Nothing
             }
         res <- middleware (\_req f -> f $ responseLBS status200 [ ] "") req send
         actual <- logToBs <$> I.readIORef iactual
@@ -453,12 +453,12 @@ caseStreamLBS = flip runSession streamLBSApp $ do
 
 caseModifyPostParamsInLogs :: Assertion
 caseModifyPostParamsInLogs = do
-    flip runSession (debugApp (Detailed False Nothing) unredacted) $ do
+    flip runSession (debugApp (Detailed $ DetailedSettings False Nothing Nothing) unredacted) $ do
         let req = toRequest "application/x-www-form-urlencoded" "username=some_user&password=dont_show_me"
         res <- srequest req
         assertStatus 200 res
 
-    flip runSession (debugApp (Detailed False (Just hidePasswords)) redacted) $ do
+    flip runSession (debugApp (Detailed $ DetailedSettings False (Just hidePasswords) Nothing) redacted) $ do
         let req = toRequest "application/x-www-form-urlencoded" "username=some_user&password=dont_show_me"
         res <- srequest req
         assertStatus 200 res

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -350,7 +350,7 @@ caseDebugRequestBody = do
         iactual <- I.newIORef mempty
         middleware <- mkRequestLogger def
             { destination = Callback $ \strs -> I.modifyIORef iactual $ (`mappend` strs)
-            , outputFormat = Detailed $ DetailedSettings False Nothing Nothing
+            , outputFormat = Detailed False
             }
         res <- middleware (\_req f -> f $ responseLBS status200 [ ] "") req send
         actual <- logToBs <$> I.readIORef iactual
@@ -453,12 +453,12 @@ caseStreamLBS = flip runSession streamLBSApp $ do
 
 caseModifyPostParamsInLogs :: Assertion
 caseModifyPostParamsInLogs = do
-    flip runSession (debugApp (Detailed $ DetailedSettings False Nothing Nothing) unredacted) $ do
+    flip runSession (debugApp (DetailedWithSettings $ DetailedSettings False Nothing Nothing) unredacted) $ do
         let req = toRequest "application/x-www-form-urlencoded" "username=some_user&password=dont_show_me"
         res <- srequest req
         assertStatus 200 res
 
-    flip runSession (debugApp (Detailed $ DetailedSettings False (Just hidePasswords) Nothing) redacted) $ do
+    flip runSession (debugApp (DetailedWithSettings $ DetailedSettings False (Just hidePasswords) Nothing) redacted) $ do
         let req = toRequest "application/x-www-form-urlencoded" "username=some_user&password=dont_show_me"
         res <- srequest req
         assertStatus 200 res

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.2
+Version:             3.1.3
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

This PR solves #774 in combination with a way to hide health-check logs, adapting the solution of #776.
The request filter can be generalized to the other output formats, but that was out of scope for our use case and would be more invasive.