### PR TITLE
warp: expose open connection count via getOpenConnectionCount

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for warp
 
+## 3.4.11
+
+* Expose a way to access the open connection `Counter` with `makeSettingsAndCounter`,
+  and `getCount` to be able to monitor the current open connections.
+* Added getter function to get the open connection counter from the `Settings` with
+  `getOpenConnectionCounter`.
+  [#1050](https://github.com/yesodweb/wai/pull/1050)
+
 ## 3.4.10
 
 * Using newest dependencies

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -89,6 +89,12 @@ module Network.Wai.Handler.Warp (
     getGracefulShutdownTimeout,
     getGracefulCloseTimeout1,
     getGracefulCloseTimeout2,
+    getOpenConnectionCounter,
+
+    -- ** Connection counter
+    makeSettingsAndCounter,
+    Counter,
+    getCount,
 
     -- ** Exception handler
     defaultOnException,
@@ -150,6 +156,7 @@ import Network.Socket (SockAddr, Socket)
 import Network.Wai (Request, Response, vault)
 import System.TimeManager
 
+import Network.Wai.Handler.Warp.Counter (Counter, getCount)
 import Network.Wai.Handler.Warp.FileInfoCache
 import Network.Wai.Handler.Warp.HTTP2.Request (
     getHTTP2Data,
@@ -563,6 +570,15 @@ setGracefulCloseTimeout2 x y = y{settingsGracefulCloseTimeout2 = x}
 -- Since 3.3.5
 getGracefulCloseTimeout2 :: Settings -> Int
 getGracefulCloseTimeout2 = settingsGracefulCloseTimeout2
+
+-- | Get the connection counter, if one was configured.
+-- Use 'getCount' on the returned 'Counter' to read the current value.
+--
+-- See 'makeSettingsAndCounter' to create settings with a counter.
+--
+-- Since 3.4.11
+getOpenConnectionCounter :: Settings -> Maybe Counter
+getOpenConnectionCounter = settingsConnectionCounter
 
 #ifdef MIN_VERSION_crypton_x509
 -- | Getting information of client certificate.

--- a/warp/Network/Wai/Handler/Warp/Counter.hs
+++ b/warp/Network/Wai/Handler/Warp/Counter.hs
@@ -7,6 +7,7 @@ module Network.Wai.Handler.Warp.Counter (
     increase,
     decrease,
     waitForDecreased,
+    getCount,
 ) where
 
 import Control.Concurrent.STM
@@ -35,3 +36,9 @@ increase (Counter var) = atomically $ modifyTVar' var $ \x -> x + 1
 
 decrease :: Counter -> IO ()
 decrease (Counter var) = atomically $ modifyTVar' var $ \x -> x - 1
+
+-- | Get the current count of open connections.
+--
+-- Since 3.4.11
+getCount :: Counter -> IO Int
+getCount (Counter var) = readTVarIO var

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -4,6 +4,11 @@ module Network.Wai.Handler.Warp.Internal (
     -- * Settings
     Settings (..),
     ProxyProtocol (..),
+    makeSettingsAndCounter,
+
+    -- * Connection counter
+    Counter,
+    getCount,
 
     -- * Low level run functions
     runSettingsConnection,
@@ -94,6 +99,7 @@ import Network.Socket.BufferPool
 import System.TimeManager
 
 import Network.Wai.Handler.Warp.Buffer
+import Network.Wai.Handler.Warp.Counter (Counter, getCount)
 import Network.Wai.Handler.Warp.Date
 import Network.Wai.Handler.Warp.FdCache
 import Network.Wai.Handler.Warp.FileInfoCache

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -220,7 +220,9 @@ runSettingsConnectionMakerSecure
     :: Settings -> IO (IO (Connection, Transport), SockAddr) -> Application -> IO ()
 runSettingsConnectionMakerSecure set getConnMaker app = do
     settingsBeforeMainLoop set
-    counter <- newCounter
+    counter <- case settingsConnectionCounter set of
+        Just c -> pure c
+        Nothing -> newCounter
     withII set $ acceptConnection set getConnMaker app counter
 
 -- | Running an action with internal info.

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -25,6 +25,7 @@ import System.IO (stderr)
 import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
 
+import Network.Wai.Handler.Warp.Counter (Counter, newCounter)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types
 #if WINDOWS
@@ -178,6 +179,14 @@ data Settings = Settings
     -- Default: 1049_000_000 = 1 MiB.
     --
     -- Since 3.3.22
+    , settingsConnectionCounter :: Maybe Counter
+    -- ^ A counter for tracking open connections.
+    -- Use 'makeSettingsAndCounter' to create settings with a counter,
+    -- then use 'getCount' on the returned 'Counter' to read the current value.
+    --
+    -- Default: 'Nothing' (warp creates an internal counter)
+    --
+    -- Since 3.4.11
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -222,7 +231,17 @@ defaultSettings =
         , settingsMaxTotalHeaderLength = 50 * 1024
         , settingsAltSvc = Nothing
         , settingsMaxBuilderResponseBufferSize = 1049000000
+        , settingsConnectionCounter = Nothing
         }
+
+-- | Create 'Settings' with a connection counter.
+-- Use 'getCount' on the returned 'Counter' to check open connections.
+--
+-- Since 3.4.11
+makeSettingsAndCounter :: IO (Counter, Settings)
+makeSettingsAndCounter = do
+    counter <- newCounter
+    pure (counter, defaultSettings{settingsConnectionCounter = Just counter})
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an
 -- exception should be shown or not. The goal is to hide exceptions which occur

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -21,7 +21,7 @@ import Network.HTTP.Types
 import Network.Socket
 import Network.Socket.ByteString (sendAll)
 import Network.Wai hiding (responseHeaders)
-import Network.Wai.Handler.Warp
+import Network.Wai.Handler.Warp hiding (Counter)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Timeout (timeout)
 import Test.Hspec

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.10
+version:            3.4.11
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com
@@ -290,6 +290,7 @@ benchmark parser
     hs-source-dirs:   bench .
     other-modules:
         Network.Wai.Handler.Warp.Conduit
+        Network.Wai.Handler.Warp.Counter
         Network.Wai.Handler.Warp.Date
         Network.Wai.Handler.Warp.FdCache
         Network.Wai.Handler.Warp.FileInfoCache
@@ -322,6 +323,7 @@ benchmark parser
         network,
         network,
         recv,
+        stm,
         streaming-commons,
         text,
         time-manager,


### PR DESCRIPTION
Adds ability to monitor the number of currently open connections by storing the connection counter in Settings and exposing it through a new getOpenConnectionCount function.

Fixes https://github.com/yesodweb/wai/issues/651

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->