### PR TITLE
Expose `TLS.supportedHashSignatures` via TLSSettings

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,3 +1,8 @@
+## 3.3.3
+
+* Expose TLS.supportedHashSignatures via TLSSettings
+  [#872](https://github.com/yesodweb/wai/pull/872)
+
 ## 3.3.2
 
 * Providing the Internal module.

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -102,6 +102,7 @@ defaultTlsSettings = TLSSettings {
   , tlsSessionManagerConfig = Nothing
   , tlsCredentials = Nothing
   , tlsSessionManager = Nothing
+  , tlsSupportedHashSignatures = TLS.supportedHashSignatures def
   }
 
 -- taken from stunnel example in tls-extra
@@ -256,6 +257,7 @@ runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock app =
       , TLS.supportedClientInitiatedRenegotiation = False
       , TLS.supportedSession             = True
       , TLS.supportedFallbackScsv        = True
+      , TLS.supportedHashSignatures      = tlsSupportedHashSignatures
 #if MIN_VERSION_tls(1,5,0)
       , TLS.supportedGroups              = [TLS.X25519,TLS.P256,TLS.P384]
 #endif

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -131,6 +131,11 @@ data TLSSettings = TLSSettings {
     --   specified, 'tlsSessionManagerConfig' is ignored.
     --
     --   Since 3.2.12
+  , tlsSupportedHashSignatures :: [TLS.HashAndSignatureAlgorithm]
+    -- ^ Specifying supported hash/signature algorithms, ordered by decreasing
+    -- priority. See the "Network.TLS" module for details
+    --
+    --   Since 3.3.3
   }
 
 


### PR DESCRIPTION
### Proposal 

I noticed that with **TLS1.2** the **Client Certifiicate Types** provided in the **Client Certificate Request** generated during handskake, are derived from **TLS.supportedHashSingatures** (see code snipplet below)

I do not see any way to control this value, when using **runTLS** so propose to expose it via **TLSSettings**.

_excerpt from Network.TLS.Handshake.Server:_
```
(certTypes, hashSigs)
                        | usedVersion < TLS12 = (defaultCertTypes, Nothing)
                        | otherwise =
                            let as = supportedHashSignatures $ ctxSupported ctx
                             in (nub $ mapMaybe hashSigToCertType as, Just as)
```

### Motivation

Some of the **Client Certificate Types** returned, using the default **TLS.supportedHashSignatures** seem not to be recognized by calling clients:

```
$ openssl s_client -tls1_2 -port 1234 -host localhost | grep "Client Certificate Types"
Client Certificate Types: UNKNOWN (0),, UNKNOWN (0),, ECDSA sign, RSA sign, DSA sign
```

We encountered instances of clients that seem unable to cope with that at all.