### PR TITLE
wai-app-static: add NoCache to MaxAge

### DIFF
--- a/wai-app-static/ChangeLog.md
+++ b/wai-app-static/ChangeLog.md
@@ -1,5 +1,9 @@
 # wai-app-static changelog
 
+## 3.1.9
+
+* Added `NoCache` constructor to `MaxAge` [#977](https://github.com/yesodweb/wai/pull/977)
+
 ## 3.1.8
 
 * Added `NoStore` constructor to `MaxAge` [#938](https://github.com/yesodweb/wai/pull/938)

--- a/wai-app-static/Network/Wai/Application/Static.hs
+++ b/wai-app-static/Network/Wai/Application/Static.hs
@@ -233,12 +233,14 @@ cacheControl maxage =
         MaxAgeSeconds i -> (:) ("Cache-Control", maxAgeValue i)
         MaxAgeForever -> (:) ("Cache-Control", maxAgeValue oneYear)
         NoStore -> (:) ("Cache-Control", "no-store")
+        NoCache -> (:) ("Cache-Control", "no-cache")
     headerExpires =
         case maxage of
             NoMaxAge -> id
             MaxAgeSeconds _ -> id -- FIXME
             MaxAgeForever -> (:) ("Expires", "Thu, 31 Dec 2037 23:55:55 GMT")
             NoStore -> id
+            NoCache -> id
 
 -- | Turn a @StaticSettings@ into a WAI application.
 staticApp :: StaticSettings -> W.Application

--- a/wai-app-static/WaiAppStatic/Types.hs
+++ b/wai-app-static/WaiAppStatic/Types.hs
@@ -76,6 +76,8 @@ data MaxAge
       MaxAgeForever
     | -- | set cache-control to no-store @since 3.1.8
       NoStore
+    | -- | set cache-control to no-cache @since 3.1.9
+      NoCache
 
 -- | Just the name of a folder.
 type FolderName = Piece

--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -1,5 +1,5 @@
 name:            wai-app-static
-version:         3.1.8
+version:         3.1.9
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control

At some point I wonder if `MaxAge` should be renamed.
