### PR TITLE
Use `:seti` instead of `:set` in doctests

### DIFF
--- a/auto-update/Control/AutoUpdate/Event.hs
+++ b/auto-update/Control/AutoUpdate/Event.hs
@@ -65,7 +65,7 @@ mkAutoUpdateThingsWithModify mk settings update1 = do
 --------------------------------------------------------------------------------
 
 -- $setup
--- >>> :set -XNumericUnderscores
+-- >>> :seti -XNumericUnderscores
 -- >>> import Control.Concurrent
 
 -- |


### PR DESCRIPTION
I'm not going into details, but the short story is that `:set` frequently leads to issues, as it may unload modules.

You should always use `:seti` in doctests, unless you have a very specific reason not to.