### PR TITLE
UTF-8 encoding in exceptionResponseForDebug

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 3.3.14
 
 * UTF-8 encoding in `exceptionResponseForDebug`.
+  [#836](https://github.com/yesodweb/wai/pull/836)
 
 ## 3.3.13
 

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,7 @@
+## 3.3.14
+
+* UTF-8 encoding in `exceptionResponseForDebug`.
+
 ## 3.3.13
 
 * pReadMaker is exported from the Internal module.

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -11,6 +11,7 @@ import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Lazy (fromStrict)
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
 import Data.Version (showVersion)
 import GHC.IO.Exception (IOErrorType(..))
@@ -235,4 +236,4 @@ exceptionResponseForDebug :: SomeException -> Response
 exceptionResponseForDebug e =
     responseBuilder H.internalServerError500
                     [(H.hContentType, "text/plain; charset=utf-8")]
-                    $ byteString . C8.pack $ "Exception: " ++ show e
+                    $ byteString . TE.encodeUtf8 . T.pack $ "Exception: " ++ show e

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -6,7 +6,6 @@ module Network.Wai.Handler.Warp.Settings where
 
 import Control.Concurrent (forkIOWithUnmask)
 import Control.Exception
-import Data.ByteString.Builder (byteString)
 import qualified Data.ByteString.Char8 as C8
 import Data.ByteString.Lazy (fromStrict)
 import Data.Streaming.Network (HostPreference)
@@ -236,4 +235,4 @@ exceptionResponseForDebug :: SomeException -> Response
 exceptionResponseForDebug e =
     responseBuilder H.internalServerError500
                     [(H.hContentType, "text/plain; charset=utf-8")]
-                    $ byteString . TE.encodeUtf8 . T.pack $ "Exception: " ++ show e
+                    $ TE.encodeUtf8Builder . T.pack $ "Exception: " ++ show e

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.13
+Version:             3.3.14
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
`exceptionResponseForDebug` truncates any non-ASCII characters in exception error message due to packing error `String` as 8-bit `ByteString`. This PR fixes it.

---

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->