### PR TITLE
Handle graceful shutdown for keep-alive connections

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -427,9 +427,10 @@ attachConn mysa ctx = do
     writeBufferRef <- I.newIORef writeBuffer
     -- Creating a cache for leftover input data.
     tls <- getTLSinfo ctx
-    return (conn writeBufferRef isH2, tls)
+    connActiveApps <- newCounter
+    return (conn writeBufferRef isH2 connActiveApps, tls)
   where
-    conn writeBufferRef isH2 =
+    conn writeBufferRef isH2 connActiveApps' =
         Connection
             { connSendMany = TLS.sendData ctx . L.fromChunks
             , connSendAll = sendall
@@ -440,6 +441,7 @@ attachConn mysa ctx = do
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
             , connMySockAddr = mysa
+            , connActiveApps = connActiveApps'
             }
       where
         sendall = TLS.sendData ctx . L.fromChunks . return

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -100,6 +100,7 @@ import Network.Wai.Handler.Warp.Internal
 import Network.Wai.Handler.WarpTLS.Internal
 import System.IO.Error (ioeGetErrorType, isEOFError)
 import System.Timeout (timeout)
+import Control.Concurrent.STM (TVar, readTVarIO, readTVar)
 
 ----------------------------------------------------------------
 
@@ -330,11 +331,12 @@ getter
     -> Settings
     -> Socket
     -> params
+    -> TVar Bool
     -> IO (IO (Connection, Transport), SockAddr)
-getter tlsset set@Settings{settingsAccept = accept'} sock params = do
+getter tlsset set@Settings{settingsAccept = accept'} sock params shuttingDown = do
     (s, sa) <- accept' sock
     setSocketCloseOnExec s
-    return (mkConn tlsset set s params, sa)
+    return (mkConn tlsset set s params shuttingDown, sa)
 
 mkConn
     :: TLS.TLSParams params
@@ -342,8 +344,9 @@ mkConn
     -> Settings
     -> Socket
     -> params
+    -> TVar Bool
     -> IO (Connection, Transport)
-mkConn tlsset set s params = do
+mkConn tlsset set s params shuttingDown = do
     let tm = settingsTimeout set * 1000000
     mbs <- timeout tm recvFirstBS
     case mbs of
@@ -353,8 +356,8 @@ mkConn tlsset set s params = do
     recvFirstBS = safeRecv s 4096 `onException` close s
     switch firstBS
         | S.null firstBS = close s >> throwIO ClientClosedConnectionPrematurely
-        | S.head firstBS == 0x16 = httpOverTls tlsset set s firstBS params
-        | otherwise = plainHTTP tlsset set s firstBS
+        | S.head firstBS == 0x16 = httpOverTls tlsset set s firstBS params shuttingDown
+        | otherwise = plainHTTP tlsset set s firstBS shuttingDown
 
 ----------------------------------------------------------------
 
@@ -376,13 +379,15 @@ httpOverTls
     -> Socket
     -> S.ByteString
     -> params
+    -> TVar Bool
     -> IO (Connection, Transport)
-httpOverTls TLSSettings{..} set s bs0 params =
+httpOverTls TLSSettings{..} set s bs0 params shuttingDown = do
     makeConn `onException` close s
   where
     makeConn = do
+        activeApps <- newCounter
         pool <- newBufferPool 2048 16384
-        rawRecvN <- makeRecvN bs0 $ receive s pool
+        rawRecvN <- makeRecvN bs0 $ makeRecv s (readTVar shuttingDown) activeApps pool
         let recvN = wrappedRecvN rawRecvN
         ctx <- TLS.contextNew (backend recvN) params
         TLS.contextHookSetLogging ctx tlsLogging
@@ -390,7 +395,7 @@ httpOverTls TLSSettings{..} set s bs0 params =
         mconn <- timeout tm $ do
             TLS.handshake ctx
             mysa <- getSocketName s
-            attachConn mysa ctx
+            attachConn mysa ctx shuttingDown activeApps
         case mconn of
           Nothing -> throwIO IncompleteHeaders
           Just conn -> return conn
@@ -419,16 +424,15 @@ httpOverTls TLSSettings{..} set s bs0 params =
 
 -- | Get "Connection" and "Transport" for a TLS connection that is already did the handshake.
 -- @since 3.4.7
-attachConn :: SockAddr -> TLS.Context -> IO (Connection, Transport)
-attachConn mysa ctx = do
+attachConn :: SockAddr -> TLS.Context -> TVar Bool -> Counter -> IO (Connection, Transport)
+attachConn mysa ctx shuttingDown activeApps = do
     h2 <- (== Just "h2") <$> TLS.getNegotiatedProtocol ctx
     isH2 <- I.newIORef h2
     writeBuffer <- createWriteBuffer 16384
     writeBufferRef <- I.newIORef writeBuffer
     -- Creating a cache for leftover input data.
     tls <- getTLSinfo ctx
-    connActiveApps <- newCounter
-    return (conn writeBufferRef isH2 connActiveApps, tls)
+    return (conn writeBufferRef isH2 activeApps, tls)
   where
     conn writeBufferRef isH2 connActiveApps' =
         Connection
@@ -442,6 +446,7 @@ attachConn mysa ctx = do
             , connHTTP2 = isH2
             , connMySockAddr = mysa
             , connActiveApps = connActiveApps'
+            , connShuttingDown = readTVarIO shuttingDown
             }
       where
         sendall = TLS.sendData ctx . L.fromChunks . return
@@ -509,10 +514,10 @@ tryIO = try
 ----------------------------------------------------------------
 
 plainHTTP
-    :: TLSSettings -> Settings -> Socket -> S.ByteString -> IO (Connection, Transport)
-plainHTTP TLSSettings{..} set s bs0 = case onInsecure of
+    :: TLSSettings -> Settings -> Socket -> S.ByteString -> TVar Bool -> IO (Connection, Transport)
+plainHTTP TLSSettings{..} set s bs0 shuttingDown = case onInsecure of
     AllowInsecure -> do
-        conn' <- socketConnection set s
+        conn' <- socketConnection set s shuttingDown
         cachedRef <- I.newIORef bs0
         let conn'' =
                 conn'

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.4.13
+Version:             3.4.14
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -24,6 +24,7 @@ Library
                    , warp                          >= 3.3.29   && < 3.5
                    , tls                           >= 2.1.3    && < 2.4
                    , network                       >= 2.2.1
+                   , stm                           >= 2.3
                    , streaming-commons
                    , tls-session-manager           >= 0.0.4
                    , recv                          >= 0.1.0   && < 0.2.0

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for warp
 
+## 3.4.12.1
+
+* Graceful shutdown waited for all connections to close, resulting in potentially indefinite waiting on keep-alive connections. It now proactively closes connections after waiting for current request processing to be completed.
+  [#1064] (https://github.com/yesodweb/wai/pull/1064)
+
 ## 3.4.12
 
 * Respond with `Connection: close` header if connection is to be closed after a request.

--- a/warp/Network/Wai/Handler/Warp/Counter.hs
+++ b/warp/Network/Wai/Handler/Warp/Counter.hs
@@ -8,6 +8,7 @@ module Network.Wai.Handler.Warp.Counter (
     decrease,
     waitForDecreased,
     getCount,
+    getCountSTM
 ) where
 
 import Control.Concurrent.STM
@@ -36,6 +37,9 @@ increase (Counter var) = atomically $ modifyTVar' var $ \x -> x + 1
 
 decrease :: Counter -> IO ()
 decrease (Counter var) = atomically $ modifyTVar' var $ \x -> x - 1
+
+getCountSTM :: Counter -> STM Int
+getCountSTM (Counter var) = readTVar var
 
 -- | Get the current count of open connections.
 --

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -120,6 +120,7 @@ http1server settings ii conn transport app addr th istatus src =
         -- See comment below referencing
         -- https://github.com/yesodweb/wai/issues/618
         | Just NoKeepAliveRequest <- fromException e = return ()
+        | Just ShutdownInProgress <- fromException e = return ()
         -- No valid request
         | Just (BadFirstLine _) <- fromException e = return ()
         | isAsyncException e = throwIO e

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -42,7 +42,7 @@ http2
     -> ByteString
     -> IO ()
 http2 settings ii conn transport app peersa th bs = do
-    rawRecvN <- makeRecvN bs $ connRecv conn
+    rawRecvN <- makeRecvN bs $ connRecv conn `E.catch` \ShutdownInProgress -> mempty
     writeBuffer <- readIORef $ connWriteBuffer conn
     -- This thread becomes the sender in http2 library.
     -- In the case of event source, one request comes and one

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -15,6 +15,8 @@ module Network.Wai.Handler.Warp.Internal (
     runSettingsConnection,
     runSettingsConnectionMaker,
     runSettingsConnectionMakerSecure,
+    -- TODO naming and order tidy-up
+    makeRecv,
     Transport (..),
 
     -- * Connection

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -9,6 +9,7 @@ module Network.Wai.Handler.Warp.Internal (
     -- * Connection counter
     Counter,
     getCount,
+    newCounter,
 
     -- * Low level run functions
     runSettingsConnection,
@@ -99,7 +100,7 @@ import Network.Socket.BufferPool
 import System.TimeManager
 
 import Network.Wai.Handler.Warp.Buffer
-import Network.Wai.Handler.Warp.Counter (Counter, getCount)
+import Network.Wai.Handler.Warp.Counter (Counter, getCount, newCounter)
 import Network.Wai.Handler.Warp.Date
 import Network.Wai.Handler.Warp.FdCache
 import Network.Wai.Handler.Warp.FileInfoCache

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -120,7 +120,9 @@ sendResponse
     -> IO Bool
     -- ^ Returing True if the connection is persistent.
 sendResponse settings conn ii th req reqidxhdr src response = do
-    hs <- addConnection . addAltSvc settings <$> addServerAndDate hs0
+    -- handle graceful shutdown
+    shuttingDown <- connShuttingDown conn
+    hs <- addConnection shuttingDown . addAltSvc settings <$> addServerAndDate hs0
     if hasBody s
         then do
             -- The response to HEAD does not have body.
@@ -134,12 +136,12 @@ sendResponse settings conn ii th req reqidxhdr src response = do
                 Nothing -> return ()
                 Just realStatus -> logger req realStatus mlen
             T.tickle th
-            return ret
+            return $ ret && not shuttingDown
         else do
             _ <- sendRsp conn ii th ver s hs rspidxhdr maxRspBufSize method RspNoBody
             logger req s Nothing
             T.tickle th
-            return isPersist
+            return $ isPersist && not shuttingDown
   where
     defServer = settingsServerName settings
     logger = settingsLogger settings
@@ -148,7 +150,7 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     s = responseStatus response
     hs0 = sanitizeHeaders $ responseHeaders response
     rspidxhdr = indexResponseHeader hs0
-    addConnection hs = if (hasBody s && not ret) || (not (hasBody s) && not isPersist)
+    addConnection shuttingDown hs = if shuttingDown || (hasBody s && not ret) || (not (hasBody s) && not isPersist)
                        then (H.hConnection, "close") : hs
                        else hs
     getdate = getDate ii

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -64,6 +64,7 @@ socketConnection _ s = do
     writeBufferRef <- newIORef writeBuffer
     isH2 <- newIORef False -- HTTP/1.x
     mysa <- getSocketName s
+    connActiveApps' <- newCounter
     return
         Connection
             { connSendMany = Sock.sendMany s
@@ -87,6 +88,7 @@ socketConnection _ s = do
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
             , connMySockAddr = mysa
+            , connActiveApps = connActiveApps'
             }
   where
     receive' sock pool = E.handle handler $ receive sock pool
@@ -366,10 +368,16 @@ fork set mkConn addr app counter ii = settingsFork set $ \unmask -> do
             $ \goingon ->
                 -- Actually serve this connection.  bracket with closeConn
                 -- above ensures the connection is closed.
-                when goingon $ serveConnection conn ii th addr transport set app
+                when goingon $ serveConnection conn ii th addr transport set (updateConnActiveApps conn)
 
     onOpen adr = increase counter >> settingsOnOpen set adr
     onClose adr _ = decrease counter >> settingsOnClose set adr
+
+    updateConnActiveApps conn req resp =
+        E.bracket_
+            (increase $ connActiveApps conn)
+            (decrease $ connActiveApps conn)
+            (app req resp)
 
 serveConnection
     :: Connection

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -27,6 +27,7 @@ import Network.Socket (
     getSocketName,
     setSocketOption,
     withSocketsDo,
+    waitReadSocketSTM,
  )
 #if MIN_VERSION_network(3,1,1)
 import Network.Socket (gracefulClose)
@@ -51,13 +52,30 @@ import Network.Wai.Handler.Warp.Imports hiding (readInt)
 import Network.Wai.Handler.Warp.SendFile
 import Network.Wai.Handler.Warp.Settings
 import Network.Wai.Handler.Warp.Types
+import Control.Concurrent.STM (atomically, writeTVar, check, readTVar, readTVarIO, newTVarIO, TVar, STM)
+import Data.Functor (($>))
+import Control.Exception (throwIO)
+
+makeRecv :: Socket -> STM Bool -> Counter -> BufferPool -> Recv
+makeRecv sock shuttingDown activeApps pool = do
+    sockWait <- waitReadSocketSTM sock
+    join . atomically $ do
+        isShuttingDown <- shuttingDown
+        appsInProgress <- getCountSTM activeApps
+        -- when shutting down and no apps in progress throw
+        check (isShuttingDown && appsInProgress < 1) $> throwIO ShutdownInProgress
+        <|>
+        -- else wait for socket readiness and do non-blocking read
+        sockWait $> recv
+    where
+        recv = receive sock pool
 
 -- | Creating 'Connection' for plain HTTP based on a given socket.
-socketConnection :: Settings -> Socket -> IO Connection
+socketConnection :: Settings -> Socket -> TVar Bool -> IO Connection
 #if MIN_VERSION_network(3,1,1)
-socketConnection set s = do
+socketConnection set s shuttingDown = do
 #else
-socketConnection _ s = do
+socketConnection _ s shuttingDown = do
 #endif
     bufferPool <- newBufferPool 2048 16384
     writeBuffer <- createWriteBuffer 16384
@@ -83,15 +101,16 @@ socketConnection _ s = do
 #else
             , connClose = close s
 #endif
-            , connRecv = receive' s bufferPool
+            , connRecv = receive' s bufferPool connActiveApps'
             , connRecvBuf = \_ _ -> return True -- obsoleted
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
             , connMySockAddr = mysa
             , connActiveApps = connActiveApps'
+            , connShuttingDown = readTVarIO shuttingDown
             }
   where
-    receive' sock pool = E.handle handler $ receive sock pool
+    receive' sock pool activeApps = E.handle handler $ makeRecv sock (readTVar shuttingDown) activeApps pool
       where
         handler :: E.IOException -> IO ByteString
         handler e
@@ -174,12 +193,12 @@ runSettingsSocket set@Settings{settingsAccept = accept'} socket app = do
     settingsInstallShutdownHandler set closeListenSocket
     runSettingsConnection set getConn app
   where
-    getConn = do
+    getConn shuttingDown = do
         (s, sa) <- accept' socket
         setSocketCloseOnExec s
         -- NoDelay causes an error for AF_UNIX.
         setSocketOption s NoDelay 1 `E.catch` throughAsync (return ())
-        conn <- socketConnection set s
+        conn <- socketConnection set s shuttingDown
         return (conn, sa)
 
     closeListenSocket = close socket
@@ -194,19 +213,19 @@ runSettingsSocket set@Settings{settingsAccept = accept'} socket app = do
 --
 -- Since 1.3.5
 runSettingsConnection
-    :: Settings -> IO (Connection, SockAddr) -> Application -> IO ()
+    :: Settings -> (TVar Bool -> IO (Connection, SockAddr)) -> Application -> IO ()
 runSettingsConnection set getConn app = runSettingsConnectionMaker set getConnMaker app
   where
-    getConnMaker = do
-        (conn, sa) <- getConn
+    getConnMaker shuttingDown = do
+        (conn, sa) <- getConn shuttingDown
         return (return conn, sa)
 
 -- | This modifies the connection maker so that it returns 'TCP' for 'Transport'
 -- (i.e. plain HTTP) then calls 'runSettingsConnectionMakerSecure'.
 runSettingsConnectionMaker
-    :: Settings -> IO (IO Connection, SockAddr) -> Application -> IO ()
+    :: Settings -> (TVar Bool -> IO (IO Connection, SockAddr)) -> Application -> IO ()
 runSettingsConnectionMaker x y =
-    runSettingsConnectionMakerSecure x (toTCP <$> y)
+    runSettingsConnectionMakerSecure x (fmap toTCP . y)
   where
     toTCP = first ((,TCP) <$>)
 
@@ -219,7 +238,7 @@ runSettingsConnectionMaker x y =
 --
 -- Since 2.1.4
 runSettingsConnectionMakerSecure
-    :: Settings -> IO (IO (Connection, Transport), SockAddr) -> Application -> IO ()
+    :: Settings -> (TVar Bool -> IO (IO (Connection, Transport), SockAddr)) -> Application -> IO ()
 runSettingsConnectionMakerSecure set getConnMaker app = do
     settingsBeforeMainLoop set
     counter <- case settingsConnectionCounter set of
@@ -265,24 +284,25 @@ withII set action =
 -- Our approach is explained in the comments below.
 acceptConnection
     :: Settings
-    -> IO (IO (Connection, Transport), SockAddr)
+    -> (TVar Bool -> IO (IO (Connection, Transport), SockAddr))
     -> Application
     -> Counter
     -> InternalInfo
     -> IO ()
 acceptConnection set getConnMaker app counter ii = do
+    shuttingDown <- newTVarIO False
     -- First mask all exceptions in acceptLoop. This is necessary to
     -- ensure that no async exception is throw between the call to
     -- acceptNewConnection and the registering of connClose.
     --
     -- acceptLoop can be broken by closing the listening socket.
-    void $ E.mask_ acceptLoop
+    void $ E.mask_ $ acceptLoop shuttingDown
     -- In some cases, we want to stop Warp here without graceful shutdown.
     -- So, async exceptions are allowed here.
     -- That's why `finally` is not used.
-    gracefulShutdown set counter
+    gracefulShutdown set shuttingDown counter
   where
-    acceptLoop = do
+    acceptLoop shuttingDown = do
         -- Allow async exceptions before receiving the next connection maker.
         E.allowInterrupt
 
@@ -293,25 +313,25 @@ acceptConnection set getConnMaker app counter ii = do
         -- expensive work should not be performed in the main event
         -- loop. An example of something expensive would be TLS
         -- negotiation.
-        mx <- acceptNewConnection
+        mx <- acceptNewConnection shuttingDown
         case mx of
             Nothing -> return ()
             Just (mkConn, addr) -> do
                 fork set mkConn addr app counter ii
-                acceptLoop
+                acceptLoop shuttingDown
 
-    acceptNewConnection = do
-        ex <- E.try getConnMaker
+    acceptNewConnection shuttingDown = do
+        ex <- E.try $ getConnMaker shuttingDown
         case ex of
             Right x -> return $ Just x
             Left e -> do
                 let getErrno (Errno cInt) = cInt
                     isErrno err = ioe_errno e == Just (getErrno err)
-                if | isErrno eCONNABORTED -> acceptNewConnection
+                if | isErrno eCONNABORTED -> acceptNewConnection shuttingDown
                    | isErrno eMFILE -> do
                        settingsOnException set Nothing $ E.toException e
                        waitForDecreased counter
-                       acceptNewConnection
+                       acceptNewConnection shuttingDown
                    | otherwise -> do
                        settingsOnException set Nothing $ E.toException e
                        return Nothing
@@ -437,8 +457,9 @@ setSocketCloseOnExec socket = do
     F.setFileCloseOnExec $ fromIntegral fd
 #endif
 
-gracefulShutdown :: Settings -> Counter -> IO ()
-gracefulShutdown set counter =
+gracefulShutdown :: Settings -> TVar Bool -> Counter -> IO ()
+gracefulShutdown set shuttingDown counter = do
+    atomically $ writeTVar shuttingDown True
     case settingsGracefulShutdownTimeout set of
         Nothing ->
             waitForZero counter

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -78,6 +78,13 @@ instance E.Exception ExceptionInsideResponseBody
 
 ----------------------------------------------------------------
 
+-- | Exception thrown shutdown is requested when waiting for request on a socket
+data ShutdownInProgress = ShutdownInProgress deriving (Show, Typeable)
+
+instance E.Exception ShutdownInProgress
+
+----------------------------------------------------------------
+
 -- | Data type to abstract file identifiers.
 --   On Unix, a file descriptor would be specified to make use of
 --   the file descriptor cache.
@@ -132,6 +139,8 @@ data Connection = Connection
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
     , connActiveApps :: Counter
+    , connShuttingDown :: IO Bool
+    -- ^ Is server shutting down?
     }
 
 getConnHTTP2 :: Connection -> IO Bool

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -20,6 +20,7 @@ import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
 import qualified Network.Wai.Handler.Warp.FileInfoCache as I
 import Network.Wai.Handler.Warp.Imports
+import Network.Wai.Handler.Warp.Counter (Counter)
 
 ----------------------------------------------------------------
 
@@ -130,6 +131,7 @@ data Connection = Connection
     , connHTTP2 :: IORef Bool
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
+    , connActiveApps :: Counter
     }
 
 getConnHTTP2 :: Connection -> IO Bool

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ImpredicativeTypes #-}
+
+module GracefulShutdownSpec (spec) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception (bracket)
+import Control.Monad (void)
+import Network.HTTP.Client
+import Network.HTTP.Types
+import Network.Socket (close)
+import Network.Wai (responseLBS)
+import Network.Wai.Handler.Warp
+import System.Timeout (timeout)
+import Test.Hspec
+import Data.Functor ((<&>))
+
+spec :: Spec
+spec = describe "graceful shutdown" $
+    it "serves the request in flight, then closes keep-alive connections and exits" $ do
+        shutdownSignal <- newEmptyMVar
+        allowResponse <- newEmptyMVar
+        receivedRequests <- newQSemN 0
+        allowSecondRequest <- newEmptyMVar
+
+        let installShutdownHandler closeListenSocket =
+                void . forkIO $ do
+                    readMVar shutdownSignal
+                    closeListenSocket
+
+            settings =
+                setInstallShutdownHandler installShutdownHandler defaultSettings
+
+            app _ respond = do
+                -- signal 1 received request
+                signalQSemN receivedRequests 1
+                -- block until signaled
+                readMVar allowResponse
+                respond $ responseLBS status200 [("Content-Length", "0")] ""
+            
+            client sendRequest = do
+                -- first request should return OK
+                response <- sendRequest
+                responseStatus response `shouldBe` ok200
+                lookup "Connection" (responseHeaders response) `shouldBe` Just "close"
+                -- wait with the second request
+                void $ readMVar allowSecondRequest
+                -- second request should end with connection refused
+                sendRequest `shouldThrow` connectionRefused
+
+        bracket openFreePort (close . snd) $ \(testPort, sock) ->
+            withAsync (runSettingsSocket settings sock app) $ \server -> do
+                manager <- newManager defaultManagerSettings
+                request <- parseRequest ("http://127.0.0.1:" ++ show testPort)
+                withAsync
+                    -- start all clients
+                    (replicateConcurrently_ numClients $
+                        client (httpNoBody request manager)) $ \clients -> do
+                    -- wait for all clients to send requests
+                    waitQSemN receivedRequests numClients
+                    -- shutdown the server before serving requests
+                    putMVar shutdownSignal ()
+                    -- wait a little - otherwise some requests might not get
+                    -- Connection: close response header
+                    threadDelay 100_000
+                    -- let requests be handled
+                    putMVar allowResponse ()
+                    -- server should exit
+                    timeout 5_000_000 (wait server) >>=
+                        maybe (expectationFailure "Timeout waiting for server shutdown") pure
+                    -- let clients proceed with the second request
+                    putMVar allowSecondRequest ()
+                    -- wait for all clients and propagate any exceptions
+                    wait clients
+                
+    where
+        -- set number of clients to the number of keep-alive connections
+        numClients = managerConnCount defaultManagerSettings
+        connectionRefused = \case
+            (HttpExceptionRequest _ (ConnectionFailure _)) -> True
+            _ -> False

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.12
+version:            3.4.13
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -183,6 +183,7 @@ test-suite spec
         ExceptionSpec
         FdCacheSpec
         FileSpec
+        GracefulShutdownSpec
         HTTP
         PackIntSpec
         ReadIntSpec


### PR DESCRIPTION
Implementing graceful shutdown for keep-alive sessions (HTTP 1.x). I would like to discuss the possibility to merge it.

Fixes #853 

- [x] Bumped the version number

- [x] Update the Changelog.md file with a link to your PR

TODO:
Not sure if the following needs to be done (Internal API was changed).

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
