### PR TITLE
Add 'testWithApplication'' function

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.3.16
+
+* Add `testWithApplication'` function
+  Same as `testWithApplication` but accepts pure `Application` instead of `IO Application`
+
 ## 3.3.15
 
 * Using http2 v3.

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -103,6 +103,7 @@ module Network.Wai.Handler.Warp (
   , withApplication
   , withApplicationSettings
   , testWithApplication
+  , testWithApplication'
   , testWithApplicationSettings
   , openFreePort
     -- * Version

--- a/warp/Network/Wai/Handler/Warp/WithApplication.hs
+++ b/warp/Network/Wai/Handler/Warp/WithApplication.hs
@@ -3,6 +3,7 @@ module Network.Wai.Handler.Warp.WithApplication (
   withApplication,
   withApplicationSettings,
   testWithApplication,
+  testWithApplication',
   testWithApplicationSettings,
   openFreePort,
   withFreePort,
@@ -47,6 +48,20 @@ withApplicationSettings settings' mkApp action = do
     case result of
       Left () -> throwIO $ ErrorCall "Unexpected: runSettingsSocket exited"
       Right x -> return x
+
+-- | Same as 'testWithApplication'
+-- but accepts @app :: 'Application'@ as a first argument instead of @mkApp :: 'IO' 'Application'@.  
+--
+-- Except for the purity of its first argument, the behaviour of this function is identical to 'testWithApplication'.
+--
+-- 'testWithApplication' can be expressed via 'testWithApplication'' as:
+--
+-- >>> testWithApplication mkApp action = mkApp >>= flip testWithApplication' action
+--
+-- @since 3.3.16
+testWithApplication' :: Application -> (Port -> IO a) -> IO a
+testWithApplication' =
+  testWithApplication . return
 
 -- | Same as 'withApplication' but with different exception handling: If the
 -- given 'Application' throws an exception, 'testWithApplication' will re-throw

--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -36,6 +36,13 @@ spec = do
           readProcess "curl" ["-s", "localhost:" ++ show port] "")
         `shouldThrow` (errorCall "foo")
 
+  describe "testWithApplication'" $ do
+    it "propagates exceptions from the server to the executing thread" $ do
+      let mkApp _request _respond = throwIO $ ErrorCall "foo"
+      (testWithApplication' mkApp $ \ port -> do
+          readProcess "curl" ["-s", "localhost:" ++ show port] "")
+        `shouldThrow` (errorCall "foo")
+
 {- The future netwrok library will not export MkSocket.
   describe "withFreePort" $ do
     it "closes the socket before exiting" $ do

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.15
+Version:             3.3.16
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Add `testWithApplication'` function:

```haskell
testWithApplication' :: Application -> (Port -> IO a) -> IO a
```
  
same as `testWithApplication` function

```haskell
testWithApplication :: IO Application -> (Port -> IO a) -> IO a
```

 but accepts `Application` as a pure argument
The requirement of `testWithApplication` to pass `Application` parameter in wrapped in `IO` monad seems unnecessary strict:
Apparently the only action `testWithApplicationSettings` (the underlying implementation) does is to unwrap it with:
```haskell
testWithApplicationSettings :: Settings -> IO Application -> (Port -> IO a) -> IO a
testWithApplicationSettings settings mkApp action = do
  callingThread <- myThreadId
  app <- mkApp
  let wrappedApp request respond =
        app request respond `catch` \ e -> do
  [truncated]
```

into `app` which can be done outside of  `testWithApplication'` with:

```haskell
testWithApplication :: IO Application -> (Port -> IO a) -> IO a
testWithApplication mkApp action =
  mkApp >>= flip testWithApplication' action
```

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->