### PR TITLE
easy access sni TLSSettings smart constructor

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+## 3.4.13
+
+* Introduced new smart constructor `tlsSettingsSni` to make it more convenient
+  to dynamically change certificates. Deprecates `tlsSettingsRef` and
+  `tlsSettingsChainRef`.
+  [#1025](https://github.com/yesodweb/wai/pull/1025)
+
 ## 3.4.12
 
 * Rethrowing asynchronous exceptions

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -169,9 +169,9 @@ tlsSettingsChainMemory cert chainCerts key =
 -- depending on the hostname but also to retrieve dynamically updated
 -- credentials from an IORef. Credentials can be loaded from PEM-encoded chain
 -- and key files using 'TLS.credentialLoadX509'.
-tlsSettingsSni :: (Maybe TLS.HostName -> IO TLS.Credentials) -> IO TLSSettings
-tlsSettingsSni onServerNameIndicationHook = do
-  pure defaultTlsSettings
+tlsSettingsSni :: (Maybe TLS.HostName -> IO TLS.Credentials) -> TLSSettings
+tlsSettingsSni onServerNameIndicationHook =
+  defaultTlsSettings
     { tlsCredentials = Just (TLS.Credentials [])
     , tlsServerHooks = (tlsServerHooks defaultTlsSettings)
       { TLS.onServerNameIndication =  onServerNameIndicationHook

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -193,7 +193,7 @@ tlsSettingsRef cert key =
         { certSettings = CertFromRef cert [] key
         }
 
-{-# DEPRECATED tlsSettingsRef "Will be removed in the next major release" #-}
+{-# DEPRECATED tlsSettingsRef "This function was added to allow Warp to serve new certificates without restarting, but it has always behaved the same as 'tlsSettingsMemory'. It will be removed in the next major release. To retain existing behavior, swich to 'tlsSettingsMemory'. To dynamically update credentials, see 'tlsSettingsSni'." #-}
 
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
@@ -212,7 +212,7 @@ tlsSettingsChainRef cert chainCerts key =
         { certSettings = CertFromRef cert chainCerts key
         }
 
-{-# DEPRECATED tlsSettingsChainRef "Will be removed in the next major release" #-}
+{-# DEPRECATED tlsSettingsChainRef "This function was added to allow Warp to serve new certificates without restarting, but it has always behaved the same as 'tlsSettingsChainMemory'. It will be removed in the next major release. To retain existing behavior, swich to 'tlsSettingsChainMemory'. To dynamically update credentials, see 'tlsSettingsSni'." #-}
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -169,6 +169,8 @@ tlsSettingsChainMemory cert chainCerts key =
 -- depending on the hostname but also to retrieve dynamically updated
 -- credentials from an IORef. Credentials can be loaded from PEM-encoded chain
 -- and key files using 'TLS.credentialLoadX509'.
+--
+-- @since 3.4.13
 tlsSettingsSni :: (Maybe TLS.HostName -> IO TLS.Credentials) -> TLSSettings
 tlsSettingsSni onServerNameIndicationHook =
   defaultTlsSettings

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -193,6 +193,8 @@ tlsSettingsRef cert key =
         { certSettings = CertFromRef cert [] key
         }
 
+{-# DEPRECATED tlsSettingsRef "Will be removed in the next major release" #-}
+
 -- | A smart constructor for 'TLSSettings', but uses references to in-memory
 -- representations of the certificate and key based on 'defaultTlsSettings'.
 --
@@ -209,6 +211,8 @@ tlsSettingsChainRef cert chainCerts key =
     defaultTlsSettings
         { certSettings = CertFromRef cert chainCerts key
         }
+
+{-# DEPRECATED tlsSettingsChainRef "Will be removed in the next major release" #-}
 
 ----------------------------------------------------------------
 

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.4.12
+Version:             3.4.13
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
This implements my suggestion in our discussion in #859 

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->