### PR TITLE
Use Cabal PackageInfo_warp instead of Paths_warp

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -152,7 +152,7 @@ wrappedRecvN th slowlorisSize readN bufsize = do
     handler = throughAsync (return "")
 
 -- connClose must not be called here since Run:fork calls it
-goaway :: Connection -> H2.ErrorCodeId -> ByteString -> IO ()
+goaway :: Connection -> H2.ErrorCode -> ByteString -> IO ()
 goaway Connection{..} etype debugmsg = connSendAll bytestream
   where
     einfo = H2.encodeInfo id 0

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -85,13 +85,13 @@ toRequest' ii settings addr ref (reqths, reqvt) bodylen body th transport =
             Nothing -> case mAuth of
                 Just auth -> (tokenHost, auth) : reqths
                 _ -> reqths
-    !mPath = getHeaderValue tokenPath reqvt -- SHOULD
-    !colonMethod = fromJust $ getHeaderValue tokenMethod reqvt -- MUST
-    !mAuth = getHeaderValue tokenAuthority reqvt -- SHOULD
-    !mHost = getHeaderValue tokenHost reqvt
-    !mRange = getHeaderValue tokenRange reqvt
-    !mReferer = getHeaderValue tokenReferer reqvt
-    !mUserAgent = getHeaderValue tokenUserAgent reqvt
+    !mPath = getFieldValue tokenPath reqvt -- SHOULD
+    !colonMethod = fromJust $ getFieldValue tokenMethod reqvt -- MUST
+    !mAuth = getFieldValue tokenAuthority reqvt -- SHOULD
+    !mHost = getFieldValue tokenHost reqvt
+    !mRange = getFieldValue tokenRange reqvt
+    !mReferer = getFieldValue tokenReferer reqvt
+    !mUserAgent = getFieldValue tokenUserAgent reqvt
     -- CONNECT request will have ":path" omitted, use ":authority" as unparsed
     -- path instead so that it will have consistent behavior compare to HTTP 1.0
     (unparsedPath, query) = C8.break (== '?') $ fromJust (mPath <|> mAuth)

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -21,7 +21,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Unsafe as SU
 import qualified Data.CaseInsensitive as CI
 import qualified Data.IORef as I
-import Data.Typeable (Typeable)
 import qualified Data.Vault.Lazy as Vault
 import Data.Word8 (_cr, _lf)
 #ifdef MIN_VERSION_crypton_x509
@@ -136,7 +135,7 @@ headerLines maxTotalHeaderLength firstRequest src = do
         else push maxTotalHeaderLength src (THStatus 0 0 id id) bs
 
 data NoKeepAliveRequest = NoKeepAliveRequest
-    deriving (Show, Typeable)
+    deriving (Show)
 instance Exception NoKeepAliveRequest
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -37,7 +37,7 @@ import qualified Network.HTTP.Types as H
 import qualified Network.HTTP.Types.Header as H
 import Network.Wai
 import Network.Wai.Internal
-import qualified Paths_warp
+import qualified PackageInfo_warp
 import qualified System.TimeManager as T
 
 import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
@@ -481,7 +481,7 @@ addDate getdate rspidxhdr hdrs = case rspidxhdr ! fromEnum ResDate of
 
 -- | The version of Warp.
 warpVersion :: String
-warpVersion = showVersion Paths_warp.version
+warpVersion = showVersion PackageInfo_warp.version
 
 {-# INLINE addServer #-}
 addServer

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -6,7 +6,6 @@ module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
 import qualified Data.CaseInsensitive as CI
-import Data.List (foldl')
 import Data.Word8
 import Foreign.Ptr
 import GHC.Storable

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -22,7 +22,7 @@ import GHC.Prim (fork#)
 import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr, Socket, accept)
 import Network.Wai
-import qualified Paths_warp
+import qualified PackageInfo_warp
 import System.IO (stderr)
 import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
@@ -206,7 +206,7 @@ defaultSettings =
         , settingsAccept = defaultAccept
         , settingsNoParsePath = False
         , settingsInstallShutdownHandler = const $ return ()
-        , settingsServerName = C8.pack $ "Warp/" ++ showVersion Paths_warp.version
+        , settingsServerName = C8.pack $ "Warp/" ++ showVersion PackageInfo_warp.version
         , settingsMaximumBodyFlush = Just 8192
         , settingsProxyProtocol = ProxyProtocolNone
         , settingsSlowlorisSize = 2048

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -6,7 +6,6 @@ module Network.Wai.Handler.Warp.Types where
 
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Typeable (Typeable)
 import qualified Control.Exception as E
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
@@ -46,7 +45,7 @@ data InvalidRequest
       PayloadTooLarge
     | -- | Since 3.3.22
       RequestHeaderFieldsTooLarge
-    deriving (Eq, Typeable)
+    deriving (Eq)
 
 instance Show InvalidRequest where
     show (NotEnoughLines xs) = "Warp: Incomplete request headers, received: " ++ show xs
@@ -71,7 +70,7 @@ instance E.Exception InvalidRequest
 -- Used to determine whether keeping the HTTP1.1 connection / HTTP2 stream alive is safe
 -- or irrecoverable.
 newtype ExceptionInsideResponseBody = ExceptionInsideResponseBody E.SomeException
-    deriving (Show, Typeable)
+    deriving (Show)
 
 instance E.Exception ExceptionInsideResponseBody
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -78,7 +78,7 @@ library
         Network.Wai.Handler.Warp.Types
         Network.Wai.Handler.Warp.Windows
         Network.Wai.Handler.Warp.WithApplication
-        Paths_warp
+        PackageInfo_warp
 
     default-language: Haskell2010
     ghc-options:      -Wall
@@ -208,7 +208,7 @@ test-suite spec
         Network.Wai.Handler.Warp.Types
         Network.Wai.Handler.Warp.Windows
         Network.Wai.Handler.Warp.WithApplication
-        Paths_warp
+        PackageInfo_warp
 
     default-language:   Haskell2010
     ghc-options:        -Wall -threaded
@@ -285,7 +285,7 @@ benchmark parser
         Network.Wai.Handler.Warp.RequestHeader
         Network.Wai.Handler.Warp.Settings
         Network.Wai.Handler.Warp.Types
-        Paths_warp
+        PackageInfo_warp
 
     default-language: Haskell2010
     build-depends:

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >=1.10
+cabal-version:      3.12
 name:               warp
 version:            3.4.8
 license:            MIT


### PR DESCRIPTION
Use of `Paths_warp` causes a large dependency closure when building with nix. See https://github.com/NixOS/nixpkgs/pull/264434 for example.

This reduces the closure size of our application from 756Mb to 53Mb by virtue of not including GHC and GCC.

It makes a significant change to `cabal-version` and I'm not sure what compatibility we're trying to maintain in this project; also I made some incidental changes so that it would build with GHC 9.12.

This is not merge-ready — the PR is meant to open a discussion about using `PackageInfo_`.
