### PR TITLE
Dropped testing GHC < 8.10.7, made builds work on subsequent LTS-es

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         args:
         - "--resolver nightly --stack-yaml stack-nightly.yaml"
+        - "--resolver lts-21"
+        - "--resolver lts-20 --stack-yaml stack-lts-20.yaml"
         - "--resolver lts-19"
         - "--resolver lts-18"
-        - "--resolver lts-17 --stack-yaml stack-lts-17.yaml"
-        - "--resolver lts-16 --stack-yaml stack-lts-17.yaml"
 
     steps:
       - name: Clone project

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-09-09
+resolver: lts-20.26
 packages:
 - ./recv
 - ./auto-update
@@ -21,3 +21,11 @@ nix:
   packages:
   - fcgi
   - zlib
+extra-deps:
+  - crypton-0.33
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9
+  - crypton-x509-validation-1.6.12
+  - tls-1.8.0
+  - cgi-3001.5.0.1
+  - multipart-0.2.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.28
+resolver: lts-21.11
 packages:
 - ./recv
 - ./auto-update
@@ -21,4 +21,9 @@ nix:
   packages:
   - fcgi
   - zlib
-extra-deps: []
+extra-deps:
+  - crypton-0.33
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9
+  - crypton-x509-validation-1.6.12
+  - tls-1.8.0


### PR DESCRIPTION
Would like to see all green on CI results again.