### PR TITLE
warp-tls: fixed typo in ChangeLog

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -4,7 +4,7 @@
 
 * Install shutdown handlers passed via `Settings` to `run...` functions
 
-## 3.4.1
+## 3.4.2
 
 * Requiring warp v3.3.29.
 


### PR DESCRIPTION
Changelog entry for `3.4.2` was copy-pasted and then not changed, so here's the fix.

@kazu-yamamoto Can you publish `warp-tls-3.4.3` this after the merge? (since I've just merged in the `3.4.3` update before this fix)