### PR TITLE
using crypton

### DIFF
--- a/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Embedded/Runtime.hs
@@ -16,7 +16,7 @@ import Data.Function (on)
 import qualified Data.Text as T
 import Data.Ord
 import qualified Data.ByteString as S
-#ifdef MIN_VERSION_cryptonite
+#ifdef MIN_VERSION_crypton
 import Crypto.Hash (hash, MD5, Digest)
 import Data.ByteArray.Encoding
 #else
@@ -100,7 +100,7 @@ bsToFile name bs = File
     }
 
 runHash :: ByteString -> ByteString
-#ifdef MIN_VERSION_cryptonite
+#ifdef MIN_VERSION_crypton
 runHash = convertToBase Base64 . (hash :: S.ByteString -> Digest MD5)
 #else
 runHash = encode . hash

--- a/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
+++ b/wai-app-static/WaiAppStatic/Storage/Filesystem.hs
@@ -26,7 +26,7 @@ import WaiAppStatic.Listing
 import Network.Mime
 import System.PosixCompat.Files (fileSize, getFileStatus, modificationTime, isRegularFile)
 import Data.Maybe (catMaybes)
-#ifdef MIN_VERSION_cryptonite
+#ifdef MIN_VERSION_crypton
 import Data.ByteArray.Encoding
 import Crypto.Hash (hashlazy, MD5, Digest)
 #else
@@ -128,7 +128,7 @@ webAppLookup hashFunc prefix pieces =
 hashFile :: FilePath -> IO ByteString
 hashFile fp = withBinaryFile fp ReadMode $ \h -> do
     f <- BL.hGetContents h
-#ifdef MIN_VERSION_cryptonite
+#ifdef MIN_VERSION_crypton
     let !hash = hashlazy f :: Digest MD5
     return $ convertToBase Base64 hash
 #else

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -24,8 +24,8 @@ Flag print
     Description:   print debug info
     Default:       False
 
-Flag cryptonite
-    Description:   Use the cryptonite library for MD5 computation
+Flag crypton
+    Description:   Use the crypton library for MD5 computation
     Default:       True
 
 library
@@ -53,8 +53,8 @@ library
                    , wai-extra                 >= 3.0      && < 3.2
                    , optparse-applicative      >= 0.7
                    , warp                      >= 3.0.11   && < 3.4
-    if flag(cryptonite)
-      build-depends: cryptonite                >= 0.6
+    if flag(crypton)
+      build-depends: crypton                   >= 0.6
                    , memory                    >= 0.7
     else
       build-depends: base64-bytestring         >= 0.1

--- a/warp-quic/warp-quic.cabal
+++ b/warp-quic/warp-quic.cabal
@@ -20,7 +20,7 @@ library
                      , bytestring
                      , http3
                      , quic
-                     , tls
+                     , tls >= 1.7
                      , wai
                      , warp >= 3.3.15
   if impl(ghc >= 8)

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -44,12 +44,6 @@ module Network.Wai.Handler.WarpTLS (
     , OnInsecure (..)
     -- * Exception
     , WarpTLSException (..)
-    -- * DH parameters (re-exports)
-    --
-    -- | This custom DH parameters are not necessary anymore because
-    --   pre-defined DH parameters are supported in the TLS package.
-    , DH.Params
-    , DH.generateParams
     ) where
 
 import Control.Applicative ((<|>))
@@ -75,7 +69,6 @@ import Network.Socket (
 import Network.Socket.BufferPool
 import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
-import qualified Crypto.PubKey.DH as DH
 import qualified Network.TLS.Extra as TLSExtra
 import qualified Network.TLS.SessionManager as SM
 import Network.Wai (Application)

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -8,7 +8,6 @@ module Network.Wai.Handler.WarpTLS.Internal (
     , getCertSettings
     ) where
 
-import qualified Crypto.PubKey.DH as DH
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.IORef as I
@@ -105,9 +104,9 @@ data TLSSettings = TLSSettings {
     -- Default: def
     --
     -- Since 3.0.2
-  , tlsServerDHEParams :: Maybe DH.Params
+  , tlsServerDHEParams :: Maybe TLS.DHParams
     -- ^ Configuration for ServerDHEParams
-    -- more function lives in `cryptonite` package
+    -- more function lives in `crypton` package
     --
     -- Default: Nothing
     --

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -23,8 +23,7 @@ Library
                    , wai                           >= 3.2      && < 3.3
                    , warp                          >= 3.3.23   && < 3.4
                    , data-default-class            >= 0.0.1
-                   , tls                           >= 1.5.3
-                   , cryptonite                    >= 0.12
+                   , tls                           >= 1.7
                    , network                       >= 2.2.1
                    , streaming-commons
                    , tls-session-manager           >= 0.0.4

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE PatternGuards #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
@@ -101,9 +100,7 @@ module Network.Wai.Handler.Warp (
   , pauseTimeout
   , FileInfo(..)
   , getFileInfo
-#ifdef MIN_VERSION_x509
   , clientCertificate
-#endif
   , withApplication
   , withApplicationSettings
   , testWithApplication
@@ -132,9 +129,7 @@ module Network.Wai.Handler.Warp (
 import UnliftIO.Exception (SomeException, throwIO)
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Vault.Lazy as Vault
-#ifdef MIN_VERSION_x509
 import Data.X509
-#endif
 import qualified Network.HTTP.Types as H
 import Network.Socket (Socket, SockAddr)
 import Network.Wai (Request, Response, vault)
@@ -539,10 +534,8 @@ setGracefulCloseTimeout2 x y = y { settingsGracefulCloseTimeout2 = x }
 getGracefulCloseTimeout2 :: Settings -> Int
 getGracefulCloseTimeout2 = settingsGracefulCloseTimeout2
 
-#ifdef MIN_VERSION_x509
 -- | Getting information of client certificate.
 --
 -- Since 3.3.5
 clientCertificate :: Request -> Maybe CertificateChain
 clientCertificate = join . Vault.lookup getClientCertificateKey . vault
-#endif

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE BangPatterns #-}
 
 module Network.Wai.Handler.Warp.HTTP2.Request (
@@ -24,9 +23,7 @@ import qualified System.TimeManager as T
 import Network.Wai.Handler.Warp.HTTP2.Types
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Request (getFileInfoKey, pauseTimeoutKey)
-#ifdef MIN_VERSION_x509
 import Network.Wai.Handler.Warp.Request (getClientCertificateKey)
-#endif
 import qualified Network.Wai.Handler.Warp.Settings as S (Settings, settingsNoParsePath)
 import Network.Wai.Handler.Warp.Types
 
@@ -90,9 +87,7 @@ toRequest' ii settings addr ref (reqths,reqvt) bodylen body th transport = retur
                 $ Vault.insert setHTTP2DataKey (writeIORef ref)
                 $ Vault.insert modifyHTTP2DataKey (modifyIORef' ref)
                 $ Vault.insert pauseTimeoutKey (T.pause th)
-#ifdef MIN_VERSION_x509
                 $ Vault.insert getClientCertificateKey (getTransportClientCertificate transport)
-#endif
                   Vault.empty
 
 getHTTP2DataKey :: Vault.Key (IO (Maybe HTTP2Data))

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
@@ -9,9 +8,7 @@ module Network.Wai.Handler.Warp.Request (
   , headerLines
   , pauseTimeoutKey
   , getFileInfoKey
-#ifdef MIN_VERSION_x509
   , getClientCertificateKey
-#endif
   , NoKeepAliveRequest (..)
   ) where
 
@@ -24,9 +21,7 @@ import qualified Data.CaseInsensitive as CI
 import qualified Data.IORef as I
 import Data.Typeable (Typeable)
 import qualified Data.Vault.Lazy as Vault
-#ifdef MIN_VERSION_x509
 import Data.X509
-#endif
 import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr)
 import Network.Wai
@@ -76,9 +71,7 @@ recvRequest firstRequest settings conn ii th addr src transport = do
         rawPath = if settingsNoParsePath settings then unparsedPath else path
         vaultValue = Vault.insert pauseTimeoutKey (Timeout.pause th)
                    $ Vault.insert getFileInfoKey (getFileInfo ii)
-#ifdef MIN_VERSION_x509
                    $ Vault.insert getClientCertificateKey (getTransportClientCertificate transport)
-#endif
                      Vault.empty
     (rbody, remainingRef, bodyLength) <- bodyAndSource src cl te
     -- body producing function which will produce '100-continue', if needed
@@ -323,8 +316,6 @@ getFileInfoKey :: Vault.Key (FilePath -> IO FileInfo)
 getFileInfoKey = unsafePerformIO Vault.newKey
 {-# NOINLINE getFileInfoKey #-}
 
-#ifdef MIN_VERSION_x509
 getClientCertificateKey :: Vault.Key (Maybe CertificateChain)
 getClientCertificateKey = unsafePerformIO Vault.newKey
 {-# NOINLINE getClientCertificateKey #-}
-#endif

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module Network.Wai.Handler.Warp.Types where
 
@@ -8,9 +7,7 @@ import qualified UnliftIO
 import qualified Data.ByteString as S
 import Data.IORef (IORef, readIORef, writeIORef, newIORef)
 import Data.Typeable (Typeable)
-#ifdef MIN_VERSION_x509
 import Data.X509
-#endif
 import Network.Socket.BufferPool
 import System.Posix.Types (Fd)
 import qualified System.TimeManager as T
@@ -180,16 +177,12 @@ data Transport = TCP -- ^ Plain channel: TCP
                  , tlsMinorVersion :: Int
                  , tlsNegotiatedProtocol :: Maybe ByteString -- ^ The result of Application Layer Protocol Negociation in RFC 7301
                  , tlsChiperID :: Word16
-#ifdef MIN_VERSION_x509
                  , tlsClientCertificate :: Maybe CertificateChain
-#endif
                  }  -- ^ Encrypted channel: TLS or SSL
                | QUIC {
                    quicNegotiatedProtocol :: Maybe ByteString
                  , quicChiperID :: Word16
-#ifdef MIN_VERSION_x509
                  , quicClientCertificate :: Maybe CertificateChain
-#endif
                  }
 
 isTransportSecure :: Transport -> Bool
@@ -200,9 +193,7 @@ isTransportQUIC :: Transport -> Bool
 isTransportQUIC QUIC{} = True
 isTransportQUIC _      = False
 
-#ifdef MIN_VERSION_x509
 getTransportClientCertificate :: Transport -> Maybe CertificateChain
 getTransportClientCertificate TCP              = Nothing
 getTransportClientCertificate (TLS _ _ _ _ cc) = cc
 getTransportClientCertificate (QUIC _ _ cc)    = cc
-#endif

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -61,7 +61,7 @@ Library
                    , word8
                    , unliftio
   if flag(x509)
-      Build-Depends: x509
+      Build-Depends: crypton-x509
   if impl(ghc < 8)
       Build-Depends: semigroups
   if flag(network-bytestring)
@@ -216,7 +216,7 @@ Test-Suite spec
                    , word8
                    , unliftio
   if flag(x509)
-      Build-Depends: x509
+      Build-Depends: crypton-x509
   if impl(ghc < 8)
       Build-Depends: semigroups
                    , transformers
@@ -259,7 +259,7 @@ Benchmark parser
                   , time-manager
                   , unliftio
   if flag(x509)
-      Build-Depends: x509
+      Build-Depends: crypton-x509
   if impl(ghc < 8)
       Build-Depends: semigroups
 


### PR DESCRIPTION
While `cryptonite` has a obvious bug, it has not been fixed for a long time.
This is because the author is now inactive in the Haskell community.
In private communication with him, I was not given the upload permission of `cryptonite` to Hackage.
He suggested me to fork `cryponite` and upload it as a different package.

So, I created `crypton` and uploaded it to Hackage with the bug fixed.
Also, I created new forks for `x509`-related packages and `connection` whose prefix is `crypton-`.
There are already uploaded to Hackage.
`http2` and other network packages with the new dependency are on Hackage, too.

This PR makes wai-related packages to depend on `crypton`.