### PR TITLE
Using InvalidRequest instead of HTTP2Error

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -120,7 +120,7 @@ Library
                    , vault
                    , aeson
                    , iproute                   >= 1.7.8
-                   , http2
+                   , warp                      >= 3.3.22
                    , HUnit
                    , call-stack
 
@@ -219,7 +219,7 @@ test-suite spec
                    , cookie
                    , time
                    , case-insensitive
-                   , http2
+                   , warp
                    , aeson
                    , iproute
                    , temporary

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -5,11 +5,7 @@ module Network.Wai.Handler.Warp.HTTP2.Types where
 
 import qualified Data.ByteString as BS
 import qualified Network.HTTP.Types as H
-#if MIN_VERSION_http2(3,0,0)
 import Network.HTTP2.Frame
-#else
-import Network.HTTP2
-#endif
 import qualified Network.HTTP2.Server as H2
 
 import Network.Wai.Handler.Warp.Imports

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -40,6 +40,8 @@ data InvalidRequest = NotEnoughLines [String]
                     | ConnectionClosedByPeer
                     | OverLargeHeader
                     | BadProxyHeader String
+                    | PayloadTooLarge -- ^ Since 3.3.22
+                    | RequestHeaderFieldsTooLarge -- ^ Since 3.3.22
                     deriving (Eq, Typeable)
 
 instance Show InvalidRequest where
@@ -50,6 +52,8 @@ instance Show InvalidRequest where
     show ConnectionClosedByPeer = "Warp: Client closed connection prematurely"
     show OverLargeHeader = "Warp: Request headers too large, possible memory attack detected. Closing connection."
     show (BadProxyHeader s) = "Warp: Invalid PROXY protocol header: " ++ show s
+    show RequestHeaderFieldsTooLarge = "Request header fields too large"
+    show PayloadTooLarge = "Payload too large"
 
 instance UnliftIO.Exception InvalidRequest
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -48,7 +48,7 @@ Library
                    , hashable
                    , http-date
                    , http-types                >= 0.12
-                   , http2                     >= 3.0      && < 3.1
+                   , http2                     >= 3.0      && < 5
                    , iproute                   >= 1.3.1
                    , simple-sendfile           >= 0.2.7    && < 0.3
                    , stm                       >= 2.3
@@ -205,7 +205,7 @@ Test-Suite spec
                    , http-client
                    , http-date
                    , http-types                >= 0.12
-                   , http2                     >= 3.0      && < 3.1
+                   , http2                     >= 3.0      && < 5
                    , iproute                   >= 1.3.1
                    , network
                    , process

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.21
+Version:             3.3.22
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
I'm preparing http2 lib v4 since RFC9113 was published. http2 v4 discovered a flaw of #741.

413 and 431 is in the semantics level while HTTP2Error is in the transport level. It is mis-use that a response status code is contained in ConnectionError.

My review of #741 was not good enough. I'm very sorry.

I would like to add RequestHeaderFieldsTooLarge and PayloadTooLarge to InvalidRequest and use them instead of ConnectionError. This reduces the dependency from wai-extra to http2.

This PR also contains preparation for http2 v4.

Cc: @michalrus and @vlatkoB