### PR TITLE
tiny refactor: adjust placement of shared "I.writeIORef ref count'"

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Conduit.hs
+++ b/warp/Network/Wai/Handler/Warp/Conduit.hs
@@ -40,15 +40,16 @@ readISource (ISource src ref) = do
             toSend = min count (S.length bs)
             -- How many bytes will still remain to be sent downstream
             count' = count - toSend
+
+        I.writeIORef ref count'
+
         case () of
             ()
                 -- The expected count is greater than the size of the
                 -- chunk we just read. Send the entire chunk
                 -- downstream, and then loop on this function for the
                 -- next chunk.
-                | count' > 0 -> do
-                    I.writeIORef ref count'
-                    return bs
+                | count' > 0 -> return bs
 
                 -- Some of the bytes in this chunk should not be sent
                 -- downstream. Split up the chunk into the sent and
@@ -57,8 +58,7 @@ readISource (ISource src ref) = do
                 | otherwise -> do
                     let (x, y) = S.splitAt toSend bs
                     leftoverSource src y
-                    assert (count' == 0) $ I.writeIORef ref count'
-                    return x
+                    assert (count' == 0) $ return x
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Conduit.hs
+++ b/warp/Network/Wai/Handler/Warp/Conduit.hs
@@ -43,22 +43,20 @@ readISource (ISource src ref) = do
 
         I.writeIORef ref count'
 
-        case () of
-            ()
-                -- The expected count is greater than the size of the
-                -- chunk we just read. Send the entire chunk
-                -- downstream, and then loop on this function for the
-                -- next chunk.
-                | count' > 0 -> return bs
-
-                -- Some of the bytes in this chunk should not be sent
-                -- downstream. Split up the chunk into the sent and
-                -- not-sent parts, add the not-sent parts onto the new
-                -- source, and send the rest of the chunk downstream.
-                | otherwise -> do
-                    let (x, y) = S.splitAt toSend bs
-                    leftoverSource src y
-                    assert (count' == 0) $ return x
+        if count' > 0 then
+            -- The expected count is greater than the size of the
+            -- chunk we just read. Send the entire chunk
+            -- downstream, and then loop on this function for the
+            -- next chunk.
+            return bs
+          else do
+            -- Some of the bytes in this chunk should not be sent
+            -- downstream. Split up the chunk into the sent and
+            -- not-sent parts, add the not-sent parts onto the new
+            -- source, and send the rest of the chunk downstream.
+            let (x, y) = S.splitAt toSend bs
+            leftoverSource src y
+            assert (count' == 0) $ return x
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
This PR just moves the placement of a `writeIORef` that takes place in both branches of a conditional just below.