### PR TITLE
warp-tls: setSocketCloseOnExec

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -197,7 +197,9 @@ runTLS tset set app = withSocketsDo $
     bracket
         (bindPortTCP (getPort set) (getHost set))
         close
-        (\sock -> runTLSSocket tset set sock app)
+        (\sock -> do
+            setSocketCloseOnExec sock
+            runTLSSocket tset set sock app)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Fixes: #922 

- [ ] Bumped the version number
- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)