### PR TITLE
wai-app-static: add NoStore to MaxAge

### DIFF
--- a/wai-app-static/ChangeLog.md
+++ b/wai-app-static/ChangeLog.md
@@ -1,5 +1,9 @@
 # wai-app-static changelog
 
+## 3.1.7.6
+
+* Added `NoStore` constructor to `MaxAge` [#938](https://github.com/yesodweb/wai/pull/938)
+
 ## 3.1.7.5
 
 * Removed dependency of `time`, `old-locale` and `network` [#902](https://github.com/yesodweb/wai/pull/902)

--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -67,6 +67,7 @@ type Pieces = [Piece]
 data MaxAge = NoMaxAge -- ^ no cache-control set
             | MaxAgeSeconds Int -- ^ set to the given number of seconds
             | MaxAgeForever -- ^ essentially infinite caching; in reality, probably one year
+            | NoStore -- ^ set cache-control to no-store @since 3.1.7.6
 
 -- | Just the name of a folder.
 type FolderName = Piece


### PR DESCRIPTION
This PR adds `NoStore` constructor to `MaxAge` that sets`Cache-Control: no-store`

----

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->