### PR TITLE
Use `Data.Word8` when possible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         args:
         - "--resolver nightly --stack-yaml stack-nightly.yaml"
-        - "--resolver lts-21"
+        - "--resolver lts-22"
+        - "--resolver lts-21 --stack-yaml stack-lts-21.yaml"
         - "--resolver lts-20 --stack-yaml stack-lts-20.yaml"
         - "--resolver lts-19 --stack-yaml stack-lts-19.yaml"
         - "--resolver lts-18 --stack-yaml stack-lts-18.yaml"

--- a/stack-lts-21.yaml
+++ b/stack-lts-21.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.3
+resolver: lts-21.21
 packages:
 - ./auto-update
 - ./mime-types
@@ -23,9 +23,16 @@ nix:
   - fcgi
   - zlib
 extra-deps:
-  - crypto-token-0.1.0
+  - crypto-token-0.0.2
+  - crypton-0.34
+  - crypton-x509-1.7.6
+  - crypton-x509-store-1.6.9
+  - crypton-x509-system-1.6.7
+  - crypton-x509-validation-1.6.12
+  - http2-5.0.0
   - http3-0.0.7
+  - network-control-0.0.2
   - network-udp-0.0.0
-  - quic-0.1.14
+  - quic-0.1.12
   - sockaddr-0.0.1
   - tls-1.9.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,32 +1,26 @@
 resolver: nightly
 packages:
-- ./auto-update
-- ./mime-types
-- ./recv
-- ./time-manager
-- ./wai
-- ./wai-extra
-- ./wai-app-static
-- ./wai-frontend-monadcgi
-- ./wai-http2-extra
-- ./wai-websockets
-- ./wai-conduit
-- ./warp
-- ./warp-quic
-- ./warp-tls
+  - ./auto-update
+  - ./mime-types
+  - ./recv
+  - ./time-manager
+  - ./wai
+  - ./wai-app-static
+  - ./wai-conduit
+  - ./wai-extra
+  # Commented out packages until they are supported on nightly
+  # - ./wai-frontend-monadcgi
+  - ./wai-http2-extra
+  # - ./wai-websockets
+  - ./warp
+  # - ./warp-quic
+  - ./warp-tls
 flags:
   wai-extra:
     build-example: true
 nix:
   enable: false
   packages:
-  - fcgi
-  - zlib
-extra-deps:
-  - crypto-token-0.0.2
-  - crypton-0.34
-  - http3-0.0.7
-  - network-udp-0.0.0
-  - quic-0.1.12
-  - sockaddr-0.0.1
-  - tls-1.9.0
+    - fcgi
+    - zlib
+extra-deps: []

--- a/wai-extra/Network/Wai/EventSource/EventStream.hs
+++ b/wai-extra/Network/Wai/EventSource/EventStream.hs
@@ -13,6 +13,7 @@ import Data.ByteString.Builder
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid
 #endif
+import Data.Word8 (_colon, _lf)
 
 {-|
     Type representing a communication over an event stream.  This can be an
@@ -38,7 +39,7 @@ data ServerEvent
     Newline as a Builder.
 -}
 nl :: Builder
-nl = char7 '\n'
+nl = word8 _lf
 
 
 {-|
@@ -49,7 +50,7 @@ nameField = string7 "event:"
 idField = string7 "id:"
 dataField = string7 "data:"
 retryField = string7 "retry:"
-commentField = char7 ':'
+commentField = word8 _colon
 
 
 {-|

--- a/wai-extra/Network/Wai/Handler/CGI.hs
+++ b/wai-extra/Network/Wai/Handler/CGI.hs
@@ -14,7 +14,7 @@ import Data.Monoid (mconcat, mempty, mappend)
 #endif
 import Control.Arrow ((***))
 import Control.Monad (unless, void)
-import Data.ByteString.Builder (byteString, char7, string8, toLazyByteString)
+import Data.ByteString.Builder (byteString, string8, toLazyByteString, word8)
 import Data.ByteString.Builder.Extra (flush)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as L
@@ -26,6 +26,7 @@ import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 import qualified Data.Streaming.ByteString.Builder as Builder
 import qualified Data.String as String
+import Data.Word8 (_lf, _space)
 import Network.HTTP.Types (Status (..), hContentLength, hContentType, hRange)
 import qualified Network.HTTP.Types as H
 import Network.Socket (addrAddress, getAddrInfo)
@@ -137,7 +138,7 @@ runGeneric vars inputH outputH xsendfile app = do
                                 unless (B.null bs) $ do
                                     outputH bs
                                     loop
-                    sendBuilder $ headers s hs `mappend` char7 '\n'
+                    sendBuilder $ headers s hs `mappend` word8 _lf
                     b sendBuilder (sendBuilder flush)
                 blazeFinish >>= maybe (return ()) outputH
                 return ResponseReceived
@@ -145,7 +146,7 @@ runGeneric vars inputH outputH xsendfile app = do
     headers s hs = mconcat (map header $ status s : map header' (fixHeaders hs))
     status (Status i m) = (byteString "Status", mconcat
         [ string8 $ show i
-        , char7 ' '
+        , word8 _space
         , byteString m
         ])
     header' (x, y) = (byteString $ CI.original x, byteString y)
@@ -153,12 +154,12 @@ runGeneric vars inputH outputH xsendfile app = do
         [ x
         , byteString ": "
         , y
-        , char7 '\n'
+        , word8 _lf
         ]
     sfBuilder s hs sf fp = mconcat
         [ headers s hs
         , header (byteString sf, string8 fp)
-        , char7 '\n'
+        , word8 _lf
         , byteString sf
         , byteString " not supported"
         ]

--- a/wai-extra/Network/Wai/Header.hs
+++ b/wai-extra/Network/Wai/Header.hs
@@ -22,8 +22,8 @@ contentLength hdrs = lookup H.hContentLength hdrs >>= readInt
 readInt :: S8.ByteString -> Maybe Integer
 readInt bs =
     case S8.readInteger bs of
-        -- 'S8.all' is also 'True' for an empty string
-        Just (i, rest) | S8.all (== ' ') rest -> Just i
+        -- 'S.all' is also 'True' for an empty string
+        Just (i, rest) | S.all (== _space) rest -> Just i
         _ -> Nothing
 
 replaceHeader :: H.HeaderName -> S.ByteString -> [H.Header] -> [H.Header]

--- a/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
+++ b/wai-extra/test/Network/Wai/Middleware/StripHeadersSpec.hs
@@ -36,7 +36,7 @@ spec = describe "stripHeader" $ do
 
         simpleHeaders resp1 `shouldBe` ciTestHeaders
         simpleHeaders resp2 `shouldBe` ciTestHeaders
-        simpleHeaders resp3 `shouldBe` tail ciTestHeaders
+        simpleHeaders resp3 `shouldBe` drop 1 ciTestHeaders
 
     it "strips specific set of headers" $ do
         resp1 <- runApp host (addHeaders testHeaders) defaultRequest

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.IORef as I
 import qualified Data.Text as TS
 import qualified Data.Text.Encoding as TE
+import Data.Word8 (_e)
 import Network.Wai (Request (requestHeaders), defaultRequest, setRequestBodyChunks)
 import Network.Wai.Handler.Warp (InvalidRequest(..))
 import System.IO (IOMode (ReadMode), withFile)
@@ -190,7 +191,7 @@ caseParseRequestBody = do
       <> "Photo blog using Hack.\r\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh\r\n"
       <> "Content-Disposition: form-data; name=\"bla\"; filename=\"riedmi"
-      <> S8.replicate 8190 'e' <> "\"\r\n"
+      <> S.replicate 8190 _e <> "\"\r\n"
       <> "Content-Type: application/octet-stream\r\n\r\n"
       <> "Photo blog using Hack.\r\n\r\n"
       <> "------WebKitFormBoundaryB1pWXPZ6lNr8RiLh--\r\n"

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -229,6 +229,7 @@ test-suite spec
                    , wai-extra
                    , wai
                    , warp
+                   , word8
                    , zlib
     ghc-options:     -Wall
     default-language:          Haskell2010

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -15,6 +15,7 @@ import UnliftIO (SomeException, fromException, throwIO)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Word8 (_cr, _space)
 import Network.Socket (SockAddr(SockAddrInet, SockAddrInet6))
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
@@ -58,8 +59,8 @@ http1 settings ii conn transport app origAddr th bs0 = do
                             return origAddr
 
     parseProxyProtocolHeader src seg = do
-        let (header,seg') = BS.break (== 0x0d) seg -- 0x0d == CR
-            maybeAddr = case BS.split 0x20 header of -- 0x20 == space
+        let (header,seg') = BS.break (== _cr) seg
+            maybeAddr = case BS.split _space header of
                 ["PROXY","TCP4",clientAddr,_,clientPort,_] ->
                     case [x | (x, t) <- reads (decodeAscii clientAddr), null t] of
                         [a] -> Just (SockAddrInet (readInt clientPort)

--- a/warp/Network/Wai/Handler/Warp/PackInt.hs
+++ b/warp/Network/Wai/Handler/Warp/PackInt.hs
@@ -3,6 +3,7 @@
 module Network.Wai.Handler.Warp.PackInt where
 
 import Data.ByteString.Internal (unsafeCreate)
+import Data.Word8 (_0)
 import Foreign.Ptr (Ptr, plusPtr)
 import Foreign.Storable (poke)
 import qualified Network.HTTP.Types as H
@@ -29,7 +30,7 @@ packIntegral n = unsafeCreate len go0
     go :: Integral a => a -> Ptr Word8 -> IO ()
     go i p = do
         let (d,r) = i `divMod` 10
-        poke p (48 + fromIntegral r)
+        poke p (_0 + fromIntegral r)
         when (d /= 0) $ go d (p `plusPtr` (-1))
 
 {-# SPECIALIZE packIntegral :: Int -> ByteString #-}
@@ -49,7 +50,7 @@ packStatus status = unsafeCreate 3 $ \p -> do
     poke (p `plusPtr` 2) (toW8 r0)
   where
     toW8 :: Int -> Word8
-    toW8 n = 48 + fromIntegral n
+    toW8 n = _0 + fromIntegral n
     !s = fromIntegral $ H.statusCode status
     (!q0,!r0) = s `divMod` 10
     (!q1,!r1) = q0 `divMod` 10

--- a/warp/Network/Wai/Handler/Warp/ReadInt.hs
+++ b/warp/Network/Wai/Handler/Warp/ReadInt.hs
@@ -10,6 +10,7 @@ module Network.Wai.Handler.Warp.ReadInt (
   ) where
 
 import qualified Data.ByteString as S
+import Data.Word8 (isDigit, _0)
 
 import Network.Wai.Handler.Warp.Imports hiding (readInt)
 
@@ -27,8 +28,5 @@ readInt bs = fromIntegral $ readInt64 bs
 
 {-# NOINLINE readInt64 #-}
 readInt64 :: ByteString -> Int64
-readInt64 bs = S.foldl' (\ !i !c -> i * 10 + fromIntegral (c - 48)) 0
+readInt64 bs = S.foldl' (\ !i !c -> i * 10 + fromIntegral (c - _0)) 0
              $ S.takeWhile isDigit bs
-
-isDigit :: Word8 -> Bool
-isDigit w = w >= 48 && w <= 57

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -26,7 +26,7 @@ import Data.Function (on)
 import Data.List (deleteBy)
 import Data.Streaming.ByteString.Builder (newByteStringBuilderRecv, reuseBufferStrategy)
 import Data.Version (showVersion)
-import Data.Word8 (_cr, _lf)
+import Data.Word8 (_cr, _lf, _space, _tab)
 import qualified Network.HTTP.Types as H
 import qualified Network.HTTP.Types.Header as H
 import Network.Wai
@@ -179,11 +179,11 @@ sanitizeHeaderValue v = case C8.lines $ S.filter (/= _cr) v of
     []     -> ""
     x : xs -> C8.intercalate "\r\n" (x : mapMaybe addSpaceIfMissing xs)
   where
-    addSpaceIfMissing line = case C8.uncons line of
-        Nothing                           -> Nothing
+    addSpaceIfMissing line = case S.uncons line of
+        Nothing -> Nothing
         Just (first, _)
-          | first == ' ' || first == '\t' -> Just line
-          | otherwise                     -> Just $ " " <> line
+          | first == _space || first == _tab -> Just line
+          | otherwise -> Just $ _space `S.cons` line
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -6,6 +6,7 @@ module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
 import qualified Data.CaseInsensitive as CI
+import Data.Word8
 import Data.List (foldl')
 import Foreign.Ptr
 import GHC.Storable
@@ -36,10 +37,10 @@ httpVer10 = "HTTP/1.0 "
 copyStatus :: Ptr Word8 -> H.HttpVersion -> H.Status -> IO (Ptr Word8)
 copyStatus !ptr !httpversion !status = do
     ptr1 <- copy ptr httpVer
-    writeWord8OffPtr ptr1 0 (zero + fromIntegral r2)
-    writeWord8OffPtr ptr1 1 (zero + fromIntegral r1)
-    writeWord8OffPtr ptr1 2 (zero + fromIntegral r0)
-    writeWord8OffPtr ptr1 3 spc
+    writeWord8OffPtr ptr1 0 (_0 + fromIntegral r2)
+    writeWord8OffPtr ptr1 1 (_0 + fromIntegral r1)
+    writeWord8OffPtr ptr1 2 (_0 + fromIntegral r0)
+    writeWord8OffPtr ptr1 3 _space
     ptr2 <- copy (ptr1 `plusPtr` 4) (H.statusMessage status)
     copyCRLF ptr2
   where
@@ -61,25 +62,14 @@ copyHeaders !ptr (h:hs) = do
 copyHeader :: Ptr Word8 -> H.Header -> IO (Ptr Word8)
 copyHeader !ptr (k,v) = do
     ptr1 <- copy ptr (CI.original k)
-    writeWord8OffPtr ptr1 0 colon
-    writeWord8OffPtr ptr1 1 spc
+    writeWord8OffPtr ptr1 0 _colon
+    writeWord8OffPtr ptr1 1 _space
     ptr2 <- copy (ptr1 `plusPtr` 2) v
     copyCRLF ptr2
 
 {-# INLINE copyCRLF #-}
 copyCRLF :: Ptr Word8 -> IO (Ptr Word8)
 copyCRLF !ptr = do
-    writeWord8OffPtr ptr 0 cr
-    writeWord8OffPtr ptr 1 lf
+    writeWord8OffPtr ptr 0 _cr
+    writeWord8OffPtr ptr 1 _lf
     return $! ptr `plusPtr` 2
-
-zero :: Word8
-zero = 48
-spc :: Word8
-spc = 32
-colon :: Word8
-colon = 58
-cr :: Word8
-cr = 13
-lf :: Word8
-lf = 10

--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -6,8 +6,8 @@ module Main where
 
 import Control.Monad
 import qualified Data.ByteString as S
---import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as B (unpack)
+import Data.Word8 (_H, _P, _T, _slash, _period)
 import qualified Network.HTTP.Types as H
 import Network.Wai.Handler.Warp.Types
 import Prelude hiding (lines)
@@ -138,12 +138,12 @@ parseRequestLine2 requestLine@(PS fptr off len) = withForeignPtr fptr $ \ptr -> 
         w0 <- peek $ p `plusPtr` n
         when (w0 /= w) $ throwIO NonHttp
     checkHTTP httpptr = do
-        check httpptr 0 72 -- 'H'
-        check httpptr 1 84 -- 'T'
-        check httpptr 2 84 -- 'T'
-        check httpptr 3 80 -- 'P'
-        check httpptr 4 47 -- '/'
-        check httpptr 6 46 -- '.'
+        check httpptr 0 _H
+        check httpptr 1 _T
+        check httpptr 2 _T
+        check httpptr 3 _P
+        check httpptr 4 _slash
+        check httpptr 6 _period
     httpVersion httpptr = do
         major <- peek $ httpptr `plusPtr` 5
         minor <- peek $ httpptr `plusPtr` 7

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -258,6 +258,7 @@ Benchmark parser
                   , recv
                   , time-manager
                   , unliftio
+                  , word8
   if flag(x509)
       Build-Depends: crypton-x509
   if impl(ghc < 8)


### PR DESCRIPTION
Wanted to get rid of literal numbers when we can use values from `Data.Word8` and have it more obvious what's happening in the code. Also feels more robust to see `_colon` instead of `58` or `0x3A`.