### PR TITLE
Add extension map to `mime-types`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal.sandbox.config
 *~
 stack*.yaml.lock
 dist-newstyle/
+.hie

--- a/mime-types/ChangeLog.md
+++ b/mime-types/ChangeLog.md
@@ -1,3 +1,9 @@
+## 0.1.2.0
+
+* Added `defaultExtensionMap` to provide the inverse of `defaultMimeMap`.
+
+See PR [#930](https://github.com/yesodweb/wai/pull/930) and [#948](https://github.com/yesodweb/wai/pull/948).
+
 ## 0.1.1.0
 
 * Replace `audio/x-mpegurl` with IANA registered type

--- a/mime-types/Network/Mime.hs
+++ b/mime-types/Network/Mime.hs
@@ -6,6 +6,7 @@ module Network.Mime
       -- * Defaults
     , defaultMimeType
     , defaultMimeMap
+    , defaultExtensionMap
       -- * Utilities
     , fileNameExtensions
       -- * Types
@@ -13,8 +14,10 @@ module Network.Mime
     , MimeType
     , MimeMap
     , Extension
+    , ExtensionMap
     ) where
 
+import qualified Data.List as L
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.ByteString (ByteString)
@@ -23,6 +26,12 @@ import qualified Data.Map as Map
 
 -- | Maps extensions to mime types.
 type MimeMap = Map.Map Extension MimeType
+
+-- | Maps mime types to extensions.
+-- The list of extensions is in alphabetical order.
+--
+-- @since 0.1.2.0
+type ExtensionMap = Map.Map MimeType [Extension]
 
 -- | The filename component of a filepath, leaving off the directory but
 -- keeping all extensions.
@@ -75,8 +84,21 @@ defaultMimeType = "application/octet-stream"
 --
 -- Generated from the Apache and nginx mime.types files.
 defaultMimeMap :: MimeMap
-defaultMimeMap = Map.fromAscList [
-      ("123", "application/vnd.lotus-1-2-3")
+defaultMimeMap = Map.fromAscList mimeAscList
+
+-- | A mapping of 'MimeType' to a set of 'Extension's.
+--
+-- @since 0.1.2.0
+defaultExtensionMap :: ExtensionMap
+defaultExtensionMap =
+    L.foldr go mempty mimeAscList
+  where
+    go (ext, mimeType) =
+        Map.alter (Just . maybe [ext] (ext :)) mimeType
+
+mimeAscList :: [(Extension, MimeType)]
+mimeAscList =
+    [ ("123", "application/vnd.lotus-1-2-3")
     , ("3dml", "text/vnd.in3d.3dml")
     , ("3ds", "image/x-3ds")
     , ("3g2", "video/3gpp2")

--- a/mime-types/mime-types.cabal
+++ b/mime-types/mime-types.cabal
@@ -1,5 +1,5 @@
 name:                mime-types
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Basic mime-type handling types and functions
 description:         API docs and the README are available at <http://www.stackage.org/package/mime-types>.
 homepage:            https://github.com/yesodweb/wai


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Wanted to adjust the #930 PR. So here's my own. Still crediting #930 in the ChangeLog.
Looks like a good addition.