### PR TITLE
Option to log requests before application is called in wai-extra RequestLogging Middleware

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.7
+
+* Added new `logStdoutDevWithRequestPrelogging` middleware [#857](https://github.com/yesodweb/wai/pull/857)
+
 ## 3.1.6
 
 * Remove unused dependencies [#837](https://github.com/yesodweb/wai/pull/837)

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.1.7
 
-* Added new `logStdoutDevWithRequestPrelogging` middleware [#857](https://github.com/yesodweb/wai/pull/857)
+* Added new `mPrelogRequests` option to `DetailedSettings` [#857](https://github.com/yesodweb/wai/pull/857)
 
 ## 3.1.6
 

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -36,6 +36,7 @@ import Network.Wai
 import System.Log.FastLogger
 import Network.HTTP.Types as H
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Monoid (mconcat, (<>))
 import Data.Time (getCurrentTime, diffUTCTime, NominalDiffTime, UTCTime)
 import Network.Wai.Parse (sinkRequestBody, lbsBackEnd, fileName, Param, File
                          , getRequestBodyType)

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -6,7 +6,6 @@ module Network.Wai.Middleware.RequestLogger
     ( -- * Basic stdout logging
       logStdout
     , logStdoutDev
-    , logStdoutDevWithRequestPrelogging
       -- * Create more versions
     , mkRequestLogger
     , RequestLoggerSettings
@@ -237,14 +236,6 @@ logStdout = unsafePerformIO $ mkRequestLogger def { outputFormat = Apache FromSo
 {-# NOINLINE logStdoutDev #-}
 logStdoutDev :: Middleware
 logStdoutDev = unsafePerformIO $ mkRequestLogger def
-
--- | Development request logger middleware.
---
--- This uses the 'Detailed' 'True' logging format and logs to 'stdout'.
--- @since 3.1.7
-{-# NOINLINE logStdoutDevWithRequestPrelogging #-}
-logStdoutDevWithRequestPrelogging :: Middleware
-logStdoutDevWithRequestPrelogging = unsafePerformIO $ mkRequestLogger def { outputFormat = DetailedWithSettings (def { mPrelogRequests = True }) }
 
 -- | Prints a message using the given callback function for each request.
 -- This is not for serious production use- it is inefficient.

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -77,8 +77,9 @@ data DetailedSettings = DetailedSettings
     { useColors :: Bool
     , mModifyParams :: Maybe (Param -> Maybe Param)
     , mFilterRequests :: Maybe (Request -> Response -> Bool)
-    , mPrelogRequests :: Bool
+    , mPrelogRequests :: Bool -- ^ @since 3.1.7
     }
+
 instance Default DetailedSettings where
     def = DetailedSettings
         { useColors = True
@@ -240,6 +241,7 @@ logStdoutDev = unsafePerformIO $ mkRequestLogger def
 -- | Development request logger middleware.
 --
 -- This uses the 'Detailed' 'True' logging format and logs to 'stdout'.
+-- @since 3.1.7
 {-# NOINLINE logStdoutDevWithRequestPrelogging #-}
 logStdoutDevWithRequestPrelogging :: Middleware
 logStdoutDevWithRequestPrelogging = unsafePerformIO $ mkRequestLogger def { outputFormat = DetailedWithSettings (def { mPrelogRequests = True }) }

--- a/wai-extra/test/WaiExtraSpec.hs
+++ b/wai-extra/test/WaiExtraSpec.hs
@@ -458,9 +458,9 @@ caseStreamLBS = flip runSession streamLBSApp $ do
 
 caseModifyPostParamsInLogs :: Assertion
 caseModifyPostParamsInLogs = do
-    let formatUnredacted = DetailedWithSettings $ DetailedSettings False Nothing Nothing
+    let formatUnredacted = DetailedWithSettings $ DetailedSettings False Nothing Nothing False
         outputUnredacted = [("username", "some_user"), ("password", "dont_show_me")]
-        formatRedacted = DetailedWithSettings $ DetailedSettings False (Just hidePasswords) Nothing
+        formatRedacted = DetailedWithSettings $ DetailedSettings False (Just hidePasswords) Nothing False
         hidePasswords p@(k,_) = Just $ if k == "password" then (k, "***REDACTED***") else p
         outputRedacted = [("username", "some_user"), ("password", "***REDACTED***")]
 
@@ -492,8 +492,8 @@ caseModifyPostParamsInLogs = do
 
 caseFilterRequestsInLogs :: Assertion
 caseFilterRequestsInLogs = do
-    let formatUnfiltered = DetailedWithSettings $ DetailedSettings False Nothing Nothing
-        formatFiltered = DetailedWithSettings . DetailedSettings False Nothing $ Just hideHealthCheck
+    let formatUnfiltered = DetailedWithSettings $ DetailedSettings False Nothing Nothing False
+        formatFiltered = DetailedWithSettings $ DetailedSettings False Nothing (Just hideHealthCheck) False
         pathHidden = "/health-check"
         pathNotHidden = "/foobar"
 

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.6
+Version:             3.1.7
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->