### PR TITLE
Eagerly remove `Handle`s from the manager

### DIFF
--- a/auto-update/ChangeLog.md
+++ b/auto-update/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for auto-update
 
+## 0.2.0
+
+* Add `reaperModify` to the `Reaper` API, allowing workload modification outside
+  of the main `reaperAction` loop.
+  [#985](https://github.com/yesodweb/wai/pull/985)
+
 ## 0.1.6
 
 * Add control of activation on leading vs. trailing edges for Control.Debounce

--- a/auto-update/Control/Reaper.hs
+++ b/auto-update/Control/Reaper.hs
@@ -109,6 +109,20 @@ data Reaper workload item = Reaper
     -- ^ Adding an item to the workload
     , reaperRead :: IO workload
     -- ^ Reading workload.
+    , reaperModify :: (workload -> workload) -> IO workload
+    -- ^ Modify the workload. The resulting workload is returned.
+    --
+    --   If there is no reaper thread, the modifier will not be applied and
+    --   'reaperEmpty' will be returned.
+    --
+    --   If the reaper is currently executing jobs, those jobs will not be in
+    --   the given workload and the workload might appear empty.
+    --
+    --   If all jobs are removed by the modifier, the reaper thread will not be
+    --   killed. The reaper thread will only terminate if 'reaperKill' is called
+    --   or the result of 'reaperAction' satisfies 'reaperNull'.
+    --
+    --  @since 0.2.0
     , reaperStop :: IO workload
     -- ^ Stopping the reaper thread if exists.
     --   The current workload is returned.
@@ -136,6 +150,7 @@ mkReaper settings@ReaperSettings{..} = do
         Reaper
             { reaperAdd = add settings stateRef tidRef
             , reaperRead = readRef stateRef
+            , reaperModify = modifyRef stateRef
             , reaperStop = stop stateRef
             , reaperKill = kill tidRef
             }
@@ -145,6 +160,13 @@ mkReaper settings@ReaperSettings{..} = do
         case mx of
             NoReaper -> return reaperEmpty
             Workload wl -> return wl
+    modifyRef stateRef modifier = atomicModifyIORef' stateRef $ \mx ->
+        case mx of
+            NoReaper ->
+              (NoReaper, reaperEmpty)
+            Workload wl ->
+              let !wl' = modifier wl
+               in (Workload wl', wl')
     stop stateRef = atomicModifyIORef' stateRef $ \mx ->
         case mx of
             NoReaper -> (NoReaper, reaperEmpty)

--- a/auto-update/auto-update.cabal
+++ b/auto-update/auto-update.cabal
@@ -1,5 +1,5 @@
 name:                auto-update
-version:             0.1.6
+version:             0.2.0
 synopsis:            Efficiently run periodic, on-demand actions
 description:         API docs and the README are available at <http://www.stackage.org/package/auto-update>.
 homepage:            https://github.com/yesodweb/wai

--- a/time-manager/ChangeLog.md
+++ b/time-manager/ChangeLog.md
@@ -1,0 +1,8 @@
+# ChangeLog for time-manager
+
+## 0.1.0
+
+* [#986](https://github.com/yesodweb/wai/pull/986)
+    * Change behavior of `cancel` to immediately remove the `Handle` from the
+    reaper's workload, rather than waiting for timeout.
+    * Using auto-update v0.2.0.

--- a/time-manager/time-manager.cabal
+++ b/time-manager/time-manager.cabal
@@ -1,5 +1,5 @@
 Name:                time-manager
-Version:             0.0.1
+Version:             0.1.0
 Synopsis:            Scalable timer
 License:             MIT
 License-file:        LICENSE
@@ -11,10 +11,11 @@ Build-Type:          Simple
 Cabal-Version:       >=1.10
 Stability:           Stable
 Description:         Scalable timer functions provided by a timer manager.
+Extra-Source-Files:  ChangeLog.md
 
 Library
   Build-Depends:     base                      >= 4.12       && < 5
-                   , auto-update
+                   , auto-update               >= 0.2        && < 0.3
                    , unliftio
   Default-Language:  Haskell2010
   Exposed-modules:   System.TimeManager

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for warp
 
+## 3.4.1
+
+* Using time-manager v0.1.0, and auto-update v0.2.0.
+  [#986](https://github.com/yesodweb/wai/pull/986)
+
 ## 3.4.0
 
 * Reworked request lines (`CRLF`) parsing: [#968](https://github.com/yesodweb/wai/pulls)

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -39,7 +39,7 @@ Flag x509
 Library
   Build-Depends:     base                      >= 4.12       && < 5
                    , array
-                   , auto-update               >= 0.1.3    && < 0.2
+                   , auto-update               >= 0.2      && < 0.3
                    , bsb-http-chunked                         < 0.1
                    , bytestring                >= 0.9.1.4
                    , case-insensitive          >= 0.2

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,5 +1,5 @@
 Name:                warp
-Version:             3.4.0
+Version:             3.4.1
 Synopsis:            A fast, light-weight web server for WAI applications.
 License:             MIT
 License-file:        LICENSE
@@ -55,7 +55,7 @@ Library
                    , stm                       >= 2.3
                    , streaming-commons         >= 0.1.10
                    , text
-                   , time-manager
+                   , time-manager              >= 0.1      && < 0.2
                    , vault                     >= 0.3
                    , wai                       >= 3.2.4    && < 3.3
                    , word8


### PR DESCRIPTION
This PR is based on #985. That should be merged first, then this can be rebased on `main` and merged.

Previously, if many streams were opened on a connection with a very long timeout, the handles would accumulate. This PR causes the handles to be removed from the manager immediately upon `cancel`, instead of relying on timeouts causing the reaper to remove them.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->