### PR TITLE
Fix header length calculation

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.3.15
+
+* Fix header length calculation for `settingsMaxTotalHeaderLength`
+  [#838](https://github.com/yesodweb/wai/pull/838)
+
 ## 3.3.14
 
 * UTF-8 encoding in `exceptionResponseForDebug`.

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -227,8 +227,7 @@ push maxTotalHeaderLength src (THStatus totalLen chunkLen lines prepend) bs'
         | currentTotal > maxTotalHeaderLength = throwIO OverLargeHeader
         | otherwise = push' mnl
   where
-    currentTotal = totalLen + chunkLen + thisChunkLen
-    thisChunkLen = S.length bs'
+    currentTotal = totalLen + chunkLen
     -- bs: current header chunk, plus maybe (parts of) next header
     bs = prepend bs'
     bsLen = S.length bs
@@ -258,6 +257,7 @@ push maxTotalHeaderLength src (THStatus totalLen chunkLen lines prepend) bs'
         push maxTotalHeaderLength src status bst
       where
         prepend' = S.append bs
+        thisChunkLen = S.length bs'
         newChunkLen = chunkLen + thisChunkLen
         status = THStatus totalLen newChunkLen lines prepend'
     -- Found a newline, but next line continues as a multiline header

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -225,30 +225,38 @@ push :: Int -> Source -> THStatus -> ByteString -> IO [ByteString]
 push maxTotalHeaderLength src (THStatus totalLen chunkLen lines prepend) bs'
         -- Too many bytes
         | currentTotal > maxTotalHeaderLength = throwIO OverLargeHeader
-        | otherwise = push' mnl
+        | otherwise = push' mNL
   where
     currentTotal = totalLen + chunkLen
     -- bs: current header chunk, plus maybe (parts of) next header
     bs = prepend bs'
     bsLen = S.length bs
-    -- 10 is the code point for newline (\n)
-    findNewLine = S.elemIndex 10
-    mnl = do
-        nl <- findNewLine bs
+    -- Maybe newline
+    -- Returns: Maybe
+    --    ( length of this chunk up to newline
+    --    , position of newline in relation to entire current header
+    --    , is this part of a multiline header
+    --    )
+    mNL = do
+        -- 10 is the code point for newline (\n)
+        chunkNL <- S.elemIndex 10 bs'
+        let headerNL = chunkNL + S.length (prepend "")
+            chunkNLlen = chunkNL + 1
         -- check if there are two more bytes in the bs
         -- if so, see if the second of those is a horizontal space
-        if bsLen > nl + 1 then
-            let c = S.index bs (nl + 1)
-                b = case nl of
+        if bsLen > headerNL + 1 then
+            let c = S.index bs (headerNL + 1)
+                b = case headerNL of
                       0 -> True
                       1 -> S.index bs 0 == 13
                       _ -> False
-            in Just (nl, not b && (c == 32 || c == 9))
+                isMultiline = not b && (c == 32 || c == 9)
+            in Just (chunkNLlen, headerNL, isMultiline)
             else
-            Just (nl, False)
+            Just (chunkNLlen, headerNL, False)
 
     {-# INLINE push' #-}
-    push' :: Maybe (Int, Bool) -> IO [ByteString]
+    push' :: Maybe (Int, Int, Bool) -> IO [ByteString]
     -- No newline find in this chunk.  Add it to the prepend,
     -- update the length, and continue processing.
     push' Nothing = do
@@ -261,29 +269,26 @@ push maxTotalHeaderLength src (THStatus totalLen chunkLen lines prepend) bs'
         newChunkLen = chunkLen + thisChunkLen
         status = THStatus totalLen newChunkLen lines prepend'
     -- Found a newline, but next line continues as a multiline header
-    push' (Just (end, True)) = push maxTotalHeaderLength src status rest
+    push' (Just (chunkNLlen, end, True)) =
+        push maxTotalHeaderLength src status rest
       where
         rest = S.drop (end + 1) bs
         prepend' = S.append (SU.unsafeTake (checkCR bs end) bs)
-        -- This is safe or we wouldn't have an 'end'
-        Just thisChunkUpToNL = findNewLine bs'
         -- If we'd just update the entire current chunk up to newline
         -- we wouldn't count all the dropped newlines in between.
         -- So update 'chunkLen' with current chunk up to newline
         -- and use 'chunkLen' later on to add to 'totalLen'.
-        newChunkLen = chunkLen + thisChunkUpToNL + 1
+        newChunkLen = chunkLen + chunkNLlen
         status = THStatus totalLen newChunkLen lines prepend'
     -- Found a newline at position end.
-    push' (Just (end, False))
+    push' (Just (chunkNLlen, end, False))
       -- leftover
       | S.null line = do
             when (start < bsLen) $ leftoverSource src (SU.unsafeDrop start bs)
             return (lines [])
       -- more headers
       | otherwise   = let lines' = lines . (line:)
-                          -- This is safe or we wouldn't have an 'end'
-                          Just thisChunkUpToNL = findNewLine bs'
-                          newTotalLength = totalLen + chunkLen + thisChunkUpToNL + 1
+                          newTotalLength = totalLen + chunkLen + chunkNLlen
                           status = THStatus newTotalLength 0 lines' id
                       in if start < bsLen then
                              -- more bytes in this chunk, push again

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -209,8 +209,8 @@ type BSEndo = ByteString -> ByteString
 type BSEndoList = [ByteString] -> [ByteString]
 
 data THStatus = THStatus
-    {-# UNPACK #-} !Int -- running total byte count (excluding current header chunk)
-    {-# UNPACK #-} !Int -- current header chunk byte count
+    !Int -- running total byte count (excluding current header chunk)
+    !Int -- current header chunk byte count
     BSEndoList -- previously parsed lines
     BSEndo -- bytestrings to be prepended
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.14
+Version:             3.3.15
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

I found the cause of #807 and thought "why not try and fix it". I think I've succeeded, but of course please review my logic.
I especially haven't tested the multi-line header case, so if anyone has any ideas for that, do tell.

The problem was that the `running total byte count` would be added together with the length of the `prepend applied to the incoming chunk`, but the length of `prepend` was already included in the `running total byte count`, so with unfortunate chunkage the length would increase more than the actual bytes, because bytes are being counted twice or even more times.

<details>
<summary>
Code with traces _before_ fix
</summary>

```haskell
push :: Int -> Source -> THStatus -> ByteString -> IO [ByteString]
push maxTotalHeaderLength src (THStatus len lines prepend) bs'
        -- Too many bytes
        | len > maxTotalHeaderLength =
            trace debugMsg $ throwIO OverLargeHeader
        | otherwise =
            trace debugMsg $ push' mnl
  where
    debugMsg = unlines
        [ "THStatus len:     " <> show len
        , "THStatus lines:   " <> show (lines [])
        , "THStatus prepend: " <> show (prepend "")
        ]
    bs = prepend bs'
    bsLen = S.length bs
    mnl = do
        nl <- S.elemIndex 10 bs
        -- check if there are two more bytes in the bs
        -- if so, see if the second of those is a horizontal space
        if bsLen > nl + 1 then
            let c = S.index bs (nl + 1)
                b = case nl of
                      0 -> True
                      1 -> S.index bs 0 == 13
                      _ -> False
            in Just (nl, not b && (c == 32 || c == 9))
            else
            Just (nl, False)

    {-# INLINE push' #-}
    push' :: Maybe (Int, Bool) -> IO [ByteString]
    -- No newline find in this chunk.  Add it to the prepend,
    -- update the length, and continue processing.
    push' Nothing = do
        bst <- readSource' src
        when (S.null bst) $ throwIO IncompleteHeaders
        trace "Nothing" $ push maxTotalHeaderLength src status bst
      where
        len' = len + bsLen
        prepend' = S.append bs
        status = THStatus len' lines prepend'
    -- Found a newline, but next line continues as a multiline header
    push' (Just (end, True)) = trace "Just/True" $ push maxTotalHeaderLength src status rest
      where
        rest = S.drop (end + 1) bs
        prepend' = S.append (SU.unsafeTake (checkCR bs end) bs)
        len' = len + end
        status = THStatus len' lines prepend'
    -- Found a newline at position end.
    push' (Just (end, False))
      -- leftover
      | S.null line = trace "Just/False/null" $ do
            when (start < bsLen) $ leftoverSource src (SU.unsafeDrop start bs)
            return (lines [])
      -- more headers
      | otherwise   = let len' = len + start
                          lines' = lines . (line:)
                          status = THStatus len' lines' id
                      in if start < bsLen then
                             -- more bytes in this chunk, push again
                             let bs'' = SU.unsafeDrop start bs
                              in trace "Just/False/then" $ push maxTotalHeaderLength src status bs''
                           else do
                             -- no more bytes in this chunk, ask for more
                             bst <- readSource' src
                             when (S.null bs) $ throwIO IncompleteHeaders
                             trace "Just/False/else" $ push maxTotalHeaderLength src status bst
      where
        start = end + 1 -- start of next chunk
        line = SU.unsafeTake (checkCR bs end) bs
```
</details>
<details>
<summary>
Screenshot of traces _before_ fix
</summary>

![Trace before fix](https://user-images.githubusercontent.com/6840701/105564889-78b0f180-5d24-11eb-8314-bf0678b13a61.png)
</details>
<details>
<summary>
Code with traces _after_ fix
</summary>

```haskell
push :: Int -> Source -> THStatus -> ByteString -> IO [ByteString]
push maxTotalHeaderLength src (THStatus totalLen chunkLen lines prepend) bs'
        -- Too many bytes
        | totalLen + chunkLen > maxTotalHeaderLength =
            trace debugMsg $ throwIO OverLargeHeader
        | otherwise =
            trace debugMsg $ push' mnl
  where
    debugMsg = unlines
        [ "THStatus totalLen: " <> show totalLen
        , "THStatus chunkLen: " <> show chunkLen
        , "THStatus lines:    " <> show (lines [])
        , "THStatus prepend:  " <> show (prepend "")
        ]
    -- bs: current header chunk, plus maybe (parts of) next header
    bs = prepend bs'
    bsLen = S.length bs
    -- 10 is the code point for newline (\n)
    findNewLine = S.elemIndex 10
    mnl = do
        nl <- findNewLine bs
        -- check if there are two more bytes in the bs
        -- if so, see if the second of those is a horizontal space
        if bsLen > nl + 1
            then let c = S.index bs (nl + 1)
                     b = case nl of
                           0 -> True
                           1 -> S.index bs 0 == 13
                           _ -> False
                 in Just (nl, not b && (c == 32 || c == 9))
            else Just (nl, False)

    {-# INLINE push' #-}
    push' :: Maybe (Int, Bool) -> IO [ByteString]
    -- No newline find in this chunk.  Add it to the prepend,
    -- update the length, and continue processing.
    push' Nothing = do
        bst <- readSource' src
        when (S.null bst) $ throwIO IncompleteHeaders
        trace "Nothing" $ push maxTotalHeaderLength src status bst
      where
        thisChunk = S.length bs'
        prepend' = S.append bs
        newChunkLen = chunkLen + thisChunk
        status = THStatus totalLen newChunkLen lines prepend'
    -- Found a newline, but next line continues as a multiline header
    push' (Just (end, True)) = trace "Just/True" $
        push maxTotalHeaderLength src status rest
      where
        rest = S.drop (end + 1) bs
        prepend' = S.append (SU.unsafeTake (checkCR bs end) bs)
        -- This is safe or we wouldn't have an 'end'
        Just thisChunkUpToNL = findNewLine bs'
        -- If we'd just update entire current chunk up to newline
        -- we wouldn't count all the dropped newlines in between.
        -- So update 'chunkLen' with current chunk up to newline
        -- and use 'chunkLen' to add to 'totalLen'
        newChunkLen = chunkLen + thisChunkUpToNL + 1
        status = THStatus totalLen newChunkLen lines prepend'
    -- Found a newline at position end.
    push' (Just (end, False))
      -- leftover
      | S.null line = trace "Just/False/null" $ do
            when (start < bsLen) $ leftoverSource src (SU.unsafeDrop start bs)
            return (lines [])
      -- more headers
      | otherwise   = let lines' = lines . (line:)
                          -- This is safe or we wouldn't have an 'end'
                          Just thisChunkUpToNL = findNewLine bs'
                          newTotalLength = totalLen + chunkLen + thisChunkUpToNL + 1
                          status = THStatus newTotalLength 0 lines' id
                      in if start < bsLen then
                             -- more bytes in this chunk, push again
                             let bs'' = SU.unsafeDrop start bs
                              in trace "Just/False/then" $ push maxTotalHeaderLength src status bs''
                           else do
                             -- no more bytes in this chunk, ask for more
                             bst <- readSource' src
                             when (S.null bs) $ throwIO IncompleteHeaders
                             trace "Just/False/else" $ push maxTotalHeaderLength src status bst
      where
        start = end + 1 -- start of next chunk
        line = SU.unsafeTake (checkCR bs end) bs
```
</details>
<details>
<summary>
Screenshot of traces _after_ fix
</summary>

![Trace after fix](https://user-images.githubusercontent.com/6840701/105564631-4fdc2c80-5d23-11eb-91a8-cbddcf0df9cd.png)
</details>