### PR TITLE
cabal.project: Remove allow-newer and SRP stanzas

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,53 +12,5 @@ packages:
     wai-conduit
     time-manager
 
--- These need hackage revisions but otherwise test fine in the repo
-allow-newer:
-      cryptohash-md5:base
-    , vault:base
-    , hashable:base
-    , hashable:bytestring
-    , hashable:ghc-bignum
-    , async:base
-    , integer-logarithms:base
-    , integer-logarithms:ghc-bignum
-    , integer-logarithms:ghc-prim
-    , scientific:base
-    , http-api-data:base
-    , split:base
-    , blaze-markup:base
-    , attoparsec:ghc-prim
-    , aeson:ghc-prim
-    , time-compat:base
-    , indexed-traversable-instances:base
-    , these:base
-    , assoc:base
-    , text-short:base
-    , text-short:ghc-prim
-    , semialign:base
-    , indexed-traversable:base
-    , data-fix:base
-    , splitmix:base
-    , OneTuple:base
-    , postgresql-simple:base
-    , bytestring-lexing:base
-    , HTTP:base
-    , quickcheck-instances:base
-    , postgresql-libpq:base
-    , hsc2hs:base
-    , cabal-doctest:base
-
--- https://github.com/haskell-foundation/foundation/pull/564
-source-repository-package
-    type: git
-    location: https://github.com/parsonsmatt/foundation
-    tag: 688c32ccd9a951bc96dd09423a6e6684f091d510
-    subdir: basement
-    subdir: foundation
-
--- https://github.com/vincenthz/hs-memory/pull/93
-source-repository-package
-    type: git
-    location: https://github.com/parsonsmatt/hs-memory
-    tag: 296b79424854eae293f6ba09b5308a0bf4dfd6d5
-
+tests: True
+test-show-details: direct


### PR DESCRIPTION
Also enable building of test code by default and improve test output.

Before these changes the code in Git would not even compile with `ghc-9.6` (using `cabal`). With these changes it builds and all test pass both with `ghc-9.6` and `ghc-9.10`.

I would have updated the tests, but I do not use `stack` and have zero knowledge of it.