### PR TITLE
Mime type to extension

### DIFF
--- a/mime-types/Network/Mime.hs
+++ b/mime-types/Network/Mime.hs
@@ -6,6 +6,7 @@ module Network.Mime
       -- * Defaults
     , defaultMimeType
     , defaultMimeMap
+    , defaultExtensionMap
       -- * Utilities
     , fileNameExtensions
       -- * Types
@@ -17,12 +18,17 @@ module Network.Mime
 
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.ByteString (ByteString)
+import Data.ByteString (ByteString, sort)
 import Data.ByteString.Char8 ()
 import qualified Data.Map as Map
+import Data.Function (on)
+import Data.List (groupBy)
 
 -- | Maps extensions to mime types.
 type MimeMap = Map.Map Extension MimeType
+-- | Maps mime types to extensions.
+-- @since 0.1.2.0
+type ExtensionMap = Map.Map MimeType [Extension]
 
 -- | The filename component of a filepath, leaving off the directory but
 -- keeping all extensions.
@@ -75,7 +81,17 @@ defaultMimeType = "application/octet-stream"
 --
 -- Generated from the Apache and nginx mime.types files.
 defaultMimeMap :: MimeMap
-defaultMimeMap = Map.fromAscList [
+defaultMimeMap = Map.fromAscList mimeAscList
+
+-- | A default mapping from mime type to filename extensions.
+-- Note there can be multiple extensions for a given mime type.
+-- Generated from the Apache and nginx mime.types files.
+-- @since 0.1.2.0
+defaultExtensionMap :: ExtensionMap
+defaultExtensionMap = Map.fromAscList $ map (\xs -> (fst $ head xs, map snd xs)) $ groupBy ((==) `on` fst) . sort . map swap $ mimeAscList
+
+mimeAscList :: [(Extension, MimeType)]
+mimeAscList = [
       ("123", "application/vnd.lotus-1-2-3")
     , ("3dml", "text/vnd.in3d.3dml")
     , ("3ds", "image/x-3ds")

--- a/mime-types/mime-types.cabal
+++ b/mime-types/mime-types.cabal
@@ -1,5 +1,5 @@
 name:                mime-types
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Basic mime-type handling types and functions
 description:         API docs and the README are available at <http://www.stackage.org/package/mime-types>.
 homepage:            https://github.com/yesodweb/wai


### PR DESCRIPTION

Hi this supports this issue: https://github.com/yesodweb/wai/issues/738
Which is also something I wanted. Let me know what you all think of this approach.
I didn't attempt any ordering or tried to choose a canonical extension as the linked issue suggestion.

**Examples**
```haskell
λ> Map.lookup ("application/json" :: ByteString) defaultExtensionMap 
Just ["json"]
it :: Maybe [Extension]
λ> Map.lookup ("application/vnd.clonk.c4group" :: ByteString) defaultExtensionMap 
Just ["c4u","c4p","c4g","c4f","c4d"]
it :: Maybe [Extension]
```


-----
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
