### PR TITLE
wai: forgot to change `@since` declaration

### DIFF
--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -103,7 +103,7 @@ getRequestBodyChunk = requestBody
 -- The supplied IO action should return the next chunk of the body each time it
 -- is called and 'B.empty' when it has been fully consumed.
 --
--- @since 3.2.5
+-- @since 3.2.4
 setRequestBodyChunks :: IO B.ByteString -> Request -> Request
 setRequestBodyChunks requestBody r =
   r {requestBody = requestBody}


### PR DESCRIPTION
Was checking `wai` one last time before releasing `v3.2.4`.
Found this documentation error that was missed, so fixed it here.

Shall we release `wai-3.2.4` once this is merged?