### PR TITLE
Install settings shutdown handler for TLS servers

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -226,6 +226,7 @@ getSessionManager TLSSettings{..} = case tlsSessionManagerConfig of
 --   specified 'Socket'.
 runTLSSocket :: TLSSettings -> Settings -> Socket -> Application -> IO ()
 runTLSSocket tlsset set sock app = do
+    settingsInstallShutdownHandler set (close sock)
     credentials <- loadCredentials tlsset
     mgr <- getSessionManager tlsset
     runTLSSocket' tlsset set credentials mgr sock app

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.3.4
+Version:             3.3.4.1
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Any shutdown handler passing in the settings to 'runTLS' or 'runTLSSocket' was not being installed in the same way that 'runSettingsSocket' and friends do for non-TLS servers.

This updates 'runTLSSocket' to make it install the shutdown handler from the settings so that warp-tls behaves the same way as warp in this regard.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->