### PR TITLE
[Draft] Use newer ghc-prim functions for mhDigitToInt

### DIFF
--- a/warp/Network/Wai/Handler/Warp/ReadInt.hs
+++ b/warp/Network/Wai/Handler/Warp/ReadInt.hs
@@ -41,7 +41,7 @@ data Table = Table !Addr#
 
 {-# NOINLINE mhDigitToInt #-}
 mhDigitToInt :: Word8 -> Int
-mhDigitToInt (W8# i) = I# (word2Int# (indexWord8OffAddr# addr (word2Int# i)))
+mhDigitToInt (W8# i) = I# (int8ToInt# (word8ToInt8# (indexWord8OffAddr# addr (int8ToInt# (word8ToInt8# i)))))
   where
     !(Table addr) = table
     table :: Table


### PR DESCRIPTION
This makes it compile on 9.2, but haven't checked earlier versions yet.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->