### PR TITLE
Added ability to have IO action returning (LBS.ByteString, LBS.ByteString) to OnInsecure

### DIFF
--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+* Introduced additional constructor `DenyInsecureWithAction` for `OnInsecure`,
+  allowing the insertion of a custom function to consume the request bytestring,
+  returning a strict header bytestring and a lazy body bytestring for the given request.
+  [#1032](https://github.com/yesodweb/wai/pull/1032)
+
 ## 3.4.13
 
 * Introduced new smart constructor `tlsSettingsSni` to make it more convenient

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -506,6 +506,8 @@ tryIO = try
 
 ----------------------------------------------------------------
 
+-- test
+
 plainHTTP
     :: TLSSettings -> Settings -> Socket -> S.ByteString -> IO (Connection, Transport)
 plainHTTP TLSSettings{..} set s bs0 = case onInsecure of

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -539,9 +539,9 @@ plainHTTP TLSSettings{..} set s bs0 = case onInsecure of
         throwIO InsecureConnectionDenied
     DenyInsecureWithAction responseAction -> do
         -- This branch allows any IO action in response to an
-        -- unexpected HTTP request, returning a header and a
-        -- lazy bytestring for sending.
-        (responseHeader, responseBody) <- responseAction
+        -- unexpected HTTP request, consuming it, and returning a header
+        -- and a lazy bytestring for sending.
+        (responseHeader, responseBody) <- responseAction bs0
         
         sendAll s responseHeader
         mapM_ (sendAll s) $ L.toChunks responseBody

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -544,7 +544,7 @@ plainHTTP TLSSettings{..} set s bs0 = case onInsecure of
         (responseHeader, responseBody) <- responseAction
         
         sendAll s responseHeader
-        mapM_ (sendAll s) $ L.toChunks responseLBS
+        mapM_ (sendAll s) $ L.toChunks responseBody
         
         close s
         throwIO InsecureConnectionDenied

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -41,6 +41,10 @@ data OnInsecure
     = DenyInsecure L.ByteString
     | AllowInsecure
     | DenyInsecureWithAction (IO (L.ByteString, L.ByteString))
+    -- ^ Ability to run an IO action generating a header and a
+    -- body response on an insecure connection.
+    --
+    -- @since 3.4.14
 
 instance Show OnInsecure where
     show (DenyInsecure lbs) = "DenyInsecure " ++ show lbs

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -40,16 +40,16 @@ instance Show CertSettings where
 data OnInsecure
     = DenyInsecure L.ByteString
     | AllowInsecure
-    | DenyInsecureWithAction (IO (L.ByteString, L.ByteString))
+    | DenyInsecureWithAction (S.ByteString -> IO (L.ByteString, L.ByteString))
     -- ^ Ability to run an IO action generating a header and a
-    -- body response on an insecure connection.
+    -- body response, consuming the insecure request sent.
     --
     -- @since 3.4.14
 
 instance Show OnInsecure where
     show (DenyInsecure lbs) = "DenyInsecure " ++ show lbs
     show AllowInsecure = "AllowInsecure"
-    show (DenyInsecureWithAction _) = "DenyInsecureWithAction <IO Action>"
+    show (DenyInsecureWithAction _) = "DenyInsecureWithAction < ByteString -> IO Action >"
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -40,7 +40,7 @@ instance Show CertSettings where
 data OnInsecure
     = DenyInsecure L.ByteString
     | AllowInsecure
-    | DenyInsecureWithAction (S.ByteString -> IO (L.ByteString, L.ByteString))
+    | DenyInsecureWithAction (S.ByteString -> IO (S.ByteString, L.ByteString))
     -- ^ Ability to run an IO action generating a header and a
     -- body response, consuming the insecure request sent.
     --

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -49,7 +49,7 @@ data OnInsecure
 instance Show OnInsecure where
     show (DenyInsecure lbs) = "DenyInsecure " ++ show lbs
     show AllowInsecure = "AllowInsecure"
-    show (DenyInsecureWithAction _) = "DenyInsecureWithAction " ++ "<IO Action>"
+    show (DenyInsecureWithAction _) = "DenyInsecureWithAction <IO Action>"
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -40,7 +40,12 @@ instance Show CertSettings where
 data OnInsecure
     = DenyInsecure L.ByteString
     | AllowInsecure
-    deriving (Show)
+    | DenyInsecureWithAction (IO (L.ByteString, L.ByteString))
+
+instance Show OnInsecure where
+    show (DenyInsecure lbs) = "DenyInsecure " ++ show lbs
+    show AllowInsecure = "AllowInsecure"
+    show (DenyInsecureWithAction _) = "DenyInsecureWithAction " ++ "<IO Action>"
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS/Internal.hs
@@ -41,8 +41,8 @@ data OnInsecure
     = DenyInsecure L.ByteString
     | AllowInsecure
     | DenyInsecureWithAction (S.ByteString -> IO (S.ByteString, L.ByteString))
-    -- ^ Ability to run an IO action generating a header and a
-    -- body response, consuming the insecure request sent.
+    -- ^ Ability to run an IO action generating a strict header and a
+    -- lazy body response, consuming the insecure request sent.
     --
     -- @since 3.4.14
 

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.4.13
+Version:             3.4.14
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [✅] Bumped the version number
- [✅] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [✅] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [✅] Update the Changelog.md file with a link to your PR
- [✅] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

I'd like to be able to force the user on the Warp-TLS (instead of at reverse proxy or DNS) level to send a redirect response to users. Adding IO also makes it possible to provide logging behavior on the Warp-TLS level, although reverse proxies and firewalls would be superior at this.