### PR TITLE
add settingsAccept

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.3.4
+
+* Add `setAccept` for hooking the socket `accept` call.
+  [#912](https://github.com/yesodweb/wai/pull/912)
+
 ## 3.3.3
 
 * Creating a bigger buffer when the current one is too small to fit the Builder

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 3.3.4
 
-* Add `setAccept` for hooking the socket `accept` call.
+* Integrated customizable `accept` hook from `Network.Wai.Handler.Warp.Settings` (cf. `setAccept`)
   [#912](https://github.com/yesodweb/wai/pull/912)
 
 ## 3.3.3

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -4,6 +4,8 @@
 
 * Integrated customizable `accept` hook from `Network.Wai.Handler.Warp.Settings` (cf. `setAccept`)
   [#912](https://github.com/yesodweb/wai/pull/912)
+* Adjusted `httpOverTls` because of the factoring out of `Network.Wai.Handler.Warp.Recv` to its own package `recv` in the `warp` package.
+  [#899](https://github.com/yesodweb/wai/pull/899)
 
 ## 3.3.3
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -66,7 +66,6 @@ import GHC.IO.Exception (IOErrorType(..))
 import Network.Socket (
     SockAddr,
     Socket,
-    accept,
     close,
 #if MIN_VERSION_network(3,1,1)
     gracefulClose,
@@ -277,12 +276,8 @@ alpn xs
 ----------------------------------------------------------------
 
 getter :: TLS.TLSParams params => TLSSettings -> Settings -> Socket -> params -> IO (IO (Connection, Transport), SockAddr)
-getter tlsset set sock params = do
-#if WINDOWS
-    (s, sa) <- windowsThreadBlockHack $ accept sock
-#else
-    (s, sa) <- accept sock
-#endif
+getter tlsset set@Settings{settingsAccept = accept'} sock params = do
+    (s, sa) <- accept' sock
     setSocketCloseOnExec s
     return (mkConn tlsset set s params, sa)
 

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -21,7 +21,7 @@ Library
   Build-Depends:     base                          >= 4.12     && < 5
                    , bytestring                    >= 0.9
                    , wai                           >= 3.2      && < 3.3
-                   , warp                          >= 3.3.23   && < 3.4
+                   , warp                          >= 3.3.24   && < 3.4
                    , data-default-class            >= 0.0.1
                    , tls                           >= 1.5.3
                    , cryptonite                    >= 0.12

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -21,7 +21,7 @@ Library
   Build-Depends:     base                          >= 4.12     && < 5
                    , bytestring                    >= 0.9
                    , wai                           >= 3.2      && < 3.3
-                   , warp                          >= 3.3.24   && < 3.4
+                   , warp                          >= 3.3.23   && < 3.4
                    , data-default-class            >= 0.0.1
                    , tls                           >= 1.5.3
                    , cryptonite                    >= 0.12

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for warp
 
+## 3.3.24
+
+* Add `setAccept` for hooking the socket `accept` call.
+  [#912](https://github.com/yesodweb/wai/pull/912)
+
 ## 3.3.23.1
 
 * Removed some package dependencies from test suite

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,17 +1,11 @@
 # ChangeLog for warp
 
-## 3.3.24
+## 3.3.23
 
 * Add `setAccept` for hooking the socket `accept` call.
   [#912](https://github.com/yesodweb/wai/pull/912)
-
-## 3.3.23.1
-
 * Removed some package dependencies from test suite
   [#902](https://github.com/yesodweb/wai/pull/902)
-
-## 3.3.23
-
 * Factored out `Network.Wai.Handler.Warp.Recv` to its own package `recv`.
   [#899](https://github.com/yesodweb/wai/pull/899)
 

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -13,7 +13,7 @@
 ## 3.3.23
 
 * Factored out `Network.Wai.Handler.Warp.Recv` to its own package `recv`.
-  [#899](https://github.com/yesodweb/wai/pull/895)
+  [#899](https://github.com/yesodweb/wai/pull/899)
 
 ## 3.3.22
 

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -378,7 +378,7 @@ setFork fork' s = s { settingsFork = fork' }
 --
 -- Default: 'defaultAccept'
 --
--- Since x.x.x
+-- Since 3.3.24
 setAccept :: (Socket -> IO (Socket, SockAddr)) -> Settings -> Settings
 setAccept accept' s = s { settingsAccept = accept' }
 

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -64,6 +64,7 @@ module Network.Wai.Handler.Warp (
   , setServerName
   , setMaximumBodyFlush
   , setFork
+  , setAccept
   , setProxyProtocolNone
   , setProxyProtocolRequired
   , setProxyProtocolOptional
@@ -135,7 +136,7 @@ import qualified Data.Vault.Lazy as Vault
 import Data.X509
 #endif
 import qualified Network.HTTP.Types as H
-import Network.Socket (SockAddr)
+import Network.Socket (Socket, SockAddr)
 import Network.Wai (Request, Response, vault)
 import System.TimeManager
 
@@ -369,6 +370,17 @@ setMaximumBodyFlush x y
 -- Since 3.0.4
 setFork :: (((forall a. IO a -> IO a) -> IO ()) -> IO ()) -> Settings -> Settings
 setFork fork' s = s { settingsFork = fork' }
+
+-- | Code to accept a new connection.
+--
+-- Useful if you need to provide connected sockets from something other
+-- than a standard accept call.
+--
+-- Default: 'defaultAccept'
+--
+-- Since x.x.x
+setAccept :: (Socket -> IO (Socket, SockAddr)) -> Settings -> Settings
+setAccept accept' s = s { settingsAccept = accept' }
 
 -- | Do not use the PROXY protocol.
 --

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -24,8 +24,8 @@ import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
 
 import Network.Wai.Handler.Warp.Imports
-import Network.Wai.Handler.Warp.Internal (windowsThreadBlockHack)
 import Network.Wai.Handler.Warp.Types
+import Network.Wai.Handler.Warp.Windows (windowsThreadBlockHack)
 
 -- | Various Warp server settings. This is purposely kept as an abstract data
 -- type so that new settings can be added without breaking backwards

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -16,7 +16,7 @@ import qualified Data.Text.IO as TIO
 import Data.Version (showVersion)
 import GHC.IO.Exception (IOErrorType(..), AsyncException (ThreadKilled))
 import qualified Network.HTTP.Types as H
-import Network.Socket (SockAddr)
+import Network.Socket (Socket, SockAddr, accept)
 import Network.Wai
 import qualified Paths_warp
 import System.IO (stderr)
@@ -66,6 +66,16 @@ data Settings = Settings
       -- Default: 'defaultFork'
       --
       -- Since 3.0.4
+
+    , settingsAccept :: Socket -> IO (Socket, SockAddr)
+      -- ^ Code to accept a new connection.
+      --
+      -- Useful if you need to provide connected sockets from something other
+      -- than a standard accept call.
+      --
+      -- Default: 'defaultAccept'
+      --
+      -- Since x.x.x
 
     , settingsNoParsePath :: Bool
       -- ^ Perform no parsing on the rawPathInfo.
@@ -178,6 +188,7 @@ defaultSettings = Settings
     , settingsFileInfoCacheDuration = 0
     , settingsBeforeMainLoop = return ()
     , settingsFork = defaultFork
+    , settingsAccept = defaultAccept
     , settingsNoParsePath = False
     , settingsInstallShutdownHandler = const $ return ()
     , settingsServerName = C8.pack $ "Warp/" ++ showVersion Paths_warp.version
@@ -274,4 +285,15 @@ defaultFork io =
     case (fork# (io unsafeUnmask) s0) of
       (# s1, _tid #) ->
         (# s1, () #)
+#endif
+
+-- | Standard "accept" call for a listening socket.
+--
+-- @since x.x.x
+defaultAccept :: Socket -> IO (Socket, SockAddr)
+defaultAccept =
+#if WINDOWS
+    windowsThreadBlockHack . accept
+#else
+    accept
 #endif

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -76,7 +76,7 @@ data Settings = Settings
       --
       -- Default: 'defaultAccept'
       --
-      -- Since x.x.x
+      -- Since 3.3.24
 
     , settingsNoParsePath :: Bool
       -- ^ Perform no parsing on the rawPathInfo.
@@ -290,7 +290,7 @@ defaultFork io =
 
 -- | Standard "accept" call for a listening socket.
 --
--- @since x.x.x
+-- @since 3.3.24
 defaultAccept :: Socket -> IO (Socket, SockAddr)
 defaultAccept =
 #if WINDOWS

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -24,6 +24,7 @@ import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
 
 import Network.Wai.Handler.Warp.Imports
+import Network.Wai.Handler.Warp.Internal (windowsThreadBlockHack)
 import Network.Wai.Handler.Warp.Types
 
 -- | Various Warp server settings. This is purposely kept as an abstract data

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.24
+Version:             3.3.23
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.23.1
+Version:             3.3.24
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Allow the user to provide a custom "accept" call for unusual socket situations.  Ref PR #909. 

### Use case ###
Reverse socket connections where the web server initiates the connection to the web client.  This is useful for IoT API servers that typically cannot receive inbound connections due to firewall and NAT.

### Manual testing ###
- My linux app when `setAccept` is not overridden: It works.
- My linux app when `setAccept` is overridden as follows
``` haskell
setAccept (\s -> do
          r <- accept s
          putStrLn "accepted!"
          pure r
        )
```
It works!

### Checklist ###

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
