### PR TITLE
correct seconds -> microseconds

### DIFF
--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -84,7 +84,7 @@ data State
 
 ----------------------------------------------------------------
 
--- | Creating timeout manager which works every N micro seconds
+-- | Creating timeout manager which works every N microseconds
 --   where N is the first argument.
 initialize :: Int -> IO Manager
 initialize timeout

--- a/warp/Network/Wai/Handler/Warp/FdCache.hs
+++ b/warp/Network/Wai/Handler/Warp/FdCache.hs
@@ -41,7 +41,7 @@ getFdNothing _ = return (Nothing, return ())
 ----------------------------------------------------------------
 
 -- | Creating 'MutableFdCache' and executing the action in the second
---   argument. The first argument is a cache duration in second.
+--   argument. The first argument is a cache duration in microseconds.
 withFdCache :: Int -> ((FilePath -> IO (Maybe Fd, Refresh)) -> IO a) -> IO a
 #ifdef WINDOWS
 withFdCache _ action = action getFdNothing
@@ -109,7 +109,7 @@ look mfc path = MM.lookup path <$> fdCache mfc
 
 ----------------------------------------------------------------
 
--- The first argument is a cache duration in second.
+-- The first argument is a cache duration in microseconds.
 initialize :: Int -> IO MutableFdCache
 initialize duration = MutableFdCache <$> mkReaper settings
   where

--- a/warp/Network/Wai/Handler/Warp/FileInfoCache.hs
+++ b/warp/Network/Wai/Handler/Warp/FileInfoCache.hs
@@ -90,7 +90,7 @@ negative reaper path = do
 
 -- | Creating a file information cache
 --   and executing the action in the second argument.
---   The first argument is a cache duration in second.
+--   The first argument is a cache duration in microseconds.
 withFileInfoCache
     :: Int
     -> ((FilePath -> IO FileInfo) -> IO a)

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -233,19 +233,19 @@ withII :: Settings -> (InternalInfo -> IO a) -> IO a
 withII set action =
     withTimeoutManager $ \tm ->
         D.withDateCache $ \dc ->
-            F.withFdCache fdCacheDurationInSeconds $ \fdc ->
-                I.withFileInfoCache fdFileInfoDurationInSeconds $ \fic -> do
+            F.withFdCache fdCacheDurationInMicroseconds $ \fdc ->
+                I.withFileInfoCache fdFileInfoDurationInMicroseconds $ \fic -> do
                     let ii = InternalInfo tm dc fdc fic
                     action ii
   where
-    !fdCacheDurationInSeconds = settingsFdCacheDuration set * 1000000
-    !fdFileInfoDurationInSeconds = settingsFileInfoCacheDuration set * 1000000
-    !timeoutInSeconds = settingsTimeout set * 1000000
+    !fdCacheDurationInMicroseconds = settingsFdCacheDuration set * 1000000
+    !fdFileInfoDurationInMicroseconds = settingsFileInfoCacheDuration set * 1000000
+    !timeoutInMicroseconds = settingsTimeout set * 1000000
     withTimeoutManager f = case settingsManager set of
         Just tm -> f tm
         Nothing ->
             E.bracket
-                (T.initialize timeoutInSeconds)
+                (T.initialize timeoutInMicroseconds)
                 T.stopManager
                 f
 


### PR DESCRIPTION
These arguments are microseconds, not seconds; the comments and identifiers are misleading.