### PR TITLE
Access to data constructor

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -29,6 +29,7 @@ module Network.Wai.Handler.WarpTLS (
     -- ** From references
     , tlsSettingsRef
     , tlsSettingsChainRef
+    , getCertSettings
     -- * Accessors
     , tlsCredentials
     , tlsLogging
@@ -294,6 +295,12 @@ tlsSettingsChainRef
 tlsSettingsChainRef cert chainCerts key = defaultTlsSettings { 
     certSettings = CertFromRef cert chainCerts key
   }
+
+
+-- Since 3.3.1
+-- | Some programs need access to cert settings
+getCertSettings :: TLSSettings -> CertSettings
+getCertSettings tlsSetgs = certSettings tlsSetgs
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -29,7 +29,7 @@ module Network.Wai.Handler.WarpTLS (
     -- ** From references
     , tlsSettingsRef
     , tlsSettingsChainRef
-    , CertSettings(..)
+    , CertSettings
     -- * Accessors
     , tlsCredentials
     , tlsLogging

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -76,122 +76,14 @@ import qualified Network.TLS.SessionManager as SM
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
+import Network.Wai.Handler.WarpTLS.Internal
 import System.IO.Error (isEOFError, ioeGetErrorType)
-
-----------------------------------------------------------------
-
--- | Determines where to load the certificate, chain 
--- certificates, and key from.
-data CertSettings 
-  = CertFromFile !FilePath ![FilePath] !FilePath
-  | CertFromMemory !S.ByteString ![S.ByteString] !S.ByteString
-  | CertFromRef !(I.IORef S.ByteString) ![I.IORef S.ByteString] !(I.IORef S.ByteString)
 
 -- | The default 'CertSettings'.
 defaultCertSettings :: CertSettings
 defaultCertSettings = CertFromFile "certificate.pem" [] "key.pem"
 
 ----------------------------------------------------------------
-
--- | Settings for WarpTLS.
-data TLSSettings = TLSSettings {
-    certSettings :: CertSettings
-    -- ^ Where are the certificate, chain certificates, and key
-    -- loaded from?
-    --
-    -- >>> certSettings defaultTlsSettings
-    -- tlsSettings "certificate.pem" "key.pem"
-    -- 
-    -- @since 3.3.0
-  , onInsecure :: OnInsecure
-    -- ^ Do we allow insecure connections with this server as well?
-    --
-    -- >>> onInsecure defaultTlsSettings
-    -- DenyInsecure "This server only accepts secure HTTPS connections."
-    --
-    -- Since 1.4.0
-  , tlsLogging :: TLS.Logging
-    -- ^ The level of logging to turn on.
-    --
-    -- Default: 'TLS.defaultLogging'.
-    --
-    -- Since 1.4.0
-  , tlsAllowedVersions :: [TLS.Version]
-#if MIN_VERSION_tls(1,5,0)
-    -- ^ The TLS versions this server accepts.
-    --
-    -- >>> tlsAllowedVersions defaultTlsSettings
-    -- [TLS13,TLS12,TLS11,TLS10]
-    --
-    -- Since 1.4.2
-#else
-    -- ^ The TLS versions this server accepts.
-    --
-    -- >>> tlsAllowedVersions defaultTlsSettings
-    -- [TLS12,TLS11,TLS10]
-    --
-    -- Since 1.4.2
-#endif
-  , tlsCiphers :: [TLS.Cipher]
-#if MIN_VERSION_tls(1,5,0)
-    -- ^ The TLS ciphers this server accepts.
-    --
-    -- >>> tlsCiphers defaultTlsSettings
-    -- [ECDHE-ECDSA-AES256GCM-SHA384,ECDHE-ECDSA-AES128GCM-SHA256,ECDHE-RSA-AES256GCM-SHA384,ECDHE-RSA-AES128GCM-SHA256,DHE-RSA-AES256GCM-SHA384,DHE-RSA-AES128GCM-SHA256,ECDHE-ECDSA-AES256CBC-SHA384,ECDHE-RSA-AES256CBC-SHA384,DHE-RSA-AES256-SHA256,ECDHE-ECDSA-AES256CBC-SHA,ECDHE-RSA-AES256CBC-SHA,DHE-RSA-AES256-SHA1,RSA-AES256GCM-SHA384,RSA-AES256-SHA256,RSA-AES256-SHA1,AES128GCM-SHA256,AES256GCM-SHA384]
-    --
-    -- Since 1.4.2
-#else
-    -- ^ The TLS ciphers this server accepts.
-    --
-    -- >>> tlsCiphers defaultTlsSettings
-    -- [ECDHE-ECDSA-AES256GCM-SHA384,ECDHE-ECDSA-AES128GCM-SHA256,ECDHE-RSA-AES256GCM-SHA384,ECDHE-RSA-AES128GCM-SHA256,DHE-RSA-AES256GCM-SHA384,DHE-RSA-AES128GCM-SHA256,ECDHE-ECDSA-AES256CBC-SHA384,ECDHE-RSA-AES256CBC-SHA384,DHE-RSA-AES256-SHA256,ECDHE-ECDSA-AES256CBC-SHA,ECDHE-RSA-AES256CBC-SHA,DHE-RSA-AES256-SHA1,RSA-AES256GCM-SHA384,RSA-AES256-SHA256,RSA-AES256-SHA1]
-    --
-    -- Since 1.4.2
-#endif
-  , tlsWantClientCert :: Bool
-    -- ^ Whether or not to demand a certificate from the client.  If this
-    -- is set to True, you must handle received certificates in a server hook
-    -- or all connections will fail.
-    --
-    -- >>> tlsWantClientCert defaultTlsSettings
-    -- False
-    --
-    -- Since 3.0.2
-  , tlsServerHooks :: TLS.ServerHooks
-    -- ^ The server-side hooks called by the tls package, including actions
-    -- to take when a client certificate is received.  See the "Network.TLS"
-    -- module for details.
-    --
-    -- Default: def
-    --
-    -- Since 3.0.2
-  , tlsServerDHEParams :: Maybe DH.Params
-    -- ^ Configuration for ServerDHEParams
-    -- more function lives in `cryptonite` package
-    --
-    -- Default: Nothing
-    --
-    -- Since 3.2.2
-  , tlsSessionManagerConfig :: Maybe SM.Config
-    -- ^ Configuration for in-memory TLS session manager.
-    -- If Nothing, 'TLS.noSessionManager' is used.
-    -- Otherwise, an in-memory TLS session manager is created
-    -- according to 'Config'.
-    --
-    -- Default: Nothing
-    --
-    -- Since 3.2.4
-  , tlsCredentials :: Maybe TLS.Credentials
-    -- ^ Specifying 'TLS.Credentials' directly.  If this value is
-    --   specified, other fields such as 'certFile' are ignored.
-    --
-    --   Since 3.2.12
-  , tlsSessionManager :: Maybe TLS.SessionManager
-    -- ^ Specifying 'TLS.SessionManager' directly. If this value is
-    --   specified, 'tlsSessionManagerConfig' is ignored.
-    --
-    --   Since 3.2.12
-  }
 
 -- | Default 'TLSSettings'. Use this to create 'TLSSettings' with the field record name (aka accessors).
 defaultTlsSettings :: TLSSettings
@@ -216,13 +108,6 @@ defaultTlsSettings = TLSSettings {
 -- taken from stunnel example in tls-extra
 ciphers :: [TLS.Cipher]
 ciphers = TLSExtra.ciphersuite_strong
-
-----------------------------------------------------------------
-
--- | An action when a plain HTTP comes to HTTP over TLS/SSL port.
-data OnInsecure = DenyInsecure L.ByteString
-                | AllowInsecure
-                deriving (Show)
 
 ----------------------------------------------------------------
 
@@ -296,12 +181,6 @@ tlsSettingsChainRef
 tlsSettingsChainRef cert chainCerts key = defaultTlsSettings { 
     certSettings = CertFromRef cert chainCerts key
   }
-
-
--- Since 3.3.1
--- | Some programs need access to cert settings
-getCertSettings :: TLSSettings -> CertSettings
-getCertSettings tlsSetgs = certSettings tlsSetgs
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -29,7 +29,6 @@ module Network.Wai.Handler.WarpTLS (
     -- ** From references
     , tlsSettingsRef
     , tlsSettingsChainRef
-    , getCertSettings
     , CertSettings(..)
     -- * Accessors
     , tlsCredentials
@@ -76,7 +75,7 @@ import qualified Network.TLS.SessionManager as SM
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
-import Network.Wai.Handler.WarpTLS.Internal
+import Network.Wai.Handler.WarpTLS.Internal(CertSettings(..), TLSSettings(..), OnInsecure(..))
 import System.IO.Error (isEOFError, ioeGetErrorType)
 
 -- | The default 'CertSettings'.

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -30,6 +30,7 @@ module Network.Wai.Handler.WarpTLS (
     , tlsSettingsRef
     , tlsSettingsChainRef
     , getCertSettings
+    , CertSettings(..)
     -- * Accessors
     , tlsCredentials
     , tlsLogging

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE CPP #-}
+
+module Network.Wai.Handler.WarpTLS.Internal (
+      CertSettings(..)
+    , TLSSettings(..)
+    , OnInsecure(..)
+    -- * Accessors
+    , getCertSettings
+    ) where
+
+import qualified Crypto.PubKey.DH as DH
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Lazy as L
+import qualified Data.IORef as I
+import qualified Network.TLS as TLS
+import qualified Network.TLS.SessionManager as SM
+
+----------------------------------------------------------------
+
+-- | Determines where to load the certificate, chain 
+-- certificates, and key from.
+data CertSettings 
+  = CertFromFile !FilePath ![FilePath] !FilePath
+  | CertFromMemory !S.ByteString ![S.ByteString] !S.ByteString
+  | CertFromRef !(I.IORef S.ByteString) ![I.IORef S.ByteString] !(I.IORef S.ByteString)
+
+----------------------------------------------------------------
+
+-- | An action when a plain HTTP comes to HTTP over TLS/SSL port.
+data OnInsecure = DenyInsecure L.ByteString
+                | AllowInsecure
+                deriving (Show)
+
+----------------------------------------------------------------
+
+-- | Settings for WarpTLS.
+data TLSSettings = TLSSettings {
+    certSettings :: CertSettings
+    -- ^ Where are the certificate, chain certificates, and key
+    -- loaded from?
+    --
+    -- >>> certSettings defaultTlsSettings
+    -- tlsSettings "certificate.pem" "key.pem"
+    -- 
+    -- @since 3.3.0
+  , onInsecure :: OnInsecure
+    -- ^ Do we allow insecure connections with this server as well?
+    --
+    -- >>> onInsecure defaultTlsSettings
+    -- DenyInsecure "This server only accepts secure HTTPS connections."
+    --
+    -- Since 1.4.0
+  , tlsLogging :: TLS.Logging
+    -- ^ The level of logging to turn on.
+    --
+    -- Default: 'TLS.defaultLogging'.
+    --
+    -- Since 1.4.0
+  , tlsAllowedVersions :: [TLS.Version]
+#if MIN_VERSION_tls(1,5,0)
+    -- ^ The TLS versions this server accepts.
+    --
+    -- >>> tlsAllowedVersions defaultTlsSettings
+    -- [TLS13,TLS12,TLS11,TLS10]
+    --
+    -- Since 1.4.2
+#else
+    -- ^ The TLS versions this server accepts.
+    --
+    -- >>> tlsAllowedVersions defaultTlsSettings
+    -- [TLS12,TLS11,TLS10]
+    --
+    -- Since 1.4.2
+#endif
+  , tlsCiphers :: [TLS.Cipher]
+#if MIN_VERSION_tls(1,5,0)
+    -- ^ The TLS ciphers this server accepts.
+    --
+    -- >>> tlsCiphers defaultTlsSettings
+    -- [ECDHE-ECDSA-AES256GCM-SHA384,ECDHE-ECDSA-AES128GCM-SHA256,ECDHE-RSA-AES256GCM-SHA384,ECDHE-RSA-AES128GCM-SHA256,DHE-RSA-AES256GCM-SHA384,DHE-RSA-AES128GCM-SHA256,ECDHE-ECDSA-AES256CBC-SHA384,ECDHE-RSA-AES256CBC-SHA384,DHE-RSA-AES256-SHA256,ECDHE-ECDSA-AES256CBC-SHA,ECDHE-RSA-AES256CBC-SHA,DHE-RSA-AES256-SHA1,RSA-AES256GCM-SHA384,RSA-AES256-SHA256,RSA-AES256-SHA1,AES128GCM-SHA256,AES256GCM-SHA384]
+    --
+    -- Since 1.4.2
+#else
+    -- ^ The TLS ciphers this server accepts.
+    --
+    -- >>> tlsCiphers defaultTlsSettings
+    -- [ECDHE-ECDSA-AES256GCM-SHA384,ECDHE-ECDSA-AES128GCM-SHA256,ECDHE-RSA-AES256GCM-SHA384,ECDHE-RSA-AES128GCM-SHA256,DHE-RSA-AES256GCM-SHA384,DHE-RSA-AES128GCM-SHA256,ECDHE-ECDSA-AES256CBC-SHA384,ECDHE-RSA-AES256CBC-SHA384,DHE-RSA-AES256-SHA256,ECDHE-ECDSA-AES256CBC-SHA,ECDHE-RSA-AES256CBC-SHA,DHE-RSA-AES256-SHA1,RSA-AES256GCM-SHA384,RSA-AES256-SHA256,RSA-AES256-SHA1]
+    --
+    -- Since 1.4.2
+#endif
+  , tlsWantClientCert :: Bool
+    -- ^ Whether or not to demand a certificate from the client.  If this
+    -- is set to True, you must handle received certificates in a server hook
+    -- or all connections will fail.
+    --
+    -- >>> tlsWantClientCert defaultTlsSettings
+    -- False
+    --
+    -- Since 3.0.2
+  , tlsServerHooks :: TLS.ServerHooks
+    -- ^ The server-side hooks called by the tls package, including actions
+    -- to take when a client certificate is received.  See the "Network.TLS"
+    -- module for details.
+    --
+    -- Default: def
+    --
+    -- Since 3.0.2
+  , tlsServerDHEParams :: Maybe DH.Params
+    -- ^ Configuration for ServerDHEParams
+    -- more function lives in `cryptonite` package
+    --
+    -- Default: Nothing
+    --
+    -- Since 3.2.2
+  , tlsSessionManagerConfig :: Maybe SM.Config
+    -- ^ Configuration for in-memory TLS session manager.
+    -- If Nothing, 'TLS.noSessionManager' is used.
+    -- Otherwise, an in-memory TLS session manager is created
+    -- according to 'Config'.
+    --
+    -- Default: Nothing
+    --
+    -- Since 3.2.4
+  , tlsCredentials :: Maybe TLS.Credentials
+    -- ^ Specifying 'TLS.Credentials' directly.  If this value is
+    --   specified, other fields such as 'certFile' are ignored.
+    --
+    --   Since 3.2.12
+  , tlsSessionManager :: Maybe TLS.SessionManager
+    -- ^ Specifying 'TLS.SessionManager' directly. If this value is
+    --   specified, 'tlsSessionManagerConfig' is ignored.
+    --
+    --   Since 3.2.12
+  }
+
+
+-- Since 3.3.1
+-- | Some programs need access to cert settings
+getCertSettings :: TLSSettings -> CertSettings
+getCertSettings tlsSetgs = certSettings tlsSetgs
+

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.3.0
+Version:             3.3.1
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -28,7 +28,7 @@ Library
                    , network                       >= 2.2.1
                    , streaming-commons
                    , tls-session-manager           >= 0.0.4
-  Exposed-modules:   Network.Wai.Handler.WarpTLS
+  Exposed-modules:   Network.Wai.Handler.WarpTLS, Network.Wai.Handler.WarpTLS.Internal
   ghc-options:       -Wall
   if os(windows)
       Cpp-Options:   -DWINDOWS


### PR DESCRIPTION
I want to update
https://github.com/snoyberg/keter/blob/a829d79bcb08c4180c88f38b174028e5e3f76f27/Keter/Types/V10.hs#L127-L129
to the newest version of warp-tls.
So access to certSettings is needed: https://github.com/yesodweb/wai/blob/f59e577f865d017b4726826ac5586bb916cf315b/warp-tls/Network/Wai/Handler/WarpTLS.hs#L96