### PR TITLE
No using data-default

### DIFF
--- a/stack-lts-19.yaml
+++ b/stack-lts-19.yaml
@@ -12,7 +12,7 @@ packages:
 - ./wai-http2-extra
 - ./wai-websockets
 - ./warp
-# - ./warp-quic
+- ./warp-quic
 - ./warp-tls
 flags:
   wai-extra:
@@ -28,12 +28,18 @@ extra-deps:
   - crypton-1.0.1
   - crypton-x509-1.7.7
   - crypton-x509-store-1.6.9
+  - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
+  - fast-logger-3.2.5
   - http-semantics-0.2.1
   - http2-5.3.4
+  - http3-0.0.18
   - memory-0.18.0
+  - network-3.1.4.0
   - network-byte-order-0.1.7
   - network-control-0.1.3
+  - quic-0.2.4
+  - sockaddr-0.0.1
   - tls-2.1.3
   - tls-session-manager-0.0.7
   - unix-time-0.4.16

--- a/stack-lts-20.yaml
+++ b/stack-lts-20.yaml
@@ -12,7 +12,7 @@ packages:
 - ./wai-http2-extra
 - ./wai-websockets
 - ./warp
-# - ./warp-quic
+- ./warp-quic
 - ./warp-tls
 flags:
   wai-extra:
@@ -28,13 +28,18 @@ extra-deps:
   - crypton-1.0.1
   - crypton-x509-1.7.7
   - crypton-x509-store-1.6.9
+  - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
+  - fast-logger-3.2.5
   - http-semantics-0.2.1
   - http2-5.3.4
+  - http3-0.0.18
   - memory-0.18.0
   - multipart-0.2.1
   - network-byte-order-0.1.7
   - network-control-0.1.3
+  - quic-0.2.4
+  - sockaddr-0.0.1
   - tls-2.1.3
   - tls-session-manager-0.0.7
   - unix-time-0.4.16

--- a/stack-lts-21.yaml
+++ b/stack-lts-21.yaml
@@ -12,7 +12,7 @@ packages:
 - ./wai-http2-extra
 - ./wai-websockets
 - ./warp
-# - ./warp-quic
+- ./warp-quic
 - ./warp-tls
 flags:
   wai-extra:
@@ -27,9 +27,14 @@ extra-deps:
   - crypton-1.0.1
   - crypton-x509-1.7.7
   - crypton-x509-store-1.6.9
+  - crypton-x509-system-1.6.7
   - crypton-x509-validation-1.6.12
   - http-semantics-0.2.1
   - http2-5.3.4
+  - http3-0.0.18
   - network-control-0.1.3
+  - quic-0.2.4
+  - sockaddr-0.0.1
   - tls-2.1.3
   - tls-session-manager-0.0.7
+  - unix-time-0.4.16

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -31,4 +31,3 @@ extra-deps:
   - tls-2.1.3
   - tls-session-manager-0.0.7
   - sockaddr-0.0.1
-  - tls-2.1.3

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -23,8 +23,12 @@ nix:
     - fcgi
     - zlib
 extra-deps:
+  - crypto-token-0.1.2
+  - http-semantics-0.2.1
   - http3-0.0.18
   - network-udp-0.0.0
-  - quic-0.2.3
+  - quic-0.2.4
+  - tls-2.1.3
+  - tls-session-manager-0.0.7
   - sockaddr-0.0.1
   - tls-2.1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.39
+resolver: lts-22.40
 packages:
 - ./auto-update
 - ./mime-types
@@ -29,7 +29,7 @@ extra-deps:
   - http3-0.0.16
   - network-control-0.1.0
   - network-udp-0.0.0
-  - quic-0.2.3
+  - quic-0.2.4
   - sockaddr-0.0.1
   - tls-2.1.3
   - tls-session-manager-0.0.7

--- a/wai-app-static/WaiAppStatic/CmdLine.hs
+++ b/wai-app-static/WaiAppStatic/CmdLine.hs
@@ -132,7 +132,7 @@ runCommandLine middleware = do
             port
             (if noindex then "no" else show index)
     let middle =
-            gzip def{gzipFiles = GzipCompress}
+            gzip defaultGzipSettings{gzipFiles = GzipCompress}
                 . (if verbose then logStdout else id)
                 . middleware clArgs
     runSettings

--- a/wai-extra/ChangeLog.md
+++ b/wai-extra/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for wai-extra
 
+## 3.1.17
+
+* Started deprecation of `data-default` [#1011](https://github.com/yesodweb/wai/pull/1011)
+  * All `Default` instances have comments that these will be removed in a future major version.
+  * `def` exported from `Network.Wai.Middleware.Gzip` now has a deprecation warning
+  * All uses of `def` have been replaced with explicit `default{TYPE_NAME}` values.
+* Some additional documentation
+
 ## 3.1.16
 
 * Substituted `data-default-class` for `data-default` [#1010](https://github.com/yesodweb/wai/pull/1010)

--- a/wai-extra/Network/Wai/Middleware/Gzip.hs
+++ b/wai-extra/Network/Wai/Middleware/Gzip.hs
@@ -51,7 +51,7 @@ import qualified Data.ByteString.Builder.Extra as Blaze (flush)
 import qualified Data.ByteString.Char8 as S8
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
-import Data.Default (Default (..))
+import qualified Data.Default as Default (Default (..))
 import Data.Function (fix)
 import Data.Maybe (isJust)
 import qualified Data.Set as Set
@@ -119,12 +119,12 @@ import Network.Wai.Util (splitCommas, trimWS)
 
 -- $settings
 --
--- If you would like to use the default settings, using just 'def' is enough.
+-- If you would like to use the default settings, use 'defaultGzipSettings'.
 -- The default settings don't compress file responses, only builder and stream
 -- responses, and only if the response passes the MIME and length checks. (cf.
 -- 'defaultCheckMime' and 'gzipSizeThreshold')
 --
--- To customize your own settings, use the 'def' method and set the
+-- To customize your own settings, use 'defaultGzipSettings' and set the
 -- fields you would like to change as follows:
 --
 -- @
@@ -196,14 +196,22 @@ data GzipFiles
 
 -- $miscellaneous
 --
--- 'def' is re-exported for convenience sake, and 'defaultCheckMime'
--- is exported in case anyone wants to use it in defining their own
--- 'gzipCheckMime' function.
+-- 'defaultCheckMime' is exported in case anyone wants to use it in
+-- defining their own 'gzipCheckMime' function.
+-- 'def' has been re-exported for convenience sake, but its use is now
+-- heavily discouraged. Please use the explicit 'defaultGzipSettings'.
 
--- | Use default MIME settings; /do not/ compress files; skip
--- compression on data smaller than 860 bytes.
-instance Default GzipSettings where
+-- | DO NOT USE THIS INSTANCE!
+-- Please use 'defaultGzipSettings'.
+--
+-- This instance will be removed in a future major version.
+instance Default.Default GzipSettings where
     def = defaultGzipSettings
+
+-- | Deprecated synonym for the 'defaultGzipSettings'.
+def :: GzipSettings
+def = defaultGzipSettings
+{-# Deprecated def "Please use 'defaultGzipSettings'. 'def' and the Default instance will be removed in a future major update." #-}
 
 -- | Default settings for the 'gzip' middleware.
 --

--- a/wai-extra/example/Main.hs
+++ b/wai-extra/example/Main.hs
@@ -16,7 +16,7 @@ import Network.Wai.EventSource (
  )
 import Network.Wai.Handler.Warp (run)
 import Network.Wai.Middleware.AddHeaders (addHeaders)
-import Network.Wai.Middleware.Gzip (def, gzip)
+import Network.Wai.Middleware.Gzip (defaultGzipSettings, gzip)
 
 app :: Chan ServerEvent -> Application
 app chan req respond =
@@ -67,7 +67,7 @@ main :: IO ()
 main = do
     chan <- newChan
     _ <- forkIO . eventChan $ chan
-    run 8080 (gzip def $ headers $ app chan)
+    run 8080 (gzip defaultGzipSettings $ headers $ app chan)
   where
     -- headers required for SSE to work through nginx
     -- not required if using warp directly

--- a/wai-extra/test/Network/Wai/ParseSpec.hs
+++ b/wai-extra/test/Network/Wai/ParseSpec.hs
@@ -138,40 +138,40 @@ caseParseRequestBody = do
 
     it "exceeding number of files" $ do
         SRequest req4 _bod4 <- toRequest'' ctype3 content3
-        (parseRequestBodyEx (setMaxRequestNumFiles 0 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxRequestNumFiles 0 def) lbsBackEnd req4
             `shouldThrow` anyException
 
     it "exceeding parameter length" $ do
         SRequest req4 _bod4 <- toRequest'' ctype3 content3
-        (parseRequestBodyEx (setMaxRequestKeyLength 2 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxRequestKeyLength 2 def) lbsBackEnd req4
             `shouldThrow` anyException
 
     it "exceeding file size" $ do
         SRequest req4 _bod4 <- toRequest'' ctype3 content3
-        (parseRequestBodyEx (setMaxRequestFileSize 2 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxRequestFileSize 2 def) lbsBackEnd req4
             `shouldThrow` (== PayloadTooLarge)
 
     it "exceeding total file size" $ do
         SRequest req4 _bod4 <- toRequest'' ctype3 content3
-        (parseRequestBodyEx (setMaxRequestFilesSize 20 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxRequestFilesSize 20 def) lbsBackEnd req4
             `shouldThrow` (== PayloadTooLarge)
         SRequest req5 _bod5 <- toRequest'' ctype3 content5
-        (parseRequestBodyEx (setMaxRequestFilesSize 20 def) lbsBackEnd req5)
+        parseRequestBodyEx (setMaxRequestFilesSize 20 def) lbsBackEnd req5
             `shouldThrow` (== PayloadTooLarge)
 
     it "exceeding max parm value size" $ do
         SRequest req4 _bod4 <- toRequest'' ctype2 content2
-        (parseRequestBodyEx (setMaxRequestParmsSize 10 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxRequestParmsSize 10 def) lbsBackEnd req4
             `shouldThrow` (== PayloadTooLarge)
 
     it "exceeding max header lines" $ do
         SRequest req4 _bod4 <- toRequest'' ctype2 content2
-        (parseRequestBodyEx (setMaxHeaderLines 1 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxHeaderLines 1 def) lbsBackEnd req4
             `shouldThrow` anyException
 
     it "exceeding header line size" $ do
         SRequest req4 _bod4 <- toRequest'' ctype3 content4
-        (parseRequestBodyEx (setMaxHeaderLineLength 8190 def) lbsBackEnd req4)
+        parseRequestBodyEx (setMaxHeaderLineLength 8190 def) lbsBackEnd req4
             `shouldThrow` (== RequestHeaderFieldsTooLarge)
 
     it "Testing parseRequestBodyEx with application/x-www-form-urlencoded" $ do
@@ -195,7 +195,7 @@ caseParseRequestBody = do
                 "thisisalongparameterkey=andthisbeanevenlongerparametervaluehelloworldhowareyou"
         let ctype = "application/x-www-form-urlencoded"
         SRequest req _bod <- toRequest'' ctype content
-        (parseRequestBodyEx (setMaxRequestParmsSize 10 def) lbsBackEnd req)
+        parseRequestBodyEx (setMaxRequestParmsSize 10 def) lbsBackEnd req
             `shouldThrow` anyException
   where
     content2 =

--- a/wai-extra/test/Network/Wai/TestSpec.hs
+++ b/wai-extra/test/Network/Wai/TestSpec.hs
@@ -108,7 +108,7 @@ spec = do
                                     ( "Set-Cookie"
                                     , toByteString $
                                         Cookie.renderSetCookie $
-                                            Cookie.def
+                                            Cookie.defaultSetCookie
                                                 { Cookie.setCookieName = TE.encodeUtf8 name
                                                 , Cookie.setCookieValue = TE.encodeUtf8 val
                                                 }
@@ -123,7 +123,7 @@ spec = do
                                     ( "Set-Cookie"
                                     , toByteString $
                                         Cookie.renderSetCookie $
-                                            Cookie.def
+                                            Cookie.defaultSetCookie
                                                 { Cookie.setCookieName =
                                                     TE.encodeUtf8 name
                                                 , Cookie.setCookieExpires =
@@ -200,7 +200,7 @@ spec = do
         it "sends a cookie set with setClientCookie to server" $ do
             sresp <- flip runSession cookieApp $ do
                 setClientCookie
-                    ( Cookie.def
+                    ( Cookie.defaultSetCookie
                         { Cookie.setCookieName = "cookie_name"
                         , Cookie.setCookieValue = "cookie_value"
                         }
@@ -212,13 +212,13 @@ spec = do
         it "sends a cookie updated with setClientCookie to server" $ do
             sresp <- flip runSession cookieApp $ do
                 setClientCookie
-                    ( Cookie.def
+                    ( Cookie.defaultSetCookie
                         { Cookie.setCookieName = "cookie_name"
                         , Cookie.setCookieValue = "cookie_value"
                         }
                     )
                 setClientCookie
-                    ( Cookie.def
+                    ( Cookie.defaultSetCookie
                         { Cookie.setCookieName = "cookie_name"
                         , Cookie.setCookieValue = "cookie_value2"
                         }
@@ -230,7 +230,7 @@ spec = do
         it "does not send a cookie deleted with deleteClientCookie to server" $ do
             sresp <- flip runSession cookieApp $ do
                 setClientCookie
-                    ( Cookie.def
+                    ( Cookie.defaultSetCookie
                         { Cookie.setCookieName = "cookie_name"
                         , Cookie.setCookieValue = "cookie_value"
                         }

--- a/wai-extra/test/sample.hs
+++ b/wai-extra/test/sample.hs
@@ -30,4 +30,4 @@ app request = return $ case pathInfo request of
     _ -> ResponseFile status404 [] "../LICENSE" Nothing
 
 main :: IO ()
-main = run 3000 $ gzip def $ jsonp app
+main = run 3000 $ gzip defaultGzipSettings $ jsonp app

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.4.10
+
+* Removed `data-default` dependency entirely. Does now require `>= tls-2.1.3`.
+  [#1011](https://github.com/yesodweb/wai/pull/1011)
+
 ## 3.4.9
 
 * Using `timeout` for `handshake` to prevent thread leaks.

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -59,7 +59,6 @@ import Control.Applicative ((<|>))
 import Control.Monad (guard, void)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Default (def)
 import qualified Data.IORef as I
 import Data.Streaming.Network (bindPortTCP, safeRecv)
 import Data.Typeable (Typeable)
@@ -259,7 +258,7 @@ runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock =
   where
     get = getter tlsset set sock params
     params =
-        def -- TLS.ServerParams
+        TLS.defaultParamsServer
             { TLS.serverWantClientCert = tlsWantClientCert
             , TLS.serverCACertificates = []
             , TLS.serverDHEParams = tlsServerDHEParams
@@ -278,12 +277,12 @@ runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock =
                     <|> (if settingsHTTP2Enabled set then Just alpn else Nothing)
             }
     shared =
-        def
+        TLS.defaultShared
             { TLS.sharedCredentials = credentials
             , TLS.sharedSessionManager = mgr
             }
     supported =
-        def -- TLS.Supported
+        TLS.defaultSupported
             { TLS.supportedVersions = tlsAllowedVersions
             , TLS.supportedCiphers = tlsCiphers
             , TLS.supportedCompressions = [TLS.nullCompression]

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -12,7 +12,6 @@ module Network.Wai.Handler.WarpTLS.Internal (
 
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
-import Data.Default (def)
 import qualified Data.IORef as I
 import qualified Network.TLS as TLS
 import qualified Network.TLS.Extra as TLSExtra
@@ -33,7 +32,7 @@ data CertSettings
 instance Show CertSettings where
     show (CertFromFile a b c) = "CertFromFile " ++ show a ++ " " ++ show b ++ " " ++ show c
     show (CertFromMemory a b c) = "CertFromMemory " ++ show a ++ " " ++ show b ++ " " ++ show c
-    show (CertFromRef _ _ _) = "CertFromRef"
+    show CertFromRef{} = "CertFromRef"
 
 ----------------------------------------------------------------
 
@@ -91,7 +90,7 @@ data TLSSettings = TLSSettings
     -- to take when a client certificate is received.  See the "Network.TLS"
     -- module for details.
     --
-    -- Default: def
+    -- Default: defaultServerHooks
     --
     -- Since 3.0.2
     , tlsServerDHEParams :: Maybe TLS.DHParams
@@ -145,16 +144,16 @@ defaultTlsSettings =
     TLSSettings
         { certSettings = defaultCertSettings
         , onInsecure = DenyInsecure "This server only accepts secure HTTPS connections."
-        , tlsLogging = def
-        , tlsAllowedVersions = TLS.supportedVersions def
+        , tlsLogging = TLS.defaultLogging
+        , tlsAllowedVersions = TLS.supportedVersions TLS.defaultSupported
         , tlsCiphers = ciphers
         , tlsWantClientCert = False
-        , tlsServerHooks = def
+        , tlsServerHooks = TLS.defaultServerHooks
         , tlsServerDHEParams = Nothing
         , tlsSessionManagerConfig = Nothing
         , tlsCredentials = Nothing
         , tlsSessionManager = Nothing
-        , tlsSupportedHashSignatures = TLS.supportedHashSignatures def
+        , tlsSupportedHashSignatures = TLS.supportedHashSignatures TLS.defaultSupported
         }
 
 -- taken from stunnel example in tls-extra

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -22,8 +22,7 @@ Library
                    , bytestring                    >= 0.9
                    , wai                           >= 3.2      && < 3.3
                    , warp                          >= 3.3.29   && < 3.5
-                   , data-default
-                   , tls                           >= 1.7      && < 2.2
+                   , tls                           >= 2.1.3    && < 2.2
                    , network                       >= 2.2.1
                    , streaming-commons
                    , tls-session-manager           >= 0.0.4


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

So I really want to get rid of any `data-default`, and now with `tls-2.1.3` we can at least get rid of the dependency on `warp-tls`. Though it requires `tls >= 2.1.3`, which will be a bit more restrictive, though I don't think many people will have problems because of this.

I've also tried my best to obviously deprecate the `Default` instances that are still in this repo. I've made a synonym for `defaultGzipSettings`, since `def` was also directly (re-)exported, so now we can give an actual Deprecation warning. Though we can't on the other instances... unfortunately.

I'm hoping come `wai-extra-3.3` these instances can be removed as well.