### PR TITLE
Getting rid of warnings and hlint suggestions

### DIFF
--- a/recv/Network/Socket/BufferPool/Buffer.hs
+++ b/recv/Network/Socket/BufferPool/Buffer.hs
@@ -6,11 +6,12 @@ module Network.Socket.BufferPool.Buffer (
   ) where
 
 import qualified Data.ByteString as BS
-import Data.ByteString.Internal (ByteString(..), memcpy)
+import Data.ByteString.Internal (ByteString(..))
 import Data.ByteString.Unsafe (unsafeTake, unsafeDrop)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Foreign.ForeignPtr
 import Foreign.Marshal.Alloc (mallocBytes, finalizerFree)
+import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Ptr (castPtr, plusPtr)
 
 import Network.Socket.BufferPool.Types
@@ -59,6 +60,6 @@ mallocBS size = do
 --   This function returns the point where the next copy should start.
 copy :: Buffer -> ByteString -> IO Buffer
 copy ptr (PS fp o l) = withForeignPtr fp $ \p -> do
-    memcpy ptr (p `plusPtr` o) (fromIntegral l)
+    copyBytes ptr (p `plusPtr` o) (fromIntegral l)
     return $ ptr `plusPtr` l
 {-# INLINE copy #-}

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.14.0
+
+* `defaultGzipSettings` now exported to not depend on `Data.Default` [#959](https://github.com/yesodweb/wai/pull/959)
+
 ## 3.1.13.0
 
 * Added `Combine Headers` `Middleware` [#901](https://github.com/yesodweb/wai/pull/901)

--- a/wai-extra/Network/Wai/EventSource.hs
+++ b/wai-extra/Network/Wai/EventSource.hs
@@ -59,3 +59,4 @@ eventStreamAppRaw handler _ sendResponse =
             case eventToBuilder event of
                 Nothing -> return ()
                 Just b  -> sendChunk b
+{- HLint ignore eventStreamAppRaw "Use forM_" -}

--- a/wai-extra/Network/Wai/EventSource/EventStream.hs
+++ b/wai-extra/Network/Wai/EventSource/EventStream.hs
@@ -66,7 +66,7 @@ field l b = l `mappend` b `mappend` nl
 eventToBuilder :: ServerEvent -> Maybe Builder
 eventToBuilder (CommentEvent txt) = Just $ field commentField txt
 eventToBuilder (RetryEvent   n)   = Just $ field retryField (string8 . show $ n)
-eventToBuilder (CloseEvent)       = Nothing
+eventToBuilder CloseEvent         = Nothing
 eventToBuilder (ServerEvent n i d)= Just $
     name n (evid i $ mconcat (map (field dataField) d)) `mappend` nl
   where

--- a/wai-extra/Network/Wai/Handler/CGI.hs
+++ b/wai-extra/Network/Wai/Handler/CGI.hs
@@ -101,21 +101,21 @@ runGeneric vars inputH outputH xsendfile app = do
                 a:_ -> addrAddress a
                 [] -> error $ "Invalid REMOTE_ADDR or REMOTE_HOST: " ++ remoteHost'
         reqHeaders = map (cleanupVarName *** B.pack) vars
-        env = Request
-            { requestMethod = rmethod
-            , rawPathInfo = B.pack pinfo
-            , pathInfo = H.decodePathSegments $ B.pack pinfo
-            , rawQueryString = B.pack qstring
-            , queryString = H.parseQuery $ B.pack qstring
-            , requestHeaders = reqHeaders
-            , isSecure = isSecure'
-            , remoteHost = addr
-            , httpVersion = H.http11 -- FIXME
-            , requestBody = requestBody'
-            , vault = mempty
-            , requestBodyLength = KnownLength $ fromIntegral contentLength
-            , requestHeaderHost = lookup "host" reqHeaders
-            , requestHeaderRange = lookup hRange reqHeaders
+        env =
+            setRequestBodyChunks requestBody' $ defaultRequest
+                { requestMethod = rmethod
+                , rawPathInfo = B.pack pinfo
+                , pathInfo = H.decodePathSegments $ B.pack pinfo
+                , rawQueryString = B.pack qstring
+                , queryString = H.parseQuery $ B.pack qstring
+                , requestHeaders = reqHeaders
+                , isSecure = isSecure'
+                , remoteHost = addr
+                , httpVersion = H.http11 -- FIXME
+                , vault = mempty
+                , requestBodyLength = KnownLength $ fromIntegral contentLength
+                , requestHeaderHost = lookup "host" reqHeaders
+                , requestHeaderRange = lookup hRange reqHeaders
 #if MIN_VERSION_wai(3,2,0)
             , requestHeaderReferer = lookup "referer" reqHeaders
             , requestHeaderUserAgent = lookup "user-agent" reqHeaders

--- a/wai-extra/Network/Wai/Handler/CGI.hs
+++ b/wai-extra/Network/Wai/Handler/CGI.hs
@@ -89,8 +89,7 @@ runGeneric vars inputH outputH xsendfile app = do
         remoteHost' =
             case lookup "REMOTE_ADDR" vars of
                 Just x -> x
-                Nothing ->
-                    fromMaybe "" $ lookup "REMOTE_HOST" vars
+                Nothing -> lookup' "REMOTE_HOST" vars
         isSecure' =
             case map toLower $ lookup' "SERVER_PROTOCOL" vars of
                 "https" -> True

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -22,6 +22,7 @@ module Network.Wai.Middleware.Gzip
       -- ** The Settings
       -- $settings
     , GzipSettings
+    , defaultGzipSettings
     , gzipFiles
     , gzipCheckMime
     , gzipSizeThreshold
@@ -124,7 +125,7 @@ import Network.Wai.Util (splitCommas, trimWS)
 -- @
 -- myGzipSettings :: 'GzipSettings'
 -- myGzipSettings =
---   'def'
+--   'defaultGzipSettings'
 --     { 'gzipFiles' = 'GzipCompress'
 --     , 'gzipCheckMime' = myMimeCheckFunction
 --     , 'gzipSizeThreshold' = 860
@@ -197,7 +198,10 @@ data GzipFiles
 -- | Use default MIME settings; /do not/ compress files; skip
 -- compression on data smaller than 860 bytes.
 instance Default GzipSettings where
-    def = GzipSettings GzipIgnore defaultCheckMime minimumLength
+    def = defaultGzipSettings
+
+defaultGzipSettings :: GzipSettings
+defaultGzipSettings = GzipSettings GzipIgnore defaultCheckMime minimumLength
 
 -- | MIME types that will be compressed by default:
 -- @text/@ @*@, @application/json@, @application/javascript@,

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -200,6 +200,13 @@ data GzipFiles
 instance Default GzipSettings where
     def = defaultGzipSettings
 
+-- | Default settings for the 'gzip' middleware.
+--
+-- * Does not compress files.
+-- * Uses 'defaultCheckMime'.
+-- * Compession threshold set to 860 bytes.
+--
+-- @since 3.1.14.0
 defaultGzipSettings :: GzipSettings
 defaultGzipSettings = GzipSettings GzipIgnore defaultCheckMime minimumLength
 

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -42,6 +42,7 @@ import Data.ByteString.Builder (byteString)
 import qualified Data.ByteString.Builder.Extra as Blaze (flush)
 import qualified Data.ByteString.Char8 as S8
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Default.Class (Default (..))
 import Data.Function (fix)
 import Data.Maybe (isJust)
@@ -348,9 +349,7 @@ compressFile s hs file mETag cache sendResponse = do
     tmpfile = cache ++ '/' : map safe file ++ eTag
 
     safe c
-        | 'A' <= c && c <= 'Z' = c
-        | 'a' <= c && c <= 'z' = c
-        | '0' <= c && c <= '9' = c
+        | isAsciiUpper c || isAsciiLower c || isDigit c = c
     safe '-' = '-'
     safe '_' = '_'
     safe _ = '_'

--- a/wai-extra/Network/Wai/Middleware/HttpAuth.hs
+++ b/wai-extra/Network/Wai/Middleware/HttpAuth.hs
@@ -43,7 +43,7 @@ type CheckCreds = ByteString
 basicAuth :: CheckCreds
           -> AuthSettings
           -> Middleware
-basicAuth checkCreds = basicAuth' (\_ -> checkCreds)
+basicAuth = basicAuth' . const
 
 -- | Like 'basicAuth', but also passes a request to the authentication function.
 --
@@ -120,7 +120,7 @@ extractBasicAuth bs =
     extract encoded =
         let raw = decodeLenient encoded
             (username, password') = S.break (== _colon) raw
-        in ((username,) . snd) <$> S.uncons password'
+        in (username,) . snd <$> S.uncons password'
 
 -- | Extract bearer authentication data from __Authorization__ header
 -- value. Returns bearer token

--- a/wai-extra/Network/Wai/Middleware/MethodOverridePost.hs
+++ b/wai-extra/Network/Wai/Middleware/MethodOverridePost.hs
@@ -38,6 +38,8 @@ setPost req = do
   body <- (mconcat . toChunks) `fmap` lazyRequestBody req
   ref <- newIORef body
   let rb = atomicModifyIORef ref $ \bs -> (mempty, bs)
+      req' = setRequestBodyChunks rb req
   case parseQuery body of
-    (("_method", Just newmethod):_) -> return $ req {requestBody = rb, requestMethod = newmethod}
-    _                               -> return $ req {requestBody = rb}
+    (("_method", Just newmethod):_) -> return req' {requestMethod = newmethod}
+    _                               -> return req'
+{- HLint ignore setPost "Use tuple-section" -}

--- a/wai-extra/Network/Wai/Middleware/RealIp.hs
+++ b/wai-extra/Network/Wai/Middleware/RealIp.hs
@@ -48,7 +48,7 @@ realIpHeader header =
 --
 -- @since 3.1.5
 realIpTrusted :: HeaderName -> (IP.IP -> Bool) -> Middleware
-realIpTrusted header isTrusted app req respond = app req' respond
+realIpTrusted header isTrusted app req = app req'
   where
     req' = fromMaybe req $ do
              (ip, port) <- IP.fromSockAddr (remoteHost req)
@@ -90,5 +90,5 @@ findRealIp reqHeaders header isTrusted =
   where
     -- account for repeated headers
     headerVals = [ v | (k, v) <- reqHeaders, k == header ]
-    ips = mapMaybe (readMaybe . B8.unpack) $ concatMap (B8.split ',') headerVals
+    ips = concatMap (mapMaybe (readMaybe . B8.unpack) . B8.split ',') headerVals
     nonTrusted = filter (not . isTrusted) ips

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -402,6 +402,7 @@ getRequestBody req = do
              x:y -> (y, x)
   let req' = req { requestBody = rbody }
   return (req', body)
+{- HLint ignore getRequestBody "Use lambda-case" -}
 
 detailedMiddleware' :: Callback
                     -> DetailedSettings
@@ -502,6 +503,7 @@ detailedMiddleware' cb DetailedSettings{..} ansiColor ansiMethod ansiStatusCode 
         <> " "
         <> toLogStr (pack $ show $ diffUTCTime t1 t0)
         <> "\n"
+{- HLint ignore detailedMiddleware' "Use lambda-case" -}
 
 statusBS :: Response -> BS.ByteString
 statusBS = pack . show . statusCode . responseStatus

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -98,7 +98,7 @@ defaultApacheSettings :: ApacheSettings
 defaultApacheSettings = ApacheSettings
     { apacheIPAddrSource = FromSocket
     , apacheRequestFilter = \_ _ -> True
-    , apacheUserGetter = \_ -> Nothing
+    , apacheUserGetter = const Nothing
     }
 
 -- | Where to take IP addresses for clients from. See 'IPAddrSource' for more information.

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -50,7 +50,7 @@ import Network.Wai
   ( Request(..), requestBodyLength, RequestBodyLength(..)
   , Middleware
   , Response, responseStatus, responseHeaders
-  , getRequestBodyChunk
+  , getRequestBodyChunk, setRequestBodyChunks
   )
 import Network.Wai.Internal (Response (..))
 import Network.Wai.Logger
@@ -400,7 +400,7 @@ getRequestBody req = do
          case chunks of
              [] -> ([], S8.empty)
              x:y -> (y, x)
-  let req' = req { requestBody = rbody }
+  let req' = setRequestBodyChunks rbody req
   return (req', body)
 {- HLint ignore getRequestBody "Use lambda-case" -}
 

--- a/wai-extra/Network/Wai/Middleware/Routed.hs
+++ b/wai-extra/Network/Wai/Middleware/Routed.hs
@@ -35,5 +35,4 @@ hostedMiddleware domain middle app req
   | otherwise            = app req
 
 hasDomain :: ByteString -> Request -> Bool
-hasDomain domain req = maybe False (== domain) mHost
-  where mHost = requestHeaderHost req
+hasDomain domain req = Just domain == requestHeaderHost req

--- a/wai-extra/Network/Wai/Middleware/StreamFile.hs
+++ b/wai-extra/Network/Wai/Middleware/StreamFile.hs
@@ -32,6 +32,6 @@ streamFile app env sendResponse = app env $ \res ->
             sendBody :: StreamingBody -> IO ResponseReceived
             sendBody body = do
                len <- getFileSize fp
-               let hs' = (hContentLength, (S8.pack (show len))) : hs
+               let hs' = (hContentLength, S8.pack (show len)) : hs
                sendResponse $ responseStream s hs' body
       _ -> sendResponse res

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -378,7 +378,7 @@ parseRequestBodyEx :: ParseRequestBodyOptions
 parseRequestBodyEx o s r =
     case getRequestBodyType r of
         Nothing -> return ([], [])
-        Just rbt -> sinkRequestBodyEx o s rbt (requestBody r)
+        Just rbt -> sinkRequestBodyEx o s rbt (getRequestBodyChunk r)
 
 sinkRequestBody :: BackEnd y
                 -> RequestBodyType

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -58,6 +58,7 @@ import Control.Exception (catchJust)
 import qualified Control.Exception as E
 import Control.Monad (guard, unless, when)
 import Control.Monad.Trans.Resource (InternalState, allocate, register, release, runInternalState)
+import Data.Bifunctor (bimap)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L
@@ -400,7 +401,7 @@ sinkRequestBodyEx o s r body = do
                 Left y'  -> ((y':y, z), ())
                 Right z' -> ((y, z':z), ())
     conduitRequestBodyEx o s r body add
-    (\(a, b) -> (reverse a, reverse b)) <$> readIORef ref
+    bimap reverse reverse <$> readIORef ref
 
 conduitRequestBodyEx :: ParseRequestBodyOptions
                      -> BackEnd y

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -497,6 +497,7 @@ readSource (Source f ref) = do
     if S.null bs
         then f
         else return bs
+{- HLint ignore readSource "Use tuple-section" -}
 
 leftover :: Source -> S.ByteString -> IO ()
 leftover (Source _ ref) = writeIORef ref

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -138,7 +138,7 @@ setRawPathInfo r rawPinfo =
     let pInfo = dropFrontSlash $ T.split (== '/') $ TE.decodeUtf8 rawPinfo
     in  r { rawPathInfo = rawPinfo, pathInfo = pInfo }
   where
-    dropFrontSlash ("":"":[]) = [] -- homepage, a single slash
+    dropFrontSlash ["",""] = [] -- homepage, a single slash
     dropFrontSlash ("":path) = path
     dropFrontSlash path = path
 

--- a/wai-extra/Network/Wai/Test.hs
+++ b/wai-extra/Network/Wai/Test.hs
@@ -184,13 +184,12 @@ extractSetCookieFromSResponse response = do
 srequest :: SRequest -> Session SResponse
 srequest (SRequest req bod) = do
     refChunks <- liftIO $ newIORef $ L.toChunks bod
-    request $
-      req
-        { requestBody = atomicModifyIORef refChunks $ \bss ->
+    let rbody = atomicModifyIORef refChunks $ \bss ->
             case bss of
                 [] -> ([], S.empty)
                 x:y -> (y, x)
-        }
+    request $ setRequestBodyChunks rbody req
+{- HLint ignore srequest "Use lambda-case" -}
 
 runResponse :: IORef SResponse -> Response -> IO ResponseReceived
 runResponse ref res = do

--- a/wai-extra/Network/Wai/UrlMap.hs
+++ b/wai-extra/Network/Wai/UrlMap.hs
@@ -38,7 +38,7 @@ type Path = [Text]
 newtype UrlMap' a = UrlMap' { unUrlMap :: [(Path, a)] }
 
 instance Functor UrlMap' where
-    fmap f (UrlMap' xs) = UrlMap' (fmap (\(p, a) -> (p, f a)) xs)
+    fmap f (UrlMap' xs) = UrlMap' (fmap (fmap f) xs)
 
 instance Applicative UrlMap' where
     pure x                        = UrlMap' [([], x)]
@@ -61,7 +61,7 @@ mount' prefix thing = UrlMap' [(prefix, toApplication thing)]
 -- | A convenience function like mount', but for mounting things under a single
 -- path segment.
 mount :: ToApplication a => Text -> a -> UrlMap
-mount prefix thing = mount' [prefix] thing
+mount prefix = mount' [prefix]
 
 -- | Mount something at the root. Use this for the last application in the
 -- block, to avoid 500 errors from none of the applications matching.
@@ -72,7 +72,7 @@ try :: Eq a
     => [a] -- ^ Path info of request
     -> [([a], b)] -- ^ List of applications to match
     -> Maybe ([a], b)
-try xs tuples = foldl go Nothing tuples
+try xs = foldl go Nothing
     where
         go (Just x) _ = Just x
         go _ (prefix, y) = stripPrefix prefix xs >>= \xs' -> return (xs', y)

--- a/wai-extra/test/Network/Wai/Middleware/RequestSizeLimitSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/RequestSizeLimitSpec.hs
@@ -42,10 +42,10 @@ spec = describe "RequestSizeLimitMiddleware" $ do
       isStatus200 resp
 
   describe "streaming chunked bodies" $ do
-    let streamingReq = defaultRequest
+    let streamingReq =
+            setRequestBodyChunks (return "a") defaultRequest
                     { isSecure = False
                     , requestBodyLength = ChunkedBody
-                    , requestBody = return "a"
                     }
     it "413s if the combined chunk size is > the size limit" $ do
       resp <- runStreamingChunkApp 11 tenByteLimitSettings streamingReq

--- a/wai-extra/test/Network/Wai/TestSpec.hs
+++ b/wai-extra/test/Network/Wai/TestSpec.hs
@@ -84,9 +84,7 @@ spec = do
       let getBodyChunk = IORef.atomicModifyIORef bodyRef $ \leftover -> ("", leftover)
       sresp <- flip runSession echoApp $
         request $
-          defaultRequest
-            { requestBody = getBodyChunk
-            }
+          setRequestBodyChunks getBodyChunk defaultRequest
       simpleBody sresp `shouldBe` "request body"
 
     it "returns the response headers of an echo app" $ do

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -123,7 +123,7 @@ Library
                    , time                      >= 1.1.4
                    , transformers              >= 0.2.2
                    , vault
-                   , wai                       >= 3.2.2.1  && < 3.3
+                   , wai                       >= 3.2.4    && < 3.3
                    , wai-logger                >= 2.3.7
                    , warp                      >= 3.3.22
                    , word8

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.13.0
+Version:             3.1.14.0
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:

--- a/wai-frontend-monadcgi/wai-frontend-monadcgi.cabal
+++ b/wai-frontend-monadcgi/wai-frontend-monadcgi.cabal
@@ -8,7 +8,7 @@ synopsis:        Run CGI apps on WAI.
 description:     API docs and the README are available at <http://www.stackage.org/package/wai-frontend-monadcgi>.
 category:        Web
 stability:       stable
-cabal-version:   >= 1.6
+cabal-version:   >= 1.8
 build-type:      Simple
 extra-source-files: README.md ChangeLog.md
 

--- a/wai-http2-extra/test/doctests.hs
+++ b/wai-http2-extra/test/doctests.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP  #-}
+#if __GLASGOW_HASKELL__ < 900 || __GLASGOW_HASKELL__ >= 902
 import Test.DocTest
+#endif
 
 main :: IO ()
 main =

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -47,9 +47,22 @@ module Network.Wai.Handler.WarpTLS (
     ) where
 
 import Control.Applicative ((<|>))
-import UnliftIO.Exception (Exception, throwIO, bracket, finally, handleAny, try, IOException, onException, SomeException(..), handleJust)
-import qualified UnliftIO.Exception as E
 import Control.Monad (void, guard)
+import UnliftIO.Exception (
+    Exception,
+    IOException,
+    SomeException (..),
+    bracket,
+    finally,
+    fromException,
+    handle,
+    handleAny,
+    handleJust,
+    onException,
+    throwIO,
+    try,
+ )
+import qualified UnliftIO.Exception as E
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import Data.Default.Class (def)
@@ -77,7 +90,6 @@ import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
 import Network.Wai.Handler.WarpTLS.Internal(CertSettings(..), TLSSettings(..), OnInsecure(..))
 import System.IO.Error (ioeGetErrorType, isEOFError)
-import UnliftIO.Exception (handle, fromException)
 
 -- | The default 'CertSettings'.
 defaultCertSettings :: CertSettings

--- a/warp/test/FdCacheSpec.hs
+++ b/warp/test/FdCacheSpec.hs
@@ -6,7 +6,7 @@ import Test.Hspec
 #ifndef WINDOWS
 import Data.IORef
 import Network.Wai.Handler.Warp.FdCache
-import System.Posix.IO (fdRead)
+import System.Posix.IO.ByteString (fdRead)
 import System.Posix.Types (Fd(..))
 
 main :: IO ()

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -57,7 +57,7 @@ Library
                    , text
                    , time-manager
                    , vault                     >= 0.3
-                   , wai                       >= 3.2      && < 3.3
+                   , wai                       >= 3.2.4    && < 3.3
                    , word8
                    , unliftio
   if flag(x509)


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Wanted to get rid of warnings you get when building the packages in this repo, so I tried to do so. And refactored some small stuff.

Only real "change" is adding `defaultGzipSettings` to hopefully at some point be able to phase out the `data-default` dependency `wai-extra` still has.