### PR TITLE
Use ETag gzip middleware (finally)

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.1.12
 
-* Added gzip caching based on `ETag` [#PR NUMBER HERE](https://github.com/yesodweb/wai/pull/PR_NUMBER_HERE):
+* Added gzip caching based on `ETag` [#885](https://github.com/yesodweb/wai/pull/885):
 
 ## 3.1.11
 

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.12
+
+* Added gzip caching based on `ETag` [#PR NUMBER HERE](https://github.com/yesodweb/wai/pull/PR_NUMBER_HERE):
+
 ## 3.1.11
 
 * Overhaul to `Network.Wai.Middleware.Gzip` [#880](https://github.com/yesodweb/wai/pull/880):

--- a/wai-extra/Network/Wai/Header.hs
+++ b/wai-extra/Network/Wai/Header.hs
@@ -5,6 +5,7 @@ module Network.Wai.Header
     , parseQValueList
     , replaceHeader
     , splitCommas
+    , trimWS
     ) where
 
 import Control.Monad (guard)

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.11
+Version:             3.1.12
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

And finally, the PR we've all been waiting for!  (Ok, maybe just me, but hey, happy to have gotten this far)

This change adds using the ETag in the caching of files, so that when used, different versions of the same compressed file can be cached.