### PR TITLE
mime-types: add image/avif

### DIFF
--- a/mime-types/ChangeLog.md
+++ b/mime-types/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.2.2
+
+* Add IANA registered `image/avif` type for `.avif` images. [#1059](https://github.com/yesodweb/wai/pull/1059)
+
 ## 0.1.2.1
 
 * Change type for JavaScript files to `text/javascript` [#1051](https://github.com/yesodweb/wai/pull/1051)

--- a/mime-types/Network/Mime.hs
+++ b/mime-types/Network/Mime.hs
@@ -102,6 +102,8 @@ defaultExtensionMap =
     go (ext, mimeType) =
         Map.alter (Just . maybe [ext] (ext :)) mimeType
 
+-- | Find the current table in IANA media-types registry
+-- https://www.iana.org/assignments/media-types/media-types.xhtml
 mimeAscList :: [(Extension, MimeType)]
 mimeAscList =
     [ ("123", "application/vnd.lotus-1-2-3")
@@ -150,6 +152,7 @@ mimeAscList =
     , ("atx", "application/vnd.antix.game-component")
     , ("au", "audio/basic")
     , ("avi", "video/x-msvideo")
+    , ("avif", "image/avif")
     , ("aw", "application/applixware")
     , ("azf", "application/vnd.airzip.filesecure.azf")
     , ("azs", "application/vnd.airzip.filesecure.azs")


### PR DESCRIPTION
Greetings! Quick addition here, `.avif` → `image/avif`.

[AVIF][] is a new-ish open standard for images, based on the AV1 codec.

It is registered in IANA: https://www.iana.org/assignments/media-types/media-types.xhtml#image

[AVIF]: https://en.wikipedia.org/wiki/AVIF

Checklist:
- [x] Bumped the version number
- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

