### PR TITLE
Export Network.Wai.Middleware.Gzip.GzipSettings.

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+# Unreleased 
+
+* Export `Network.Wai.Middleware.Gzip.GzipSettings`.
+
 ## 3.1.7
 
 * Added new `mPrelogRequests` option to `DetailedSettings` [#857](https://github.com/yesodweb/wai/pull/857)

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -2,7 +2,7 @@
 
 # Unreleased 
 
-* Export `Network.Wai.Middleware.Gzip.GzipSettings`.
+* Export `Network.Wai.Middleware.Gzip.GzipSettings`. [#860](https://github.com/yesodweb/wai/pull/860)
 
 ## 3.1.7
 

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -46,9 +46,10 @@ import qualified System.IO as IO
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import Data.Word8 (_semicolon, _space, _comma)
 
+-- | Settings for the Gzip middleware. 
 data GzipSettings = GzipSettings
-    { gzipFiles :: GzipFiles
-    , gzipCheckMime :: S.ByteString -> Bool
+    { gzipFiles :: GzipFiles -- ^ What action do we take on files?
+    , gzipCheckMime :: S.ByteString -> Bool -- ^ Which files do we compress?
     }
 
 -- | Gzip behavior for files.

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -14,7 +14,7 @@
 ---------------------------------------------------------
 module Network.Wai.Middleware.Gzip
     ( gzip
-    , GzipSettings
+    , GzipSettings (..)
     , gzipFiles
     , GzipFiles (..)
     , gzipCheckMime


### PR DESCRIPTION
Export `Network.Wai.Middleware.Gzip.GzipSettings`. 

- This is such a small change that I did not bump the version number, labeling it "Unreleased" in the changelog with accordance to the policy. 
- Documentation updated.

TO-DO: 

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)