### PR TITLE
Add requestToJSON to API, for external use

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.4
+
+* Export `Network.Wai.Middleware.RequestLogger.JSON.requestToJSON` [#827](https://github.com/yesodweb/wai/pull/827)
+
 ## 3.1.3
 
 * Add a `DetailedWithSettings` output format for `RequestLogger` that allows to hide requests and modify query parameters [#826](https://github.com/yesodweb/wai/pull/826)

--- a/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
@@ -76,13 +76,31 @@ word32ToHostAddress = T.intercalate "." . map (T.pack . show) . fromIPv4 . fromH
 readAsDouble :: String -> Double
 readAsDouble = read
 
--- | Get the JSON output for a request
+-- | Get the JSON representation for a request
 --
--- This gives a sensible JSON representation for the given request. You can
--- optionally include a request body, as well as a duration.
+-- This representation is identical to that used in 'formatAsJSON' for the
+-- request. It includes:
+--
+--   [@method@]:
+--   [@path@]:
+--   [@queryString@]:
+--   [@size@]: The size of the body, as defined in the request. This may differ
+--   from the size of the data passed in the second argument.
+--   [@body@]: The body, concatenated directly from the chunks passed in
+--   [@remoteHost@]:
+--   [@httpVersion@]:
+--   [@headers@]:
+--
+-- If a @'Just' duration@ is passed in, then additionally the JSON includes:
+--
+--   [@durationMs@] The duration, formatted in milliseconds, to 2 decimal
+--   places
 --
 -- @since 3.1.4
-requestToJSON ::  Request -> [S8.ByteString] -> Maybe NominalDiffTime -> Value
+requestToJSON :: Request -- ^ The WAI request
+              -> [S8.ByteString] -- ^ Chunked request body
+              -> Maybe NominalDiffTime -- ^ Optional request duration
+              -> Value
 requestToJSON req reqBody duration =
   object $
     [ "method" .= decodeUtf8With lenientDecode (requestMethod req)

--- a/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
@@ -96,6 +96,9 @@ readAsDouble = read
 --   [@durationMs@] The duration, formatted in milliseconds, to 2 decimal
 --   places
 --
+-- This representation is not an API, and may change at any time (within reason)
+-- without a major version bump.
+--
 -- @since 3.1.4
 requestToJSON :: Request -- ^ The WAI request
               -> [S8.ByteString] -- ^ Chunked request body

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.3
+Version:             3.1.4
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
This adds `requestToJSON` to the API, since I want to access WAI's representation of requests as JSON for [`yesod-katip`](https://github.com/ivanbakel/yesod-katip), a logging library.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->