### PR TITLE
wai: add getRequestBodyChunk to silence requestBody deprecation warning

### DIFF
--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for wai
 
+## 3.2.5
+
+* Add `setRequestBodyChunks` to mirror `getRequestBodyChunk` and avoid deprecation warnings when using `requestBody` as a setter. [#949](https://github.com/yesodweb/wai/pull/949)
+
 ## 3.2.4
 
 * Overhaul documentation of `Middleware`. [#858](https://github.com/yesodweb/wai/pull/858)

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -53,6 +53,7 @@ module Network.Wai
     , remoteHost
     , pathInfo
     , queryString
+    , setRequestBodyChunks
     , getRequestBodyChunk
     , requestBody
     , vault

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -98,6 +98,17 @@ data Request = Request {
 getRequestBodyChunk :: Request -> IO B.ByteString
 getRequestBodyChunk = requestBody
 
+-- | Set the 'requestBody' attribute on a request without triggering a
+-- deprecation warning.
+--
+-- The supplied IO action should return the next chunk of the body each time it
+-- is called and 'B.empty' when it has been fully consumed.
+--
+-- @since 3.2.5
+setRequestBodyChunks :: IO B.ByteString -> Request -> Request
+setRequestBodyChunks requestBody r =
+  r {requestBody = requestBody}
+
 instance Show Request where
     show Request{..} = "Request {" ++ intercalate ", " [a ++ " = " ++ b | (a,b) <- fields] ++ "}"
         where

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       >=1.10
 Name:                wai
-Version:             3.2.4
+Version:             3.2.5
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
                      .


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->