### PR TITLE
wai-extra: require ansi-terminal >= 0.4 and wai >= 3.2.2.1

### DIFF
--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -103,7 +103,7 @@ flag build-example
 Library
   Build-Depends:     base                      >= 4.12 && < 5
                    , aeson
-                   , ansi-terminal
+                   , ansi-terminal             >= 0.4
                    , base64-bytestring
                    , bytestring                >= 0.10.4
                    , call-stack
@@ -123,7 +123,7 @@ Library
                    , time                      >= 1.1.4
                    , transformers              >= 0.2.2
                    , vault
-                   , wai                       >= 3.0.3.0  && < 3.3
+                   , wai                       >= 3.2.2.1  && < 3.3
                    , wai-logger                >= 2.3.7
                    , warp                      >= 3.3.22
                    , word8


### PR DESCRIPTION
Otherwise for earlier `ansi-terminal` one gets
```
Network/Wai/Middleware/RequestLogger.hs:347:15: error:
    Not in scope: type constructor or class ‘Color’
    |
347 | ansiColor' :: Color -> BS.ByteString -> [BS.ByteString]
    |               ^^^^^

Network/Wai/Middleware/RequestLogger.hs:408:25: error:
    Not in scope: type constructor or class ‘Color’
    |
408 |                     -> (Color -> BS.ByteString -> [BS.ByteString])
    |
```
and for earlier `wai`:
```
Network/Wai/Middleware/RequestLogger.hs:53:5: error:
    Module ‘Network.Wai’ does not export ‘getRequestBodyChunk’
   |
53 |   , getRequestBodyChunk
   |     ^^^^^
```

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->