### PR TITLE
Add flags to avoid Cryptonite/X509

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- | Lookup files stored in memory instead of from the filesystem.
 module WaiAppStatic.Storage.Embedded.Runtime
     ( -- * Settings
@@ -15,8 +16,13 @@ import Data.Function (on)
 import qualified Data.Text as T
 import Data.Ord
 import qualified Data.ByteString as S
+#ifdef MIN_VERSION_cryptonite
 import Crypto.Hash (hash, MD5, Digest)
 import Data.ByteArray.Encoding
+#else
+import Crypto.Hash.MD5 (hash)
+import Data.ByteString.Base64 (encode)
+#endif
 import WaiAppStatic.Storage.Filesystem (defaultFileServerSettings)
 import System.FilePath (isPathSeparator)
 
@@ -94,4 +100,8 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
+#ifdef MIN_VERSION_cryptonite
 runHash = convertToBase Base64 . (hash :: S.ByteString -> Digest MD5)
+#else
+runHash = encode . hash
+#endif

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -24,6 +24,10 @@ Flag print
     Description:   print debug info
     Default:       False
 
+Flag cryptonite
+    Description:   Use the cryptonite library for MD5 computation
+    Default:       True
+
 library
     default-language: Haskell2010
     build-depends:   base                      >= 4.12     && < 5
@@ -38,8 +42,6 @@ library
                    , old-locale                >= 1.0.0.2
                    , file-embed                >= 0.0.3.1
                    , text                      >= 0.7
-                   , cryptonite                >= 0.6
-                   , memory                    >= 0.7
                    , http-date
                    , blaze-html                >= 0.5
                    , blaze-markup              >= 0.5.1
@@ -51,6 +53,12 @@ library
                    , wai-extra                 >= 3.0      && < 3.2
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.4
+    if flag(cryptonite)
+      build-depends: cryptonite                >= 0.6
+                   , memory                    >= 0.7
+    else
+      build-depends: base64-bytestring         >= 0.1
+                   , cryptohash-md5            >= 0.11.101
 
     exposed-modules: Network.Wai.Application.Static
                      WaiAppStatic.Storage.Filesystem

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.7.2
+version:         3.1.7.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -99,7 +99,9 @@ module Network.Wai.Handler.Warp (
   , pauseTimeout
   , FileInfo(..)
   , getFileInfo
+#ifdef MIN_VERSION_x509
   , clientCertificate
+#endif
   , withApplication
   , withApplicationSettings
   , testWithApplication
@@ -128,7 +130,9 @@ module Network.Wai.Handler.Warp (
 import UnliftIO.Exception (SomeException, throwIO)
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Vault.Lazy as Vault
+#ifdef MIN_VERSION_x509
 import Data.X509
+#endif
 import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr)
 import Network.Wai (Request, Response, vault)
@@ -516,8 +520,10 @@ setGracefulCloseTimeout2 x y = y { settingsGracefulCloseTimeout2 = x }
 getGracefulCloseTimeout2 :: Settings -> Int
 getGracefulCloseTimeout2 = settingsGracefulCloseTimeout2
 
+#ifdef MIN_VERSION_x509
 -- | Getting information of client certificate.
 --
 -- Since 3.3.5
 clientCertificate :: Request -> Maybe CertificateChain
 clientCertificate = join . Vault.lookup getClientCertificateKey . vault
+#endif

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 
 module Network.Wai.Handler.Warp.HTTP2.Request (
@@ -22,7 +23,10 @@ import qualified System.TimeManager as T
 
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.Imports
-import Network.Wai.Handler.Warp.Request (getFileInfoKey, pauseTimeoutKey, getClientCertificateKey)
+import Network.Wai.Handler.Warp.Request (getFileInfoKey, pauseTimeoutKey)
+#ifdef MIN_VERSION_x509
+import Network.Wai.Handler.Warp.Request (getClientCertificateKey)
+#endif
 import qualified Network.Wai.Handler.Warp.Settings as S (Settings, settingsNoParsePath)
 import Network.Wai.Handler.Warp.Types
 
@@ -86,7 +90,9 @@ toRequest' ii settings addr ref (reqths,reqvt) bodylen body th transport = retur
                 $ Vault.insert setHTTP2DataKey (writeIORef ref)
                 $ Vault.insert modifyHTTP2DataKey (modifyIORef' ref)
                 $ Vault.insert pauseTimeoutKey (T.pause th)
+#ifdef MIN_VERSION_x509
                 $ Vault.insert getClientCertificateKey (getTransportClientCertificate transport)
+#endif
                   Vault.empty
 
 getHTTP2DataKey :: Vault.Key (IO (Maybe HTTP2Data))

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -9,7 +9,9 @@ module Network.Wai.Handler.Warp.Request (
   , headerLines
   , pauseTimeoutKey
   , getFileInfoKey
+#ifdef MIN_VERSION_x509
   , getClientCertificateKey
+#endif
   , NoKeepAliveRequest (..)
   ) where
 
@@ -22,7 +24,9 @@ import qualified Data.CaseInsensitive as CI
 import qualified Data.IORef as I
 import Data.Typeable (Typeable)
 import qualified Data.Vault.Lazy as Vault
+#ifdef MIN_VERSION_x509
 import Data.X509
+#endif
 import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr)
 import Network.Wai
@@ -72,7 +76,9 @@ recvRequest firstRequest settings conn ii th addr src transport = do
         rawPath = if settingsNoParsePath settings then unparsedPath else path
         vaultValue = Vault.insert pauseTimeoutKey (Timeout.pause th)
                    $ Vault.insert getFileInfoKey (getFileInfo ii)
+#ifdef MIN_VERSION_x509
                    $ Vault.insert getClientCertificateKey (getTransportClientCertificate transport)
+#endif
                      Vault.empty
     (rbody, remainingRef, bodyLength) <- bodyAndSource src cl te
     -- body producing function which will produce '100-continue', if needed
@@ -317,6 +323,8 @@ getFileInfoKey :: Vault.Key (FilePath -> IO FileInfo)
 getFileInfoKey = unsafePerformIO Vault.newKey
 {-# NOINLINE getFileInfoKey #-}
 
+#ifdef MIN_VERSION_x509
 getClientCertificateKey :: Vault.Key (Maybe CertificateChain)
 getClientCertificateKey = unsafePerformIO Vault.newKey
 {-# NOINLINE getClientCertificateKey #-}
+#endif

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -8,7 +8,9 @@ import qualified UnliftIO
 import qualified Data.ByteString as S
 import Data.IORef (IORef, readIORef, writeIORef, newIORef)
 import Data.Typeable (Typeable)
+#ifdef MIN_VERSION_x509
 import Data.X509
+#endif
 import Foreign.Ptr (Ptr)
 import System.Posix.Types (Fd)
 import qualified System.TimeManager as T
@@ -180,12 +182,16 @@ data Transport = TCP -- ^ Plain channel: TCP
                  , tlsMinorVersion :: Int
                  , tlsNegotiatedProtocol :: Maybe ByteString -- ^ The result of Application Layer Protocol Negociation in RFC 7301
                  , tlsChiperID :: Word16
+#ifdef MIN_VERSION_x509
                  , tlsClientCertificate :: Maybe CertificateChain
+#endif
                  }  -- ^ Encrypted channel: TLS or SSL
                | QUIC {
                    quicNegotiatedProtocol :: Maybe ByteString
                  , quicChiperID :: Word16
+#ifdef MIN_VERSION_x509
                  , quicClientCertificate :: Maybe CertificateChain
+#endif
                  }
 
 isTransportSecure :: Transport -> Bool
@@ -196,7 +202,9 @@ isTransportQUIC :: Transport -> Bool
 isTransportQUIC QUIC{} = True
 isTransportQUIC _      = False
 
+#ifdef MIN_VERSION_x509
 getTransportClientCertificate :: Transport -> Maybe CertificateChain
 getTransportClientCertificate TCP              = Nothing
 getTransportClientCertificate (TLS _ _ _ _ cc) = cc
 getTransportClientCertificate (QUIC _ _ cc)    = cc
+#endif

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -32,6 +32,10 @@ Flag warp-debug
     Description: print debug output. not suitable for production
     Default:     False
 
+Flag x509
+    Description: Adds a dependency on the x509 library to enable getting TLS client certificates.
+    Default:     True
+
 Library
   Build-Depends:     base                      >= 4.12       && < 5
                    , array
@@ -55,8 +59,9 @@ Library
                    , vault                     >= 0.3
                    , wai                       >= 3.2      && < 3.3
                    , word8
-                   , x509
                    , unliftio
+  if flag(x509)
+      Build-Depends: x509
   if impl(ghc < 8)
       Build-Depends: semigroups
   if flag(network-bytestring)
@@ -213,9 +218,10 @@ Test-Suite spec
                    , vault
                    , wai                       >= 3.2      && < 3.3
                    , word8
-                   , x509
                    , unliftio
     -- Build-Tool-Depends: hspec-discover:hspec-discover
+  if flag(x509)
+      Build-Depends: x509
   if impl(ghc < 8)
       Build-Depends: semigroups
                    , transformers
@@ -253,8 +259,9 @@ Benchmark parser
                   , network
                   , time-manager
                   , unix-compat
-                  , x509
                   , unliftio
+  if flag(x509)
+      Build-Depends: x509
   if impl(ghc < 8)
       Build-Depends: semigroups
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.19
+Version:             3.3.20
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
- [X] Bumped the version number

Many warp users use a reverse proxy for TLS termination. But before this PR,
the warp library had an unconditional dependency on the x509 library. The x509
library has a big dependency footprint, which would be irrelevant for these
users. Another problem with the x509 dependency is that it depends on
Cryptonite, which is updated slowly, and is still not available for GHC 9.2.

The wai-app-static library also depends on Cryptonite, but only for computing
MD5 hashes. It seems excessive to depend on this very large library for just a
single hash function. So this PR adds a flag to enable compilation with a
different, also very well-trusted library.

Because both of these newly added flags are enabled by default, it means that a
user that isn't carefully reading the warp/wai-app-static release notes will
not notice any disruption. People that try to upgrade to GHC 9.2 after this PR
is merged may notice that the client certificates are no longer available. But
that is not so bad, since it only happens while upgrading their compiler, which
commonly introduces all kinds of breaking changes. So I don't consider it a big
detraction.

Tested using the following `cabal.project`: `packages: wai-app-static warp`

* `cabal test all -f -cryptonite -f -x509 -w ghc-9.2.1`
* `cabal test all -f cryptonite -f x509 -w ghc-9.0.2`