### PR TITLE
Refactors that should not impact anything

### DIFF
--- a/auto-update/Control/AutoUpdate.hs
+++ b/auto-update/Control/AutoUpdate.hs
@@ -51,6 +51,7 @@ import           Control.Exception       (SomeException, catch, mask_, throw,
                                           try)
 import           Control.Monad           (void)
 import           Data.IORef              (newIORef, readIORef, writeIORef)
+import           Data.Maybe              (fromMaybe)
 
 -- | Default value for creating an 'UpdateSettings'.
 --
@@ -162,7 +163,7 @@ mkAutoUpdateHelper us updateActionModify = do
                 takeMVar needsRunning
 
                 -- new value requested, so run the updateAction
-                a <- catchSome $ maybe (updateAction us) id (updateActionModify <*> maybea)
+                a <- catchSome $ fromMaybe (updateAction us) (updateActionModify <*> maybea)
 
                 -- we got a new value, update currRef and lastValue
                 writeIORef currRef $ Right a

--- a/auto-update/Control/AutoUpdate.hs
+++ b/auto-update/Control/AutoUpdate.hs
@@ -6,12 +6,12 @@
 -- second, and write the current time to a shared 'IORef', than it is for each
 -- request to make its own call to 'getCurrentTime'.
 --
--- But for a low-volume server, whose request frequency is less than once per 
--- second, that approach will result in /more/ calls to 'getCurrentTime' than 
+-- But for a low-volume server, whose request frequency is less than once per
+-- second, that approach will result in /more/ calls to 'getCurrentTime' than
 -- necessary, and worse, kills idle GC.
 --
 -- This library solves that problem by allowing you to define actions which will
--- either be performed by a dedicated thread, or, in times of low volume, will 
+-- either be performed by a dedicated thread, or, in times of low volume, will
 -- be executed by the calling thread.
 --
 -- Example usage:

--- a/auto-update/Control/Debounce.hs
+++ b/auto-update/Control/Debounce.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 -- | Debounce an action, ensuring it doesn't occur more than once for a given
 -- period of time.
 --

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 module Control.DebounceSpec (spec) where
 
 import Control.Concurrent
@@ -88,7 +87,7 @@ getWaitAction = do
 -- | Get a debounce system with access to the internals for testing
 getDebounce :: DI.DebounceEdge -> IO (IORef Int, IO (), MVar (), IO ())
 getDebounce edge = do
-  ref :: IORef Int <- newIORef 0
+  ref <- newIORef 0
   let action = modifyIORef ref (+ 1)
 
   (waitAction, returnFromWait) <- getWaitAction

--- a/auto-update/test/Control/DebounceSpec.hs
+++ b/auto-update/test/Control/DebounceSpec.hs
@@ -114,7 +114,7 @@ waitForBatonToBeTaken baton = waitUntil 5 $ tryReadMVar baton >>= (`shouldBe` No
 waitUntil :: Int -> IO a -> IO ()
 waitUntil n action = recovering policy [handler] (\_status -> void action)
   where policy = constantDelay 1000 `mappend` limitRetries (n * 1000) -- 1ms * n * 1000 tries = n seconds
-        handler _status = Handler (\(HUnitFailure {}) -> return True)
+        handler _status = Handler (\HUnitFailure{} -> return True)
 
 main :: IO ()
 main = hspec spec

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -74,7 +74,7 @@ filterButLast f (x:xs)
 
 -- | Serve an appropriate response for a folder request.
 serveFolder :: StaticSettings -> Pieces -> W.Request -> Folder -> IO StaticResponse
-serveFolder StaticSettings {..} pieces req folder@Folder {..} =
+serveFolder StaticSettings {..} pieces req folder =
     case ssListing of
         Just _ | Just path <- addTrailingSlash req, ssAddTrailingSlash ->
             return $ RawRedirect path

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -280,7 +280,7 @@ staticAppPieces ss rawPieces req sendResponse = liftIO $ do
                 , ("Location", path)
                 ] "Redirect"
 
-    response NotFound = case (ss404Handler ss) of
+    response NotFound = case ss404Handler ss of
         Just app -> app req sendResponse
         Nothing  -> sendResponse $ W.responseLBS H.status404
                         [ ("Content-Type", "text/plain")

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -93,14 +93,14 @@ args = Args
 -- Since 2.0.1
 runCommandLine :: (Args -> Middleware) -> IO ()
 runCommandLine middleware = do
-    args@Args {..} <- execParser $ info (helperOption <*> args) fullDesc
+    clArgs@Args {..} <- execParser $ info (helperOption <*> args) fullDesc
     let mime' = map (pack *** S8.pack) mime
     let mimeMap = Map.fromList mime' `Map.union` defaultMimeMap
     docroot' <- canonicalizePath docroot
     unless quiet $ printf "Serving directory %s on port %d with %s index files.\n" docroot' port (if noindex then "no" else show index)
     let middle = gzip def { gzipFiles = GzipCompress }
                . (if verbose then logStdout else id)
-               . middleware args
+               . middleware clArgs
     runSettings
         ( setPort port
         $ setHost (fromString host)

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -18,13 +18,12 @@ import Network.Wai.Middleware.RequestLogger (logStdout)
 import Network.Wai.Middleware.Gzip
 import qualified Data.Map as Map
 import qualified Data.ByteString.Char8 as S8
-import Control.Arrow ((***))
 import Data.Text (pack)
 import Data.String (fromString)
 import Network.Mime (defaultMimeMap, mimeByExt, defaultMimeType)
 import WaiAppStatic.Types (ssIndices, toPiece, ssGetMimeType, fileName, fromPiece)
 import Data.Maybe (mapMaybe)
-import Control.Arrow (second)
+import Control.Arrow (second, (***))
 import Data.Monoid ((<>))
 
 data Args = Args

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, RecordWildCards, CPP #-}
+{-# LANGUAGE RecordWildCards, CPP #-}
 -- | Command line version of wai-app-static, used for the warp-static server.
 module WaiAppStatic.CmdLine
     ( runCommandLine

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -101,7 +101,7 @@ runCommandLine middleware = do
     unless quiet $ printf "Serving directory %s on port %d with %s index files.\n" docroot' port (if noindex then "no" else show index)
     let middle = gzip def { gzipFiles = GzipCompress }
                . (if verbose then logStdout else id)
-               . (middleware args)
+               . middleware args
     runSettings
         ( setPort port
         $ setHost (fromString host)

--- a/wai-app-static/WaiAppStatic/Listing.hs
+++ b/wai-app-static/WaiAppStatic/Listing.hs
@@ -50,7 +50,7 @@ defaultListing pieces (Folder contents) = do
                                               ]
              H.body $ do
                  let hasTrailingSlash =
-                        case map fromPiece $ reverse $ pieces of
+                        case map fromPiece $ reverse pieces of
                             "":_ -> True
                             _ -> False
                  H.h1 $ showFolder' hasTrailingSlash $ filter (not . T.null . fromPiece) pieces
@@ -92,7 +92,7 @@ renderDirectoryContentsTable :: [T.Text] -- ^ requested path info
                              -> [Either FolderName File]
                              -> H.Html
 renderDirectoryContentsTable pathInfo' haskellSrc folderSrc fps =
-           H.table $ do H.thead $ do H.th ! A.class_ "first" $ H.img ! (A.src $ H.toValue haskellSrc)
+           H.table $ do H.thead $ do H.th ! A.class_ "first" $ H.img ! A.src (H.toValue haskellSrc)
                                      H.th "Name"
                                      H.th "Modified"
                                      H.th "Size"

--- a/wai-app-static/WaiAppStatic/Listing.hs
+++ b/wai-app-static/WaiAppStatic/Listing.hs
@@ -56,7 +56,7 @@ defaultListing pieces (Folder contents) = do
                  H.h1 $ showFolder' hasTrailingSlash $ filter (not . T.null . fromPiece) pieces
                  renderDirectoryContentsTable (map fromPiece pieces) haskellSrc folderSrc fps''
   where
-    image x = T.unpack $ T.concat [(relativeDirFromPieces pieces), ".hidden/", x, ".png"]
+    image x = T.unpack $ T.concat [relativeDirFromPieces pieces, ".hidden/", x, ".png"]
     folderSrc = image "folder"
     haskellSrc = image "haskell"
     showName "" = "root"
@@ -92,7 +92,7 @@ renderDirectoryContentsTable :: [T.Text] -- ^ requested path info
                              -> [Either FolderName File]
                              -> H.Html
 renderDirectoryContentsTable pathInfo' haskellSrc folderSrc fps =
-           H.table $ do H.thead $ do H.th ! (A.class_ "first") $ H.img ! (A.src $ H.toValue haskellSrc)
+           H.table $ do H.thead $ do H.th ! A.class_ "first" $ H.img ! (A.src $ H.toValue haskellSrc)
                                      H.th "Name"
                                      H.th "Modified"
                                      H.th "Size"

--- a/wai-app-static/WaiAppStatic/Listing.hs
+++ b/wai-app-static/WaiAppStatic/Listing.hs
@@ -117,8 +117,7 @@ renderDirectoryContentsTable pathInfo' haskellSrc folderSrc fps =
                            case either id fileName md of
                                (fromPiece -> "") -> unsafeToPiece ".."
                                x -> x
-                   let isFile = either (const False) (const True) md
-                       href = addCurrentDir $ fromPiece name
+                   let href = addCurrentDir $ fromPiece name
                        addCurrentDir x =
                            case reverse pathInfo' of
                                "":_ -> x -- has a trailing slash

--- a/wai-app-static/app/warp-static.hs
+++ b/wai-app-static/app/warp-static.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable, RecordWildCards #-}
 module Main (main) where
 
 import WaiAppStatic.CmdLine (runCommandLine)

--- a/wai-app-static/test/WaiAppStaticTest.hs
+++ b/wai-app-static/test/WaiAppStaticTest.hs
@@ -20,6 +20,7 @@ import Network.HTTP.Types (status500)
 import Network.Wai
 import Network.Wai.Test
 
+import Control.Monad (forM_)
 import Control.Monad.IO.Class (liftIO)
 import Network.Mime
 
@@ -48,12 +49,12 @@ spec = do
 
   describe "webApp" $ do
     it "403 for unsafe paths" $ webApp $
-      flip mapM_ ["..", "."] $ \path ->
+      forM_ ["..", "."] $ \path ->
         assertStatus 403 =<<
           request (setRawPathInfo defRequest path)
 
     it "200 for hidden paths" $ webApp $
-      flip mapM_ [".hidden/folder.png", ".hidden/haskell.png"] $ \path ->
+      forM_ [".hidden/folder.png", ".hidden/haskell.png"] $ \path ->
         assertStatus 200 =<<
           request (setRawPathInfo defRequest path)
 
@@ -70,7 +71,7 @@ spec = do
           ssMkRedirect = \_ u -> S8.append "http://www.example.com" u
         }
     it "302 redirect when multiple slashes" $ absoluteApp $
-      flip mapM_ ["/a//b/c", "a//b/c"] $ \path -> do
+      forM_ ["/a//b/c", "a//b/c"] $ \path -> do
         req <- request (setRawPathInfo defRequest path)
         assertStatus 302 req
         assertHeader "Location" "http://www.example.com/a/b/c" req
@@ -89,7 +90,7 @@ spec = do
       assertNoHeader "Last-Modified" req
 
     it "200 when invalid in-none-match sent" $ webApp $
-      flip mapM_ ["cached", ""] $ \badETag -> do
+      forM_ ["cached", ""] $ \badETag -> do
         req <- request statFile { requestHeaders  = [("If-None-Match", badETag)] }
         assertStatus 200 req
         assertHeader "ETag" etag req
@@ -115,7 +116,7 @@ spec = do
       assertBodyContains "<a href=\"b\">b</a>" resp
 
     it "200 when invalid if-modified-since header" $ fileServerApp $ do
-      flip mapM_ ["123", ""] $ \badDate -> do
+      forM_ ["123", ""] $ \badDate -> do
         req <- request statFile {
           requestHeaders = [("If-Modified-Since", badDate)]
         }

--- a/wai-frontend-monadcgi/Network/Wai/Frontend/MonadCGI.hs
+++ b/wai-frontend-monadcgi/Network/Wai/Frontend/MonadCGI.hs
@@ -36,7 +36,7 @@ cgiToAppGeneric toIO cgi env sendResponse = do
                ++ getCgiVars env
         (inputs, body') = decodeInput vars input
         req = CGIRequest
-                { cgiVars = Map.fromList $ vars
+                { cgiVars = Map.fromList vars
                 , cgiInputs = inputs
                 , cgiRequestBody = body'
                 }

--- a/wai-http2-extra/Network/Wai/Middleware/Push/Referer.hs
+++ b/wai-http2-extra/Network/Wai/Middleware/Push/Referer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- | Middleware for server push learning dependency based on Referer:.
 module Network.Wai.Middleware.Push.Referer (

--- a/wai-websockets/Network/Wai/Handler/WebSockets.hs
+++ b/wai-websockets/Network/Wai/Handler/WebSockets.hs
@@ -106,9 +106,8 @@ runWebSockets opts req app src sink = bracket mkStream ensureClose (app . pc)
             (do
                 bs <- src
                 return $ if BC.null bs then Nothing else Just bs)
-            (\mbBl -> case mbBl of
-                Nothing -> return ()
-                Just bl -> mapM_ sink (BL.toChunks bl))
+            -- 'mapM_' works here because it's 'return ()' on Nothing
+            (mapM_ $ \bl -> mapM_ sink (BL.toChunks bl))
 
     pc stream = WS.PendingConnection
         { WS.pendingOptions     = opts

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -88,8 +88,7 @@ module Network.Wai
     , modifyResponse
     ) where
 
-import           Data.ByteString.Builder      (Builder, lazyByteString)
-import           Data.ByteString.Builder      (byteString)
+import           Data.ByteString.Builder      (Builder, byteString, lazyByteString)
 import           Control.Monad                (unless)
 import qualified Data.ByteString              as B
 import qualified Data.ByteString.Lazy         as L

--- a/wai/test/Network/WaiSpec.hs
+++ b/wai/test/Network/WaiSpec.hs
@@ -22,7 +22,7 @@ spec = do
                         flush :: IO ()
                         flush = return ()
                     streamingBody add flush
-                    fmap (L.toStrict . toLazyByteString) $ readIORef builderRef
+                    L.toStrict . toLazyByteString <$> readIORef builderRef
         prop "responseLBS" $ \bytes -> do
             body <- getBody $ responseLBS undefined undefined $ L.pack bytes
             body `shouldBe` S.pack bytes

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -394,7 +394,7 @@ fill bs0 buf0 siz0 recv
       bs <- recv
       let len = S.length bs
       if len == 0 then return (False, "")
-        else if (len <= siz) then do
+        else if len <= siz then do
           buf' <- copy buf bs
           loop buf' (siz - len)
         else do

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -63,10 +63,16 @@ import qualified Data.IORef as I
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)
 import GHC.IO.Exception (IOErrorType(..))
-import Network.Socket (Socket, close, withSocketsDo, SockAddr, accept)
+import Network.Socket (
+    SockAddr,
+    Socket,
+    accept,
+    close,
 #if MIN_VERSION_network(3,1,1)
-import Network.Socket (gracefulClose)
+    gracefulClose,
 #endif
+    withSocketsDo,
+ )
 import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
 import qualified Crypto.PubKey.DH as DH

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -225,8 +225,8 @@ runTLSSocket tlsset set sock app = do
     runTLSSocket' tlsset set credentials mgr sock app
 
 runTLSSocket' :: TLSSettings -> Settings -> TLS.Credentials -> TLS.SessionManager -> Socket -> Application -> IO ()
-runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock app =
-    runSettingsConnectionMakerSecure set get app
+runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock =
+    runSettingsConnectionMakerSecure set get
   where
     get = getter tlsset set sock params
     params = def { -- TLS.ServerParams

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -169,7 +169,7 @@ tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings {
 -- @since 3.3.0
 tlsSettingsRef
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
-    -> I.IORef (S.ByteString) -- ^ Reference to key bytes
+    -> I.IORef S.ByteString -- ^ Reference to key bytes
     -> TLSSettings
 tlsSettingsRef cert key = defaultTlsSettings {
     certSettings = CertFromRef cert [] key
@@ -182,7 +182,7 @@ tlsSettingsRef cert key = defaultTlsSettings {
 tlsSettingsChainRef
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> [I.IORef S.ByteString] -- ^ Reference to chain certificate bytes
-    -> I.IORef (S.ByteString) -- ^ Reference to key bytes
+    -> I.IORef S.ByteString -- ^ Reference to key bytes
     -> TLSSettings
 tlsSettingsChainRef cert chainCerts key = defaultTlsSettings {
     certSettings = CertFromRef cert chainCerts key

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -140,7 +140,7 @@ tlsSettingsMemory
     :: S.ByteString -- ^ Certificate bytes
     -> S.ByteString -- ^ Key bytes
     -> TLSSettings
-tlsSettingsMemory cert key = defaultTlsSettings { 
+tlsSettingsMemory cert key = defaultTlsSettings {
     certSettings = CertFromMemory cert [] key
   }
 
@@ -153,7 +153,7 @@ tlsSettingsChainMemory
     -> [S.ByteString] -- ^ Chain certificate bytes
     -> S.ByteString -- ^ Key bytes
     -> TLSSettings
-tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings { 
+tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings {
     certSettings = CertFromMemory cert chainCerts key
   }
 
@@ -161,11 +161,11 @@ tlsSettingsChainMemory cert chainCerts key = defaultTlsSettings {
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
 -- @since 3.3.0
-tlsSettingsRef 
+tlsSettingsRef
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
-    -> I.IORef (S.ByteString) -- ^ Reference to key bytes 
-    -> TLSSettings 
-tlsSettingsRef cert key = defaultTlsSettings { 
+    -> I.IORef (S.ByteString) -- ^ Reference to key bytes
+    -> TLSSettings
+tlsSettingsRef cert key = defaultTlsSettings {
     certSettings = CertFromRef cert [] key
   }
 
@@ -173,12 +173,12 @@ tlsSettingsRef cert key = defaultTlsSettings {
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
 -- @since 3.3.0
-tlsSettingsChainRef 
+tlsSettingsChainRef
     :: I.IORef S.ByteString -- ^ Reference to certificate bytes
     -> [I.IORef S.ByteString] -- ^ Reference to chain certificate bytes
-    -> I.IORef (S.ByteString) -- ^ Reference to key bytes 
-    -> TLSSettings 
-tlsSettingsChainRef cert chainCerts key = defaultTlsSettings { 
+    -> I.IORef (S.ByteString) -- ^ Reference to key bytes
+    -> TLSSettings
+tlsSettingsChainRef cert chainCerts key = defaultTlsSettings {
     certSettings = CertFromRef cert chainCerts key
   }
 
@@ -196,11 +196,11 @@ runTLS tset set app = withSocketsDo $
 
 loadCredentials :: TLSSettings -> IO TLS.Credentials
 loadCredentials TLSSettings{ tlsCredentials = Just creds } = return creds
-loadCredentials TLSSettings{..} = case certSettings of 
+loadCredentials TLSSettings{..} = case certSettings of
   CertFromFile cert chainFiles key -> do
     cred <- either error id <$> TLS.credentialLoadX509Chain cert chainFiles key
     return $ TLS.Credentials [cred]
-  CertFromRef certRef chainCertsRef keyRef -> do 
+  CertFromRef certRef chainCertsRef keyRef -> do
     cert <- I.readIORef certRef
     chainCerts <- mapM I.readIORef chainCertsRef
     key <- I.readIORef keyRef

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Types.hs
@@ -1,12 +1,15 @@
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Network.Wai.Handler.Warp.HTTP2.Types where
 
 import qualified Data.ByteString as BS
 import qualified Network.HTTP.Types as H
+#if MIN_VERSION_http2(3,0,0)
+import Network.HTTP2.Frame
+#else
 import Network.HTTP2
+#endif
 import qualified Network.HTTP2.Server as H2
 
 import Network.Wai.Handler.Warp.Imports

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -177,7 +177,7 @@ runTerminateTest expected input = do
     withApp (setOnException onExc defaultSettings) dummyApp $ withMySocket $ \ms -> do
         msWrite ms input
         msClose ms -- explicitly
-        threadDelay 1000
+        threadDelay 5000
         res <- I.readIORef ref
         show res `shouldBe` show (Just expected)
 
@@ -235,7 +235,8 @@ spec = do
 
     describe "connection termination" $ do
 --        it "ConnectionClosedByPeer" $ runTerminateTest ConnectionClosedByPeer "GET / HTTP/1.1\r\ncontent-length: 10\r\n\r\nhello"
-        it "IncompleteHeaders" $ runTerminateTest IncompleteHeaders "GET / HTTP/1.1\r\ncontent-length: 10\r\n"
+        it "IncompleteHeaders" $
+            runTerminateTest IncompleteHeaders "GET / HTTP/1.1\r\ncontent-length: 10\r\n"
 
     describe "special input" $ do
         it "multiline headers" $ do

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -83,9 +83,9 @@ withMySocket body port = bracket (connectTo port) msClose body
 
 incr :: MonadIO m => Counter -> m ()
 incr icount = liftIO $ I.atomicModifyIORef icount $ \ecount ->
-    ((case ecount of
+    (case ecount of
         Left s -> Left s
-        Right i -> Right $ i + 1), ())
+        Right i -> Right $ i + 1, ())
 
 err :: (MonadIO m, Show a) => Counter -> a -> m ()
 err icount msg = liftIO $ I.writeIORef icount $ Left $ show msg
@@ -106,7 +106,7 @@ readBody icount req f = do
 
 ignoreBody :: CounterApplication
 ignoreBody icount req f = do
-    if (requestMethod req `elem` ["GET", "POST"])
+    if requestMethod req `elem` ["GET", "POST"]
         then incr icount
         else err icount ("Invalid request method" :: String, requestMethod req)
     f $ responseLBS status200 [] "Ignored the body"
@@ -309,7 +309,7 @@ spec = do
             withApp defaultSettings app $ withMySocket $ \ms -> do
                 let input = concat $ replicate 2 $
                         ["POST / HTTP/1.1\r\nTransfer-Encoding: Chunked\r\n\r\n"] ++
-                        (replicate 50 "5\r\n12345\r\n") ++
+                        replicate 50 "5\r\n12345\r\n" ++
                         ["0\r\n\r\n"]
                 mapM_ (msWrite ms) input
                 atomically $ do

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -248,7 +248,7 @@ spec = do
                         [ "GET / HTTP/1.1\r\nfoo:    bar\r\n baz\r\n\tbin\r\n\r\n"
                         ]
                 msWrite ms input
-                threadDelay 1000
+                threadDelay 5000
                 headers <- I.readIORef iheaders
                 headers `shouldBe`
                     [ ("foo", "bar baz\tbin")
@@ -263,7 +263,7 @@ spec = do
                         [ "GET / HTTP/1.1\r\nfoo:bar\r\n\r\n"
                         ]
                 msWrite ms input
-                threadDelay 1000
+                threadDelay 5000
                 headers <- I.readIORef iheaders
                 headers `shouldBe`
                     [ ("foo", "bar")


### PR DESCRIPTION
Just went through all modules to see if there were any redundant easy fixes.

Only one that might not work for all GHCs is a module where I removed `ScopedTypeVariables`, but I'm pretty sure the type inference should pick that up without the explicit type signature.

---

- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)