### PR TITLE
wai-extra: redact `Authorization` header when logging a request

### DIFF
--- a/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger/JSON.hs
@@ -148,6 +148,8 @@ requestHeadersToJSON :: RequestHeaders -> Value
 requestHeadersToJSON = toJSON . map hToJ where
   -- Redact cookies
   hToJ ("Cookie", _) = toJSON ("Cookie" :: Text, "-RDCT-" :: Text)
+  -- Redact authorization
+  hToJ ("Authorization", _) = toJSON ("Authorization" :: Text, "-RDCT-" :: Text)
   hToJ hd = headerToJSON hd
 
 responseHeadersToJSON :: [Header] -> Value


### PR DESCRIPTION
The `Authorization` request header normally contains sensitive data which we probably don't want to log.

This redacts it in a similar way to what is done for cookies. 

Happy to bump the version number if needed and add a changelog if the idea is approved.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)