### PR TITLE
Document the Middleware type alias

### DIFF
--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for wai
 
+## 3.2.4
+
+* Overhaul documentation of `Middleware`. [#858](https://github.com/yesodweb/wai/pull/858)
+
 ## 3.2.3
 
 * Add documentation recommending streaming request bodies. [#818](https://github.com/yesodweb/wai/pull/818)

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       >=1.10
 Name:                wai
-Version:             3.2.3
+Version:             3.2.4
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
                      .


### PR DESCRIPTION
I tried to come at this from the angle of

1) A user of Wai trying to understand what `Middleware` is
   and how to use it, especially what happens if you chain
   multiple middlewares and in what order their are called.

2) A developer trying to implement new middleware, how to
   modify requests and responses, and how to pass on data.

by giving examples of how the type signatures and
simple usage/implementations look.

I think `Wai` is a super fundamental module for the Haskell
ecosystem, so we should aim for the documentation to be top
notch (think: rust stdlib).

I think the rest of the module needs a simple overhaul,
but I was especially annoyed by having to reconstruct Middleware
from first principles every time I built a server (“which order
does it chain again?”).

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->