### PR TITLE
warp: if we're building the outgoing buffer, why not count the bytes?

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -222,8 +222,8 @@ sendRsp conn _ th ver s hs _ maxRspBufSize (RspBuilder body needsChunked) = do
                                  <> chunkedTransferTerminator
          | otherwise    = header <> body
         writeBufferRef = connWriteBuffer conn
-    toBufIOWith maxRspBufSize writeBufferRef (\bs -> connSendAll conn bs >> T.tickle th) hdrBdy
-    return (Just s, Nothing) -- fixme: can we tell the actual sent bytes?
+    len <- toBufIOWith maxRspBufSize writeBufferRef (\bs -> connSendAll conn bs >> T.tickle th) hdrBdy
+    return (Just s, Just $ fromIntegral len)
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Would this justify a version bump? :thinking: 

... come to think of it, should the `bytesSent` type be in `Integer`, to be able to count more than 2GB on a 32 bit machine?