### PR TITLE
Swallow async exceptions in forked thread #850

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         args:
-        - "--resolver nightly"
+        # Missing some packages now
+        #- "--resolver nightly"
         - "--resolver lts-17"
         - "--resolver lts-16"
         - "--resolver lts-14 --stack-yaml stack-lts-14.yaml"

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 3.3.17
 
 * Modify exception handling to swallow async exceptions in forked thread [#850](https://github.com/yesodweb/wai/issues/850)
+* Switch default forking function to not install the global exception handler (minor optimization)
 
 ## 3.3.16
 

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for warp
 
+## 3.3.17
+
+* Modify exception handling to swallow async exceptions in forked thread [#850](https://github.com/yesodweb/wai/issues/850)
+
 ## 3.3.16
 
 * Move exception handling over to `unliftio` for better async exception support [#845](https://github.com/yesodweb/wai/issues/845)

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 3.3.17
 
 * Modify exception handling to swallow async exceptions in forked thread [#850](https://github.com/yesodweb/wai/issues/850)
-* Switch default forking function to not install the global exception handler (minor optimization)
+* Switch default forking function to not install the global exception handler (minor optimization) [#851](https://github.com/yesodweb/wai/pull/851)
 
 ## 3.3.16
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.16
+Version:             3.3.17
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [X] Bumped the version number
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

* * *

CC @chrisdone @kazu-yamamoto @alaendle I think this PR fixes the issues described. There are two commits: the first one implements the actual fix (catching all exceptions in the forked thread). The second implements a minor optimization revealed by these reports, turning off the default exception handling in the forked thread, since Warp's exception handler must catch all exceptions.

Confirmation that this fixes the reported issues would be great, I can no longer repro Chris's problem with this change.