### PR TITLE
remove unused dependencies in wai-extra

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.6
+
+* Remove unused dependencies [#837](https://github.com/yesodweb/wai/pull/837)
+
 ## 3.1.5
 
 * `Network.Wai.Middleware.RealIp`: Add a new middleware to infer the remote IP address from headers [#834](https://github.com/yesodweb/wai/pull/834)

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -8,7 +8,7 @@ import Network.Wai (responseStream)
 import Network.Wai.Internal
 import Network.Wai (Middleware, responseToStream)
 import qualified Data.ByteString.Char8 as S8
-import System.PosixCompat (getFileStatus, fileSize, FileOffset)
+import System.Directory (getFileSize)
 import Network.HTTP.Types (hContentLength)
 
 -- |Convert ResponseFile type responses into ResponseStream type
@@ -36,8 +36,3 @@ streamFile app env sendResponse = app env $ \res ->
                let hs' = (hContentLength, (S8.pack (show len))) : hs
                sendResponse $ responseStream s hs' body
       _ -> sendResponse res
-
-getFileSize :: FilePath -> IO FileOffset
-getFileSize path = do
-    stat <- getFileStatus path
-    return (fileSize stat)

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -44,9 +44,6 @@ import Control.Monad.Trans.Class (lift)
 import qualified Control.Monad.Trans.State as ST
 import Control.Monad.Trans.Reader (runReaderT, ask)
 import Control.Monad (unless)
-import Control.DeepSeq (deepseq)
-import Control.Exception (throwIO, Exception)
-import Data.Typeable (Typeable)
 import qualified Data.Map as Map
 import qualified Web.Cookie as Cookie
 import Data.ByteString (ByteString)

--- a/wai-extra/test/Network/Wai/Middleware/RequestSizeLimitSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/RequestSizeLimitSpec.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Char8 as S8
 import Network.Wai.Middleware.RequestSizeLimit
-import Network.HTTP.Types.Status (status200, status413, Status)
+import Network.HTTP.Types.Status (status200, status413)
 import Control.Monad (replicateM)
 import Data.Aeson (encode, object, (.=))
 import Data.Text (Text)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.5
+Version:             3.1.6
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -90,10 +90,9 @@ Library
   Build-Depends:     base                      >= 4.10 && < 5
                    , bytestring                >= 0.10.4
                    , wai                       >= 3.0.3.0  && < 3.3
-                   , old-locale                >= 1.0.0.2  && < 1.1
                    , time                      >= 1.1.4
                    , network                   >= 2.6.1.0
-                   , directory                 >= 1.0.1
+                   , directory                 >= 1.2.7.0
                    , transformers              >= 0.2.2
                    , http-types                >= 0.7
                    , text                      >= 0.7
@@ -103,16 +102,12 @@ Library
                    , wai-logger                >= 2.3.2
                    , ansi-terminal
                    , resourcet                 >= 0.4.6    && < 1.3
-                   , void                      >= 0.5
                    , containers
                    , base64-bytestring
                    , word8
-                   , deepseq
                    , streaming-commons         >= 0.2
-                   , unix-compat
                    , cookie
                    , vault
-                   , zlib
                    , aeson
                    , iproute                   >= 1.7.8
                    , http2
@@ -189,10 +184,11 @@ test-suite spec
                      Network.Wai.RequestSpec
                      Network.Wai.Middleware.ApprootSpec
                      Network.Wai.Middleware.ForceSSLSpec
+                     Network.Wai.Middleware.RealIpSpec
+                     Network.Wai.Middleware.RequestSizeLimitSpec
                      Network.Wai.Middleware.RoutedSpec
                      Network.Wai.Middleware.StripHeadersSpec
                      Network.Wai.Middleware.TimeoutSpec
-                     Network.Wai.Middleware.RealIpSpec
                      WaiExtraSpec
     build-depends:   base                      >= 4        && < 5
                    , wai-extra


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

I noticed a few dependencies that were specified but never used. I also noticed that the directory package can be used to get the size of a file, but only if the lower bound is increased; I think this should be alright, but let me know if not. Does this kind of change require a version bump?