### PR TITLE
Fix wai-app-static without cryptonite

### DIFF
--- a/wai-app-static/ChangeLog.md
+++ b/wai-app-static/ChangeLog.md
@@ -1,5 +1,13 @@
 # wai-app-static changelog
 
+## 3.1.7.4
+
+* Fix a bug when the cryptonite flag is disabled. [#874](https://github.com/yesodweb/wai/pull/874)
+
+## 3.1.7.3
+
+* Introduce a flag to avoid the cryptonite dependency. [#871](https://github.com/yesodweb/wai/pull/871)
+
 ## 3.1.7.2
 
 * optparse-applicative 0.16.0.0 support

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -132,7 +132,8 @@ hashFile fp = withBinaryFile fp ReadMode $ \h -> do
     let !hash = hashlazy f :: Digest MD5
     return $ convertToBase Base64 hash
 #else
-    return . encode . hashlazy $ f
+    let !hash = hashlazy f
+    return . encode $ hash
 #endif
 
 hashFileIfExists :: ETagLookup

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.7.3
+version:         3.1.7.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Fixes a bug introduced in #871.

Without this, I get
```
hGetBufSome: illegal operation (handle is closed)
```
with `defaultWebAppSettings`.

---

- [x] Bumped the version number
- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->