### PR TITLE
Removing unliftio

### DIFF
--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module System.TimeManager (
     -- ** Types
@@ -29,11 +29,11 @@ module System.TimeManager (
 ) where
 
 import Control.Concurrent (myThreadId)
+import qualified Control.Exception as E
 import Control.Reaper
 import Data.IORef (IORef)
 import qualified Data.IORef as I
 import Data.Typeable (Typeable)
-import qualified UnliftIO.Exception as E
 
 ----------------------------------------------------------------
 
@@ -144,7 +144,7 @@ cancel (Handle mgr _ stateRef) = do
         | stateRef == stateRef' =
             hs
         | otherwise =
-            let !hs'= filt hs
+            let !hs' = filt hs
              in h : hs'
 
 -- | Setting the state to paused.

--- a/time-manager/time-manager.cabal
+++ b/time-manager/time-manager.cabal
@@ -16,7 +16,6 @@ Extra-Source-Files:  ChangeLog.md
 Library
   Build-Depends:     base                      >= 4.12       && < 5
                    , auto-update               >= 0.2        && < 0.3
-                   , unliftio
   Default-Language:  Haskell2010
   Exposed-modules:   System.TimeManager
   Ghc-Options:       -Wall

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -56,7 +56,6 @@ module Network.Wai.Handler.WarpTLS (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, forkIOWithUnmask)
 import Control.Exception (
     Exception,
     IOException,

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -56,6 +56,20 @@ module Network.Wai.Handler.WarpTLS (
 ) where
 
 import Control.Applicative ((<|>))
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, forkIOWithUnmask)
+import Control.Exception (
+    Exception,
+    IOException,
+    SomeException (..),
+    bracket,
+    finally,
+    fromException,
+    handle,
+    handleJust,
+    onException,
+    throwIO,
+    try,
+ )
 import Control.Monad (guard, void)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
@@ -73,6 +87,7 @@ import Network.Socket (
 #endif
     withSocketsDo,
  )
+import qualified Control.Exception as E
 import Network.Socket.BufferPool
 import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
@@ -82,23 +97,7 @@ import Network.Wai.Handler.Warp
 import Network.Wai.Handler.Warp.Internal
 import Network.Wai.Handler.WarpTLS.Internal
 import System.IO.Error (ioeGetErrorType, isEOFError)
-import UnliftIO.Exception (
-    Exception,
-    IOException,
-    SomeException (..),
-    bracket,
-    finally,
-    fromException,
-    handle,
-    handleAny,
-    handleJust,
-    onException,
-    throwIO,
-    try,
- )
-import qualified UnliftIO.Exception as E
-import UnliftIO.Concurrent (newEmptyMVar, putMVar, takeMVar, forkIOWithUnmask)
-import UnliftIO.Timeout (timeout)
+import System.Timeout (timeout)
 
 ----------------------------------------------------------------
 
@@ -366,7 +365,7 @@ httpOverTls TLSSettings{..} set s bs0 params =
         case mconn of
           Nothing -> throwIO IncompleteHeaders
           Just conn -> return conn
-    wrappedRecvN recvN n = handleAny (const mempty) $ recvN n
+    wrappedRecvN recvN n = handle (\(SomeException _) -> mempty) $ recvN n
     backend recvN =
         TLS.Backend
             { TLS.backendFlush = return ()

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -322,12 +322,8 @@ mkConn
     -> params
     -> IO (Connection, Transport)
 mkConn tlsset set s params = do
-    var <- newEmptyMVar
-    _ <- forkIOWithUnmask $ \umask -> do
-        let tm = settingsTimeout set * 1000000
-        mct <- umask (timeout tm recvFirstBS)
-        putMVar var mct
-    mbs <- takeMVar var
+    let tm = settingsTimeout set * 1000000
+    mbs <- timeout tm recvFirstBS
     case mbs of
       Nothing -> throwIO IncompleteHeaders
       Just bs -> switch bs

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -26,7 +26,6 @@ Library
                    , network                       >= 2.2.1
                    , streaming-commons
                    , tls-session-manager           >= 0.0.4
-                   , unliftio
                    , recv                          >= 0.1.0   && < 0.2.0
   Exposed-modules:   Network.Wai.Handler.WarpTLS
                      Network.Wai.Handler.WarpTLS.Internal

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -141,7 +141,7 @@ module Network.Wai.Handler.Warp (
 
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Vault.Lazy as Vault
-import UnliftIO.Exception (SomeException, throwIO)
+import Control.Exception (SomeException, throwIO)
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif

--- a/warp/Network/Wai/Handler/Warp/Conduit.hs
+++ b/warp/Network/Wai/Handler/Warp/Conduit.hs
@@ -2,10 +2,10 @@
 
 module Network.Wai.Handler.Warp.Conduit where
 
+import Control.Exception (assert, throwIO)
 import qualified Data.ByteString as S
 import qualified Data.IORef as I
 import Data.Word8 (_0, _9, _A, _F, _a, _cr, _f, _lf)
-import UnliftIO (assert, throwIO)
 
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types

--- a/warp/Network/Wai/Handler/Warp/FdCache.hs
+++ b/warp/Network/Wai/Handler/Warp/FdCache.hs
@@ -26,7 +26,7 @@ import System.Posix.IO (
     openFd,
     setFdOption,
  )
-import UnliftIO.Exception (bracket)
+import Control.Exception (bracket)
 #endif
 import System.Posix.Types (Fd)
 

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -9,6 +9,7 @@ module Network.Wai.Handler.Warp.HTTP1 (
 ) where
 
 import qualified Control.Concurrent as Conc (yield)
+import Control.Exception (SomeException, catch, fromException, throwIO, try)
 import qualified Data.ByteString as BS
 import Data.Char (chr)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -17,8 +18,6 @@ import Network.Socket (SockAddr (SockAddrInet, SockAddrInet6))
 import Network.Wai
 import Network.Wai.Internal (ResponseReceived (ResponseReceived))
 import qualified System.TimeManager as T
-import UnliftIO (SomeException, fromException, throwIO)
-import qualified UnliftIO
 import "iproute" Data.IP (toHostAddress, toHostAddress6)
 
 import Network.Wai.Handler.Warp.Header
@@ -115,7 +114,7 @@ http1server
     -> Source
     -> IO ()
 http1server settings ii conn transport app addr th istatus src =
-    loop FirstRequest `UnliftIO.catchAny` handler
+    loop FirstRequest `catch` handler
   where
     handler e
         -- See comment below referencing
@@ -151,7 +150,7 @@ http1server settings ii conn transport app addr th istatus src =
                 mremainingRef
                 idxhdr
                 nextBodyFlush
-                `UnliftIO.catchAny` \e -> do
+                `catch` \e -> do
                     settingsOnException settings (Just req) e
                     -- Don't throw the error again to prevent calling settingsOnException twice.
                     return CloseConnection
@@ -166,8 +165,8 @@ http1server settings ii conn transport app addr th istatus src =
         -- and ignore. See: https://github.com/yesodweb/wai/issues/618
 
         case keepAlive of
-          ReuseConnection -> loop SubsequentRequest
-          CloseConnection -> return ()
+            ReuseConnection -> loop SubsequentRequest
+            CloseConnection -> return ()
 
 data ReuseConnection = ReuseConnection | CloseConnection
 
@@ -192,7 +191,7 @@ processRequest settings ii conn app th istatus src req mremainingRef idxhdr next
     -- creating the request, we need to make sure that we don't get
     -- an async exception before calling the ResponseSource.
     keepAliveRef <- newIORef $ error "keepAliveRef not filled"
-    r <- UnliftIO.tryAny $ app req $ \res -> do
+    r <- try $ app req $ \res -> do
         T.resume th
         -- FIXME consider forcing evaluation of the res here to
         -- send more meaningful error messages to the user.
@@ -226,27 +225,27 @@ processRequest settings ii conn app th istatus src req mremainingRef idxhdr next
         then -- If there is an unknown or large amount of data to still be read
         -- from the request body, simple drop this connection instead of
         -- reading it all in to satisfy a keep-alive request.
-        case settingsMaximumBodyFlush settings of
-            Nothing -> do
-                flushEntireBody nextBodyFlush
-                T.resume th
-                return ReuseConnection
-            Just maxToRead -> do
-                let tryKeepAlive = do
-                        -- flush the rest of the request body
-                        isComplete <- flushBody nextBodyFlush maxToRead
-                        if isComplete
-                            then do
-                                T.resume th
-                                return ReuseConnection
-                            else return CloseConnection
-                case mremainingRef of
-                    Just ref -> do
-                        remaining <- readIORef ref
-                        if remaining <= maxToRead
-                            then tryKeepAlive
-                            else return CloseConnection
-                    Nothing -> tryKeepAlive
+            case settingsMaximumBodyFlush settings of
+                Nothing -> do
+                    flushEntireBody nextBodyFlush
+                    T.resume th
+                    return ReuseConnection
+                Just maxToRead -> do
+                    let tryKeepAlive = do
+                            -- flush the rest of the request body
+                            isComplete <- flushBody nextBodyFlush maxToRead
+                            if isComplete
+                                then do
+                                    T.resume th
+                                    return ReuseConnection
+                                else return CloseConnection
+                    case mremainingRef of
+                        Just ref -> do
+                            remaining <- readIORef ref
+                            if remaining <= maxToRead
+                                then tryKeepAlive
+                                else return CloseConnection
+                        Nothing -> tryKeepAlive
         else return CloseConnection
 
 sendErrorResponse

--- a/warp/Network/Wai/Handler/Warp/HTTP2/PushPromise.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/PushPromise.hs
@@ -3,9 +3,9 @@
 
 module Network.Wai.Handler.Warp.HTTP2.PushPromise where
 
+import qualified Control.Exception as E
 import qualified Network.HTTP.Types as H
 import qualified Network.HTTP2.Server as H2
-import qualified UnliftIO
 
 import Network.Wai
 import Network.Wai.Handler.Warp.FileInfoCache
@@ -22,9 +22,9 @@ fromPushPromises ii req = do
 
 fromPushPromise :: InternalInfo -> PushPromise -> IO (Maybe H2.PushPromise)
 fromPushPromise ii (PushPromise path file rsphdr w) = do
-    efinfo <- UnliftIO.tryIO $ getFileInfo ii file
+    efinfo <- E.try $ getFileInfo ii file
     case efinfo of
-        Left (_ex :: UnliftIO.IOException) -> return Nothing
+        Left (_ex :: E.IOException) -> return Nothing
         Right finfo -> do
             let !siz = fromIntegral $ fileInfoSize finfo
                 !fileSpec = H2.FileSpec file 0 siz

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Response.hs
@@ -6,13 +6,13 @@ module Network.Wai.Handler.Warp.HTTP2.Response (
     fromResponse,
 ) where
 
+import qualified Control.Exception as E
 import qualified Data.ByteString.Builder as BB
 import qualified Data.List as L (find)
 import qualified Network.HTTP.Types as H
 import qualified Network.HTTP2.Server as H2
 import Network.Wai hiding (responseBuilder, responseFile, responseStream)
 import Network.Wai.Internal (Response (..))
-import qualified UnliftIO
 
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.HTTP2.Request (getHTTP2Data)
@@ -81,9 +81,9 @@ responseFile st rsphdr method path (Just fp) _ _ =
     !bytes' = fromIntegral $ filePartByteCount fp
     !fileSpec = H2.FileSpec path off' bytes'
 responseFile _ rsphdr method path Nothing ii reqhdr = do
-    efinfo <- UnliftIO.tryIO $ getFileInfo ii path
+    efinfo <- E.try $ getFileInfo ii path
     case efinfo of
-        Left (_ex :: UnliftIO.IOException) -> return $ response404 rsphdr
+        Left (_ex :: E.IOException) -> return $ response404 rsphdr
         Right finfo -> do
             let reqidx = indexRequestHeader reqhdr
                 rspidx = indexResponseHeader rsphdr

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -27,7 +27,7 @@ import Data.Word8 (_cr, _lf)
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
-import UnliftIO (Exception, throwIO)
+import Control.Exception (Exception, throwIO)
 import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr)
 import Network.Wai

--- a/warp/Network/Wai/Handler/Warp/RequestHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/RequestHeader.hs
@@ -13,7 +13,7 @@ import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Ptr (Ptr, minusPtr, nullPtr, plusPtr)
 import Foreign.Storable (peek)
 import qualified Network.HTTP.Types as H
-import UnliftIO (throwIO)
+import Control.Exception (throwIO)
 
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -14,6 +14,7 @@ module Network.Wai.Handler.Warp.Response (
     addAltSvc,
 ) where
 
+import qualified Control.Exception as E
 import Data.Array ((!))
 import qualified Data.ByteString as S
 import Data.ByteString.Builder (Builder, byteString)
@@ -38,7 +39,6 @@ import Network.Wai
 import Network.Wai.Internal
 import qualified Paths_warp
 import qualified System.TimeManager as T
-import qualified UnliftIO
 
 import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
@@ -315,9 +315,9 @@ sendRsp conn ii th ver s0 hs0 rspidxhdr maxRspBufSize method (RspFile path (Just
 -- Simple WAI applications.
 -- Status is ignored
 sendRsp conn ii th ver _ hs0 rspidxhdr maxRspBufSize method (RspFile path Nothing reqidxhdr hook) = do
-    efinfo <- UnliftIO.tryIO $ getFileInfo ii path
+    efinfo <- E.try $ getFileInfo ii path
     case efinfo of
-        Left (_ex :: UnliftIO.IOException) ->
+        Left (_ex :: E.IOException) ->
 #ifdef WARP_DEBUG
             print _ex >>
 #endif

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -19,13 +19,13 @@ import Foreign.ForeignPtr (newForeignPtr_)
 import Foreign.Ptr (plusPtr)
 import qualified System.IO as IO
 #else
+import qualified Control.Exception as E
 import Foreign.C.Error (throwErrno)
 import Foreign.C.Types
 import Foreign.Ptr (Ptr, castPtr, plusPtr)
 import Network.Sendfile
 import Network.Wai.Handler.Warp.FdCache (openFile, closeFile)
 import System.Posix.Types
-import qualified UnliftIO
 #endif
 
 import Network.Wai.Handler.Warp.Buffer
@@ -118,7 +118,7 @@ readSendFile buf siz send fid off0 len0 hook headers = do
 #else
 readSendFile :: Buffer -> BufSize -> (ByteString -> IO ()) -> SendFile
 readSendFile buf siz send fid off0 len0 hook headers =
-    UnliftIO.bracket setup teardown $ \fd -> do
+    E.bracket setup teardown $ \fd -> do
         hn <- packHeader buf siz send hook headers 0
         let room = siz - hn
             buf' = buf `plusPtr` hn

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -9,6 +9,7 @@
 
 module Network.Wai.Handler.Warp.Settings where
 
+import Control.Exception (SomeException, fromException)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as C8
 import Data.Streaming.Network (HostPreference)
@@ -25,7 +26,6 @@ import qualified Paths_warp
 import System.IO (stderr)
 import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
-import UnliftIO (SomeException, fromException)
 
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -7,7 +7,7 @@ module Network.Wai.Handler.Warp.Types where
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Typeable (Typeable)
-import qualified UnliftIO
+import qualified Control.Exception as E
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
@@ -60,7 +60,7 @@ instance Show InvalidRequest where
     show RequestHeaderFieldsTooLarge = "Request header fields too large"
     show PayloadTooLarge = "Payload too large"
 
-instance UnliftIO.Exception InvalidRequest
+instance E.Exception InvalidRequest
 
 ----------------------------------------------------------------
 
@@ -70,10 +70,10 @@ instance UnliftIO.Exception InvalidRequest
 --
 -- Used to determine whether keeping the HTTP1.1 connection / HTTP2 stream alive is safe
 -- or irrecoverable.
-newtype ExceptionInsideResponseBody = ExceptionInsideResponseBody UnliftIO.SomeException
+newtype ExceptionInsideResponseBody = ExceptionInsideResponseBody E.SomeException
     deriving (Show, Typeable)
 
-instance UnliftIO.Exception ExceptionInsideResponseBody
+instance E.Exception ExceptionInsideResponseBody
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/WithApplication.hs
+++ b/warp/Network/Wai/Handler/Warp/WithApplication.hs
@@ -10,6 +10,8 @@ module Network.Wai.Handler.Warp.WithApplication (
 ) where
 
 import Control.Concurrent
+import Control.Concurrent.Async
+import qualified Control.Exception as E
 import Control.Monad (when)
 import Data.Streaming.Network (bindRandomPortTCP)
 import Network.Socket
@@ -17,8 +19,6 @@ import Network.Wai
 import Network.Wai.Handler.Warp.Run
 import Network.Wai.Handler.Warp.Settings
 import Network.Wai.Handler.Warp.Types
-import qualified UnliftIO
-import UnliftIO.Async
 
 -- | Runs the given 'Application' on a free port. Passes the port to the given
 -- operation and executes it, while the 'Application' is running. Shuts down the
@@ -47,7 +47,7 @@ withApplicationSettings settings' mkApp action = do
                 (runSettingsSocket settings sock app)
                 (waitFor started >> action port)
         case result of
-            Left () -> UnliftIO.throwString "Unexpected: runSettingsSocket exited"
+            Left () -> E.throwIO $ E.ErrorCall "Unexpected: runSettingsSocket exited"
             Right x -> return x
 
 -- | Same as 'withApplication' but with different exception handling: If the
@@ -75,11 +75,11 @@ testWithApplicationSettings settings mkApp action = do
     callingThread <- myThreadId
     app <- mkApp
     let wrappedApp request respond =
-            app request respond `UnliftIO.catchAny` \e -> do
+            app request respond `E.catch` \e -> do
                 when
                     (defaultShouldDisplayException e)
                     (throwTo callingThread e)
-                UnliftIO.throwIO e
+                E.throwIO e
     withApplicationSettings settings (return wrappedApp) action
 
 data Waiter a = Waiter
@@ -104,4 +104,4 @@ openFreePort = bindRandomPortTCP "127.0.0.1"
 
 -- | Like 'openFreePort' but closes the socket before exiting.
 withFreePort :: ((Port, Socket) -> IO a) -> IO a
-withFreePort = UnliftIO.bracket openFreePort (close . snd)
+withFreePort = E.bracket openFreePort (close . snd)

--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -16,7 +16,7 @@ import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Storable
 import qualified Network.HTTP.Types as H
-import UnliftIO.Exception (impureThrow, throwIO)
+import Control.Exception (impureThrow, throwIO)
 import Prelude hiding (lines)
 
 import Network.Wai.Handler.Warp.Request (FirstRequest (..), headerLines)

--- a/warp/test/ExceptionSpec.hs
+++ b/warp/test/ExceptionSpec.hs
@@ -6,6 +6,8 @@ module ExceptionSpec (main, spec) where
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative
 #endif
+import Control.Concurrent.Async (withAsync)
+import Control.Exception
 import Control.Monad
 import qualified Data.Streaming.Network as N
 import Network.HTTP.Types hiding (Header)
@@ -14,8 +16,6 @@ import Network.Wai hiding (Response, responseStatus)
 import Network.Wai.Handler.Warp
 import Network.Wai.Internal (Request (..))
 import Test.Hspec
-import UnliftIO.Async (withAsync)
-import UnliftIO.Exception
 
 import HTTP
 

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -23,8 +23,8 @@ import Network.Wai.Handler.Warp
 import System.IO.Unsafe (unsafePerformIO)
 import System.Timeout (timeout)
 import Test.Hspec
-import UnliftIO.Exception (IOException, bracket, onException, try)
-import qualified UnliftIO.Exception as E
+import Control.Exception (IOException, bracket, onException, try)
+import qualified Control.Exception as E
 
 import HTTP
 

--- a/warp/test/SendFileSpec.hs
+++ b/warp/test/SendFileSpec.hs
@@ -13,7 +13,7 @@ import System.Exit
 import qualified System.IO as IO
 import System.Process (system)
 import Test.Hspec
-import UnliftIO.Exception
+import Control.Exception
 
 main :: IO ()
 main = hspec spec

--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -2,12 +2,12 @@
 
 module WithApplicationSpec where
 
+import Control.Exception
 import Network.HTTP.Types
 import Network.Wai
 import System.Environment
 import System.Process
 import Test.Hspec
-import UnliftIO.Exception
 
 import Network.Wai.Handler.Warp.WithApplication
 
@@ -30,17 +30,17 @@ spec = do
                 output `shouldBe` "foo"
 
         it "does not propagate exceptions from the server to the executing thread" $ do
-            let mkApp = return $ \_request _respond -> throwString "foo"
+            let mkApp = return $ \_request _respond -> throwIO $ ErrorCall "foo"
             withApplication mkApp $ \port -> do
                 output <- readProcess "curl" ["-s", "localhost:" ++ show port] ""
                 output `shouldContain` "Something went wron"
 
     describe "testWithApplication" $ do
         it "propagates exceptions from the server to the executing thread" $ do
-            let mkApp = return $ \_request _respond -> throwString "foo"
+            let mkApp = return $ \_request _respond -> throwIO $ ErrorCall "foo"
             testWithApplication
                 mkApp
                 ( \port -> do
                     readProcess "curl" ["-s", "localhost:" ++ show port] ""
                 )
-                `shouldThrow` (\(StringException str _) -> str == "foo")
+                `shouldThrow` (errorCall "foo")

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -86,6 +86,7 @@ library
         base >=4.12 && <5,
         array,
         auto-update >=0.2.2 && <0.3,
+        async,
         bsb-http-chunked <0.1,
         bytestring >=0.9.1.4,
         case-insensitive >=0.2,
@@ -104,8 +105,7 @@ library
         time-manager >=0.1 && <0.2,
         vault >=0.3,
         wai >=3.2.4 && <3.3,
-        word8,
-        unliftio
+        word8
 
     if flag(x509)
         build-depends: crypton-x509
@@ -217,6 +217,7 @@ test-suite spec
         QuickCheck,
         array,
         auto-update,
+        async,
         bsb-http-chunked <0.1,
         bytestring >=0.9.1.4,
         case-insensitive >=0.2,
@@ -240,8 +241,7 @@ test-suite spec
         time-manager,
         vault,
         wai >=3.2.2.1 && <3.3,
-        word8,
-        unliftio
+        word8
 
     if flag(x509)
         build-depends: crypton-x509
@@ -306,7 +306,6 @@ benchmark parser
         streaming-commons,
         text,
         time-manager,
-        unliftio,
         vault,
         wai,
         word8

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -295,7 +295,7 @@ benchmark parser
         bytestring,
         case-insensitive,
         containers,
-        gauge,
+        criterion,
         ghc-prim,
         hashable,
         http-date,


### PR DESCRIPTION
This PR removes `unliftio` from WAI families.
This is because TLS `bye` and network `gracefulClose` cannot used with `bracket` of `unliftio`.

In my field testing for a week, I have not found any problems.
This PR is just to run CI.