### PR TITLE
Send conn close

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.3.31
+Version:             3.3.32
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
I think this not a very good solution to #956, but at least it avoids nginx tripping over closed connections. I think it would be nice if warp doesn't actually close the connection, but I don't know why it was decided to close the connection, so I might be missing something. 

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)