### PR TITLE
prevent thunks from building when calculating size in 'toBufWith'

### DIFF
--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 module Network.Wai.Handler.Warp.IO where
 
 import Control.Exception (mask_)
@@ -19,7 +20,7 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
           size = bufSize writeBuffer
       (len, signal) <- writer buf size
       bufferIO buf len io
-      let totalBytesSent = toInteger len + bytesSent
+      let !totalBytesSent = toInteger len + bytesSent
       case signal of
         Done -> return totalBytesSent
         More minSize next


### PR DESCRIPTION
Small correction that I missed when making #946 