### PR TITLE
warp: changed check in 'waitForZero' to never loop indefinitely and arguably be more readable.

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Counter.hs
+++ b/warp/Network/Wai/Handler/Warp/Counter.hs
@@ -21,7 +21,7 @@ newCounter = Counter <$> newTVarIO 0
 waitForZero :: Counter -> IO ()
 waitForZero (Counter ref) = atomically $ do
     x <- readTVar ref
-    unless (x == 0) retry
+    when (x > 0) retry
 
 increase :: Counter -> IO ()
 increase (Counter ref) = atomically $ modifyTVar' ref $ \x -> x + 1


### PR DESCRIPTION
Doesn't need a version bump or anything.

Based on #893 