### PR TITLE
data-default-class -> data-default

### DIFF
--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for wai-extra
 
+## 3.1.16
+
+* Substituted `data-default-class` for `data-default` [#1010](https://github.com/yesodweb/wai/pull/1010)
+
 ## 3.1.15
 
 * Added `validateHeadersMiddleware` for validating response headers set by the application [#990](https://github.com/yesodweb/wai/pull/990).

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -51,7 +51,7 @@ import qualified Data.ByteString.Builder.Extra as Blaze (flush)
 import qualified Data.ByteString.Char8 as S8
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
-import Data.Default.Class (Default (..))
+import Data.Default (Default (..))
 import Data.Function (fix)
 import Data.Maybe (isJust)
 import qualified Data.Set as Set

--- a/wai-extra/Network/Wai/Middleware/RequestLogger.hs
+++ b/wai-extra/Network/Wai/Middleware/RequestLogger.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteString.Builder as B (Builder, byteString)
 import Data.ByteString.Char8 (pack)
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as LBS
-import Data.Default.Class (Default (def))
+import Data.Default (Default (def))
 import Data.IORef
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 #if __GLASGOW_HASKELL__ < 804

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -1,5 +1,5 @@
 Name:                wai-extra
-Version:             3.1.15
+Version:             3.1.16
 Synopsis:            Provides some basic WAI handlers and middleware.
 description:
   Provides basic WAI handler and middleware functionality:
@@ -110,7 +110,7 @@ Library
                    , case-insensitive          >= 0.2
                    , containers
                    , cookie
-                   , data-default-class
+                   , data-default
                    , directory                 >= 1.2.7.0
                    , fast-logger               >= 2.4.5
                    , http-types                >= 0.7

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 3.4.8
+
+* Substituted `data-default-class` for `data-default` [#1010](https://github.com/yesodweb/wai/pull/1010)
+
 ## 3.4.7
 
 * Expose `attachConn` to use post-handshake TLS connection.

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -59,7 +59,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (guard, void)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Default.Class (def)
+import Data.Default (def)
 import qualified Data.IORef as I
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -12,7 +12,7 @@ module Network.Wai.Handler.WarpTLS.Internal (
 
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Default.Class (def)
+import Data.Default (def)
 import qualified Data.IORef as I
 import qualified Network.TLS as TLS
 import qualified Network.TLS.Extra as TLSExtra

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.4.7
+Version:             3.4.8
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE
@@ -22,7 +22,7 @@ Library
                    , bytestring                    >= 0.9
                    , wai                           >= 3.2      && < 3.3
                    , warp                          >= 3.3.29   && < 3.5
-                   , data-default-class            >= 0.0.1
+                   , data-default                  >= 0.8
                    , tls                           >= 1.7      && < 2.2
                    , network                       >= 2.2.1
                    , streaming-commons


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

See: haskell-grpc-native/http2-client#97
See: kazu-yamamoto/crypton-certificate#11
See: haskell-tls/hs-tls#486
See: commercialhaskell/stackage#7545

---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->