### PR TITLE
Multiline syntax bug

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -428,9 +428,9 @@ plainHTTP TLSSettings{..} set s bs0 = case onInsecure of
         -- FIXME: Content-Length:
         -- FIXME: TLS/<version>
         sendAll s "HTTP/1.1 426 Upgrade Required\
-        \r\nUpgrade: TLS/1.0, HTTP/1.1\
-        \r\nConnection: Upgrade\
-        \r\nContent-Type: text/plain\r\n\r\n"
+            \\r\nUpgrade: TLS/1.0, HTTP/1.1\
+            \\r\nConnection: Upgrade\
+            \\r\nContent-Type: text/plain\r\n\r\n"
         mapM_ (sendAll s) $ L.toChunks lbs
         close s
         throwIO InsecureConnectionDenied

--- a/warp/Network/Wai/Handler/Warp/HTTP2/PushPromise.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/PushPromise.hs
@@ -17,9 +17,7 @@ import Network.Wai.Handler.Warp.Types
 fromPushPromises :: InternalInfo -> Request -> IO [H2.PushPromise]
 fromPushPromises ii req = do
     mh2data <- getHTTP2Data req
-    let pp = case mh2data of
-          Nothing     -> []
-          Just h2data -> http2dataPushPromise h2data
+    let pp = maybe [] http2dataPushPromise mh2data
     catMaybes <$> mapM (fromPushPromise ii) pp
 
 fromPushPromise :: InternalInfo -> PushPromise -> IO (Maybe H2.PushPromise)


### PR DESCRIPTION
warp-tls: when making multiline strings, the first `\` on a new line doesn't escape the next character, it's the start of the next part of the string.

This will result in the following response (note the trailing `r`s)
```
HTTP/1.1 426 Upgrade Requiredr
Upgrade: TLS/1.0, HTTP/1.1r
Connection: Upgrader
Content-Type: text/plain

```

I'm not sure why this hasn't been a problem yet? Probably because it's the response when denying something, so if the response is off, it still indicates that it's a 426? :shrug: 