### PR TITLE
Vlix/graceful shutdown

### DIFF
--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,5 +1,4 @@
 resolver: nightly
-compiler: ghc-9.12.2
 packages:
   - ./auto-update
   - ./mime-types

--- a/warp-tls/ChangeLog.md
+++ b/warp-tls/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 3.4.14
+
+* Build with `warp-3.4.13`.
+  [#1071](https://github.com/yesodweb/wai/pull/1071)
+
 ## 3.4.13
 
 * Introduced new smart constructor `tlsSettingsSni` to make it more convenient

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -59,6 +59,9 @@ module Network.Wai.Handler.WarpTLS (
 ) where
 
 import Control.Applicative ((<|>))
+#if MIN_VERSION_warp(3,4,13)
+import Control.Concurrent.STM (newTVarIO, TVar)
+#endif
 import Control.Exception (
     Exception,
     IOException,
@@ -90,9 +93,6 @@ import Network.Socket (
 #endif
     withSocketsDo,
  )
-#if MIN_VERSION_warp(3,4,13)
-import GHC.Conc (newTVarIO, TVar)
-#endif
 import Network.Socket.BufferPool
 import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
@@ -360,12 +360,10 @@ mkConn tlsset set s params = do
       Just bs -> switch bs
   where
     recvFirstBS = safeRecv s 4096 `onException` close s
-    switch firstBS =
-        case S.uncons firstBS of
-            Nothing -> close s >> throwIO ClientClosedConnectionPrematurely
-            Just (w8, _)
-                | w8 == 0x16 -> httpOverTls tlsset set s firstBS params
-                | otherwise -> plainHTTP tlsset set s firstBS
+    switch firstBS
+        | S.null firstBS = close s >> throwIO ClientClosedConnectionPrematurely
+        | S.head firstBS == 0x16 = httpOverTls tlsset set s firstBS params
+        | otherwise = plainHTTP tlsset set s firstBS
 
 ----------------------------------------------------------------
 

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -394,7 +394,7 @@ httpOverTls TLSSettings{..} set s bs0 params =
 #if MIN_VERSION_warp(3,4,13)
         appsInProgress <- newTVarIO 0
         (ss, _) <- makeServerState set
-        let recv = makeRecv s pool ss appsInProgress
+        let recv = makeGracefulRecv s pool ss appsInProgress
 #else
         let recv = receive s pool
 #endif

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -72,6 +72,7 @@ import Control.Exception (
     throwIO,
     try,
  )
+import qualified Control.Exception as E
 import Control.Monad (guard, void)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
@@ -89,7 +90,9 @@ import Network.Socket (
 #endif
     withSocketsDo,
  )
-import qualified Control.Exception as E
+#if MIN_VERSION_warp(3,4,13)
+import GHC.Conc (newTVarIO, TVar)
+#endif
 import Network.Socket.BufferPool
 import Network.Socket.ByteString (sendAll)
 import qualified Network.TLS as TLS
@@ -274,10 +277,16 @@ runTLSSocket'
     -> Socket
     -> Application
     -> IO ()
-runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock =
-    runSettingsConnectionMakerSecure set get
+runTLSSocket' tlsset@TLSSettings{..} set credentials mgr sock app = do
+#if MIN_VERSION_warp(3,4,13)
+    (_, newSettings) <- makeServerState set
+    let get = getter tlsset newSettings sock params
+    runSettingsConnectionMakerSecure newSettings get app
+#else
+    let get = getter tlsset set sock params
+    runSettingsConnectionMakerSecure set get app
+#endif
   where
-    get = getter tlsset set sock params
     params =
         TLS.defaultParamsServer
             { TLS.serverWantClientCert = tlsWantClientCert
@@ -351,10 +360,12 @@ mkConn tlsset set s params = do
       Just bs -> switch bs
   where
     recvFirstBS = safeRecv s 4096 `onException` close s
-    switch firstBS
-        | S.null firstBS = close s >> throwIO ClientClosedConnectionPrematurely
-        | S.head firstBS == 0x16 = httpOverTls tlsset set s firstBS params
-        | otherwise = plainHTTP tlsset set s firstBS
+    switch firstBS =
+        case S.uncons firstBS of
+            Nothing -> close s >> throwIO ClientClosedConnectionPrematurely
+            Just (w8, _)
+                | w8 == 0x16 -> httpOverTls tlsset set s firstBS params
+                | otherwise -> plainHTTP tlsset set s firstBS
 
 ----------------------------------------------------------------
 
@@ -382,7 +393,14 @@ httpOverTls TLSSettings{..} set s bs0 params =
   where
     makeConn = do
         pool <- newBufferPool 2048 16384
-        rawRecvN <- makeRecvN bs0 $ receive s pool
+#if MIN_VERSION_warp(3,4,13)
+        appsInProgress <- newTVarIO 0
+        (ss, _) <- makeServerState set
+        let recv = makeRecv s pool ss appsInProgress
+#else
+        let recv = receive s pool
+#endif
+        rawRecvN <- makeRecvN bs0 recv
         let recvN = wrappedRecvN rawRecvN
         ctx <- TLS.contextNew (backend recvN) params
         TLS.contextHookSetLogging ctx tlsLogging
@@ -390,7 +408,11 @@ httpOverTls TLSSettings{..} set s bs0 params =
         mconn <- timeout tm $ do
             TLS.handshake ctx
             mysa <- getSocketName s
+#if MIN_VERSION_warp(3,4,13)
+            attachConn mysa ctx appsInProgress
+#else
             attachConn mysa ctx
+#endif
         case mconn of
           Nothing -> throwIO IncompleteHeaders
           Just conn -> return conn
@@ -419,8 +441,16 @@ httpOverTls TLSSettings{..} set s bs0 params =
 
 -- | Get "Connection" and "Transport" for a TLS connection that is already did the handshake.
 -- @since 3.4.7
-attachConn :: SockAddr -> TLS.Context -> IO (Connection, Transport)
+attachConn
+    :: SockAddr
+    -> TLS.Context
+#if MIN_VERSION_warp(3,4,13)
+    -> TVar Int -> IO (Connection, Transport)
+attachConn mysa ctx appsInProgress = do
+#else
+    -> IO (Connection, Transport)
 attachConn mysa ctx = do
+#endif
     h2 <- (== Just "h2") <$> TLS.getNegotiatedProtocol ctx
     isH2 <- I.newIORef h2
     writeBuffer <- createWriteBuffer 16384
@@ -440,6 +470,9 @@ attachConn mysa ctx = do
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
             , connMySockAddr = mysa
+#if MIN_VERSION_warp(3,4,13)
+            , connAppsInProgress = appsInProgress
+#endif
             }
       where
         sendall = TLS.sendData ctx . L.fromChunks . return

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -1,5 +1,5 @@
 Name:                warp-tls
-Version:             3.4.13
+Version:             3.4.14
 Synopsis:            HTTP over TLS support for Warp via the TLS package
 License:             MIT
 License-file:        LICENSE

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -25,6 +25,7 @@ Library
                    , tls                           >= 2.1.3    && < 2.4
                    , network                       >= 2.2.1
                    , streaming-commons
+                   , stm                           >= 2.3
                    , tls-session-manager           >= 0.0.4
                    , recv                          >= 0.1.0   && < 0.2.0
   Exposed-modules:   Network.Wai.Handler.WarpTLS

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,9 +1,21 @@
 # ChangeLog for warp
 
+## 3.4.13
+
+* Change graceful shutdown logic to stop accepting data from idle connections,
+  but to wait for busy `Application`s, adding `Connection: close` headers to
+  responses if the server is shutting down.
+  This should make sure the server doesn't wait for idle keep-alive connections.
+* Expose a broader way to access internal state like the open connection `Counter`
+  and whether the server is currently `ShuttingDown` or not.
+  Users can use `makeSettingsAndServerState` to get a `ServerState` while
+  making `defaultSettings`.
+  [#1071](https://github.com/yesodweb/wai/pull/1071)
+
 ## 3.4.12
 
 * Respond with `Connection: close` header if connection is to be closed after a request.
-   [#958](https://github.com/yesodweb/wai/pull/958)
+  [#958](https://github.com/yesodweb/wai/pull/958)
 
 ## 3.4.11
 

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -92,13 +92,6 @@ module Network.Wai.Handler.Warp (
     getOpenConnectionCounter,
     getServerState,
 
-    -- ** Connection counter
-    --
-    -- /Deprecated in favor of 'ServerState'/
-    makeSettingsAndCounter,
-    Counter,
-    getCount,
-
     -- ** Internal server state
     --
     -- Creating 'Settings' with insight into the internal state of the server.
@@ -114,6 +107,13 @@ module Network.Wai.Handler.Warp (
     -- *** STM versions
     currentOpenConnectionsSTM,
     currentShuttingDownStateSTM,
+
+    -- ** Connection counter
+    --
+    -- /Deprecated in favor of 'ServerState'/
+    makeSettingsAndCounter,
+    Counter,
+    getCount,
 
     -- ** Exception handler
     defaultOnException,

--- a/warp/Network/Wai/Handler/Warp.hs
+++ b/warp/Network/Wai/Handler/Warp.hs
@@ -90,11 +90,30 @@ module Network.Wai.Handler.Warp (
     getGracefulCloseTimeout1,
     getGracefulCloseTimeout2,
     getOpenConnectionCounter,
+    getServerState,
 
     -- ** Connection counter
+    --
+    -- /Deprecated in favor of 'ServerState'/
     makeSettingsAndCounter,
     Counter,
     getCount,
+
+    -- ** Internal server state
+    --
+    -- Creating 'Settings' with insight into the internal state of the server.
+    --
+    -- When using 'makeSettingsAndServerState', you will receive the 'ServerState'
+    -- that will be used by @warp@ so that you can query things like the
+    -- 'currentOpenConnections', and 'currentShuttingDownState'.
+    ServerState,
+    makeSettingsAndServerState,
+    currentOpenConnections,
+    currentShuttingDownState,
+
+    -- *** STM versions
+    currentOpenConnectionsSTM,
+    currentShuttingDownStateSTM,
 
     -- ** Exception handler
     defaultOnException,
@@ -576,9 +595,21 @@ getGracefulCloseTimeout2 = settingsGracefulCloseTimeout2
 --
 -- See 'makeSettingsAndCounter' to create settings with a counter.
 --
+-- /DEPRECATED in favor of 'getServerState'/
+--
 -- Since 3.4.11
 getOpenConnectionCounter :: Settings -> Maybe Counter
 getOpenConnectionCounter = settingsConnectionCounter
+
+-- | Get the 'ServerState', if one was configured.
+-- Use things like 'currentOpenConnections' and 'currentShuttingDownState' to
+-- query information about the current state of the server.
+--
+-- See 'makeSettingsAndServerState' to create 'Settings' with a 'ServerState'.
+--
+-- Since 3.4.12
+getServerState :: Settings -> Maybe ServerState
+getServerState = settingsServerState
 
 #ifdef MIN_VERSION_crypton_x509
 -- | Getting information of client certificate.

--- a/warp/Network/Wai/Handler/Warp/Counter.hs
+++ b/warp/Network/Wai/Handler/Warp/Counter.hs
@@ -8,6 +8,7 @@ module Network.Wai.Handler.Warp.Counter (
     decrease,
     waitForDecreased,
     getCount,
+    getCountSTM,
 ) where
 
 import Control.Concurrent.STM
@@ -42,3 +43,9 @@ decrease (Counter var) = atomically $ modifyTVar' var $ \x -> x - 1
 -- Since 3.4.11
 getCount :: Counter -> IO Int
 getCount (Counter var) = readTVarIO var
+
+-- | Get the current count in an 'STM' transaction.
+--
+-- Since 3.4.13
+getCountSTM :: Counter -> STM Int
+getCountSTM (Counter tvar) = readTVar tvar

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -23,14 +23,7 @@ module Network.Wai.Handler.Warp.Internal (
 
     -- ** Server state
     ServerState,
-    newServerState,
     makeServerState,
-    currentOpenConnections,
-    currentShuttingDownState,
-
-    -- *** STM versions
-    currentOpenConnectionsSTM,
-    currentShuttingDownStateSTM,
 
     -- * Low level run functions
     runSettingsConnection,

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -5,10 +5,21 @@ module Network.Wai.Handler.Warp.Internal (
     Settings (..),
     ProxyProtocol (..),
     makeSettingsAndCounter,
+    makeSettingsAndServerState,
 
-    -- * Connection counter
+    -- ** Connection counter
     Counter,
     getCount,
+
+    -- ** Server state
+    ServerState,
+    newServerState,
+    currentOpenConnections,
+    currentShuttingDownState,
+
+    -- *** STM versions
+    currentOpenConnectionsSTM,
+    currentShuttingDownStateSTM,
 
     -- * Low level run functions
     runSettingsConnection,

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -14,6 +14,7 @@ module Network.Wai.Handler.Warp.Internal (
     -- ** Server state
     ServerState,
     newServerState,
+    makeServerState,
     currentOpenConnections,
     currentShuttingDownState,
 
@@ -33,6 +34,7 @@ module Network.Wai.Handler.Warp.Internal (
 
     -- ** Receive
     Recv,
+    makeRecv,
     RecvBuf,
 
     -- ** Buffer

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -1,5 +1,15 @@
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
+-- |
+-- __IMPORTANT NOTICE__
+--
+-- This module exports internals mainly to provide the @warp-tls@ package
+-- with tools to implement what it needs to. This module\/API should /NOT/ be
+-- expected to remain stable at all, even between minor releases.
+--
+-- If you see a use case for these functions or types for other purposes,
+-- please create an issue in the repository so that we might add it to the
+-- main 'Network.Wai.Handler.Warp' API.
 module Network.Wai.Handler.Warp.Internal (
     -- * Settings
     Settings (..),

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -34,7 +34,7 @@ module Network.Wai.Handler.Warp.Internal (
 
     -- ** Receive
     Recv,
-    makeRecv,
+    makeGracefulRecv,
     RecvBuf,
 
     -- ** Buffer

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -123,6 +123,8 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     isShuttingDown <-
         case settingsServerState settings of
             Just serverState -> currentShuttingDownState serverState
+            -- Should never be reached!
+            -- (cf. 'makeServerState' in 'runSettingsConnectionMakerSecure')
             Nothing -> pure False
     let shouldPersist =
             not isShuttingDown && if hasBody s then ret else isPersist

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -161,7 +161,7 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     (isKeepAlive, needsChunked) = infoFromResponse rspidxhdr (isPersist, isChunked)
     method = requestMethod req
     isHead = method == H.methodHead
-    !rsp = case response of
+    rsp = case response of
         ResponseFile _ _ path mPart -> RspFile path mPart reqidxhdr (T.tickle th)
         ResponseBuilder _ _ b
             | isHead -> RspNoBody

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -120,6 +120,14 @@ sendResponse
     -> IO Bool
     -- ^ Returing True if the connection is persistent.
 sendResponse settings conn ii th req reqidxhdr src response = do
+    isShuttingDown <-
+        case settingsServerState settings of
+            Just serverState -> currentShuttingDownState serverState
+            Nothing -> pure False
+    let shouldPersist =
+            not isShuttingDown && if hasBody s then ret else isPersist
+        addConnection hs =
+            if shouldPersist then hs else (H.hConnection, "close") : hs
     hs <- addConnection . addAltSvc settings <$> addServerAndDate hs0
     if hasBody s
         then do
@@ -133,13 +141,11 @@ sendResponse settings conn ii th req reqidxhdr src response = do
             case ms of
                 Nothing -> return ()
                 Just realStatus -> logger req realStatus mlen
-            T.tickle th
-            return ret
         else do
             _ <- sendRsp conn ii th ver s hs rspidxhdr maxRspBufSize method RspNoBody
             logger req s Nothing
-            T.tickle th
-            return isPersist
+    T.tickle th
+    return shouldPersist
   where
     defServer = settingsServerName settings
     logger = settingsLogger settings
@@ -148,9 +154,6 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     s = responseStatus response
     hs0 = sanitizeHeaders $ responseHeaders response
     rspidxhdr = indexResponseHeader hs0
-    addConnection hs = if (hasBody s && not ret) || (not (hasBody s) && not isPersist)
-                       then (H.hConnection, "close") : hs
-                       else hs
     getdate = getDate ii
     addServerAndDate = addDate getdate rspidxhdr . addServer defServer rspidxhdr
     (isPersist, isChunked0) = infoFromRequest req reqidxhdr
@@ -158,7 +161,7 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     (isKeepAlive, needsChunked) = infoFromResponse rspidxhdr (isPersist, isChunked)
     method = requestMethod req
     isHead = method == H.methodHead
-    rsp = case response of
+    !rsp = case response of
         ResponseFile _ _ path mPart -> RspFile path mPart reqidxhdr (T.tickle th)
         ResponseBuilder _ _ b
             | isHead -> RspNoBody

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -57,12 +57,13 @@ import Network.Wai.Handler.Warp.ShuttingDown (ShuttingDown, readShuttingDownSTM,
 import Network.Wai.Handler.Warp.Types
 
 -- | Creating 'Connection' for plain HTTP based on a given socket.
-socketConnection :: Settings -> Socket -> ShuttingDown -> IO Connection
-#if MIN_VERSION_network(3,1,1)
-socketConnection set s shuttingDown = do
-#else
-socketConnection _ s shuttingDown = do
-#endif
+--
+-- (N.B. make sure the 'Settings' have an initialized 'ServerState' to guarantee
+-- a graceful shutdown)
+socketConnection :: Settings -> Socket -> IO Connection
+socketConnection set s = do
+    (ss, _) <- makeServerState set
+    let shuttingDown = serverShuttingDown ss
     bufferPool <- newBufferPool 2048 16384
     writeBuffer <- createWriteBuffer 16384
     writeBufferRef <- newIORef writeBuffer
@@ -87,7 +88,7 @@ socketConnection _ s shuttingDown = do
 #else
             , connClose = close s
 #endif
-            , connRecv = receive' bufferPool appsInProgress
+            , connRecv = receive' bufferPool shuttingDown appsInProgress
             , connRecvBuf = \_ _ -> return True -- obsoleted
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
@@ -95,7 +96,7 @@ socketConnection _ s shuttingDown = do
             , connAppsInProgress = appsInProgress
             }
   where
-    receive' bufferPool appsInProgress =
+    receive' bufferPool shuttingDown appsInProgress =
         E.handle handler $ makeRecv s bufferPool shuttingDown appsInProgress
       where
         handler :: E.IOException -> IO ByteString
@@ -193,16 +194,15 @@ runSettings set app =
 runSettingsSocket :: Settings -> Socket -> Application -> IO ()
 runSettingsSocket oldSettings@Settings{settingsAccept = accept'} socket app = do
     settingsInstallShutdownHandler oldSettings closeListenSocket
-    (ServerState{serverShuttingDown}, newSettings) <- makeServerState oldSettings
-    let mkConn = getConn newSettings serverShuttingDown
-    runSettingsConnection newSettings mkConn app
+    (_, newSettings) <- makeServerState oldSettings
+    runSettingsConnection newSettings (getConn newSettings) app
   where
-    getConn newSettings shuttingDown = do
+    getConn set = do
         (s, sa) <- accept' socket
         setSocketCloseOnExec s
         -- NoDelay causes an error for AF_UNIX.
         setSocketOption s NoDelay 1 `E.catch` throughAsync (return ())
-        conn <- socketConnection newSettings s shuttingDown
+        conn <- socketConnection set s
         return (conn, sa)
 
     closeListenSocket = close socket

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -20,6 +20,7 @@ import Control.Concurrent.STM (
  )
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
+import Data.Functor (($>))
 import Data.IORef (newIORef, readIORef)
 import Data.Streaming.Network (bindPortTCP)
 import Foreign.C.Error (Errno (..), eCONNABORTED, eMFILE)
@@ -138,13 +139,13 @@ socketConnection set s = do
 makeRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
 makeRecv sock pool ss appsInProgress = do
     sockWait <- waitReadSocketSTM sock
-    ok <- atomically $
-        -- when shutting down throw
-        (checkShutdown >> pure False)
+    isShuttingDown <- atomically $
+        -- when shutting down
+        (checkShutdown $> True)
         <|>
         -- else wait for socket readiness and do non-blocking read
-        (sockWait >> pure True)
-    if ok then recv else pure ""
+        (sockWait $> False)
+    if isShuttingDown then pure "" else recv
   where
     recv = receive sock pool
     checkShutdown = do

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -104,7 +104,7 @@ socketConnection set s = do
             }
   where
     receive' bufferPool ss appsInProgress =
-        E.handle handler $ makeRecv s bufferPool ss appsInProgress
+        E.handle handler $ makeGracefulRecv s bufferPool ss appsInProgress
       where
         handler :: E.IOException -> IO ByteString
         handler e
@@ -136,8 +136,12 @@ socketConnection set s = do
             E.throwIO
             $ Sock.sendAll sock bs
 
-makeRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
-makeRecv sock pool ss appsInProgress = do
+-- | Create a 'Recv' using 'Network.Socket.BufferPool.Recv.receive', but make
+-- it non-blocking with 'waitReadSocketSTM' /AND/ cut off receiving any bytes
+-- when the server is shutting down and there are no more 'Application's
+-- actively using this 'Socket'.
+makeGracefulRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
+makeGracefulRecv sock pool ss appsInProgress = do
     sockWait <- waitReadSocketSTM sock
     isShuttingDown <- atomically $
         -- when shutting down

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -10,7 +10,14 @@
 module Network.Wai.Handler.Warp.Run where
 
 import Control.Arrow (first)
-import Control.Concurrent.STM (atomically, check)
+import Control.Concurrent.STM (
+    TVar,
+    atomically,
+    check,
+    modifyTVar',
+    newTVarIO,
+    readTVar,
+ )
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (newIORef, readIORef)
@@ -53,7 +60,7 @@ import Network.Wai.Handler.Warp.HTTP2.Types (isHTTP2)
 import Network.Wai.Handler.Warp.Imports hiding (readInt)
 import Network.Wai.Handler.Warp.SendFile (sendFile)
 import Network.Wai.Handler.Warp.Settings
-import Network.Wai.Handler.Warp.ShuttingDown (ShuttingDown, readShuttingDownSTM, writeShuttingDown)
+import Network.Wai.Handler.Warp.ShuttingDown (writeShuttingDown)
 import Network.Wai.Handler.Warp.Types
 
 -- | Creating 'Connection' for plain HTTP based on a given socket.
@@ -63,13 +70,12 @@ import Network.Wai.Handler.Warp.Types
 socketConnection :: Settings -> Socket -> IO Connection
 socketConnection set s = do
     (ss, _) <- makeServerState set
-    let shuttingDown = serverShuttingDown ss
     bufferPool <- newBufferPool 2048 16384
     writeBuffer <- createWriteBuffer 16384
     writeBufferRef <- newIORef writeBuffer
     isH2 <- newIORef False -- HTTP/1.x
     mysa <- getSocketName s
-    appsInProgress <- newCounter
+    appsInProgress <- newTVarIO 0
     return
         Connection
             { connSendMany = Sock.sendMany s
@@ -88,7 +94,7 @@ socketConnection set s = do
 #else
             , connClose = close s
 #endif
-            , connRecv = receive' bufferPool shuttingDown appsInProgress
+            , connRecv = receive' bufferPool ss appsInProgress
             , connRecvBuf = \_ _ -> return True -- obsoleted
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
@@ -96,8 +102,8 @@ socketConnection set s = do
             , connAppsInProgress = appsInProgress
             }
   where
-    receive' bufferPool shuttingDown appsInProgress =
-        E.handle handler $ makeRecv s bufferPool shuttingDown appsInProgress
+    receive' bufferPool ss appsInProgress =
+        E.handle handler $ makeRecv s bufferPool ss appsInProgress
       where
         handler :: E.IOException -> IO ByteString
         handler e
@@ -129,8 +135,8 @@ socketConnection set s = do
             E.throwIO
             $ Sock.sendAll sock bs
 
-makeRecv :: Socket -> BufferPool -> ShuttingDown -> Counter -> Recv
-makeRecv sock pool shuttingDown appsInProgress = do
+makeRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
+makeRecv sock pool ss appsInProgress = do
     sockWait <- waitReadSocketSTM sock
     ok <- atomically $
         -- when shutting down throw
@@ -142,8 +148,8 @@ makeRecv sock pool shuttingDown appsInProgress = do
   where
     recv = receive sock pool
     checkShutdown = do
-       check =<< readShuttingDownSTM shuttingDown
-       check . (<= 0) =<< getCountSTM appsInProgress
+       check =<< currentShuttingDownStateSTM ss
+       check . (<= 0) =<< readTVar appsInProgress
 
 -- | Run an 'Application' on the given port.
 -- This calls 'runSettings' with 'defaultSettings'.
@@ -418,8 +424,8 @@ serveConnection conn ii th origAddr transport settings app = do
     let appsInProgress = connAppsInProgress conn
         app' req rsp =
             E.bracket_
-                (increase appsInProgress)
-                (decrease appsInProgress)
+                (atomically $ modifyTVar' appsInProgress $ (+ 1))
+                (atomically $ modifyTVar' appsInProgress $ \i -> (i - 1))
                 $ app req rsp
     if settingsHTTP2Enabled settings && h2
         then do

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
-{-# LANGUAGE MultiWayIf #-}
 
 module Network.Wai.Handler.Warp.Run where
 
 import Control.Arrow (first)
+import Control.Concurrent.STM (atomically, check)
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (newIORef, readIORef)
@@ -26,6 +28,7 @@ import Network.Socket (
 #endif
     getSocketName,
     setSocketOption,
+    waitReadSocketSTM,
     withSocketsDo,
  )
 #if MIN_VERSION_network(3,1,1)
@@ -39,7 +42,7 @@ import System.IO.Error (ioeGetErrorType)
 import qualified System.TimeManager as T
 import System.Timeout (timeout)
 
-import Network.Wai.Handler.Warp.Buffer
+import Network.Wai.Handler.Warp.Buffer (createWriteBuffer)
 import Network.Wai.Handler.Warp.Counter
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
@@ -48,22 +51,24 @@ import Network.Wai.Handler.Warp.HTTP1 (http1)
 import Network.Wai.Handler.Warp.HTTP2 (http2)
 import Network.Wai.Handler.Warp.HTTP2.Types (isHTTP2)
 import Network.Wai.Handler.Warp.Imports hiding (readInt)
-import Network.Wai.Handler.Warp.SendFile
+import Network.Wai.Handler.Warp.SendFile (sendFile)
 import Network.Wai.Handler.Warp.Settings
+import Network.Wai.Handler.Warp.ShuttingDown (ShuttingDown, readShuttingDownSTM, writeShuttingDown)
 import Network.Wai.Handler.Warp.Types
 
 -- | Creating 'Connection' for plain HTTP based on a given socket.
-socketConnection :: Settings -> Socket -> IO Connection
+socketConnection :: Settings -> Socket -> ShuttingDown -> IO Connection
 #if MIN_VERSION_network(3,1,1)
-socketConnection set s = do
+socketConnection set s shuttingDown = do
 #else
-socketConnection _ s = do
+socketConnection _ s shuttingDown = do
 #endif
     bufferPool <- newBufferPool 2048 16384
     writeBuffer <- createWriteBuffer 16384
     writeBufferRef <- newIORef writeBuffer
     isH2 <- newIORef False -- HTTP/1.x
     mysa <- getSocketName s
+    appsInProgress <- newCounter
     return
         Connection
             { connSendMany = Sock.sendMany s
@@ -82,14 +87,16 @@ socketConnection _ s = do
 #else
             , connClose = close s
 #endif
-            , connRecv = receive' s bufferPool
+            , connRecv = receive' bufferPool appsInProgress
             , connRecvBuf = \_ _ -> return True -- obsoleted
             , connWriteBuffer = writeBufferRef
             , connHTTP2 = isH2
             , connMySockAddr = mysa
+            , connAppsInProgress = appsInProgress
             }
   where
-    receive' sock pool = E.handle handler $ receive sock pool
+    receive' bufferPool appsInProgress =
+        E.handle handler $ makeRecv s bufferPool shuttingDown appsInProgress
       where
         handler :: E.IOException -> IO ByteString
         handler e
@@ -120,6 +127,22 @@ socketConnection _ s = do
             )
             E.throwIO
             $ Sock.sendAll sock bs
+
+makeRecv :: Socket -> BufferPool -> ShuttingDown -> Counter -> Recv
+makeRecv sock pool shuttingDown appsInProgress = do
+    sockWait <- waitReadSocketSTM sock
+    ok <- atomically $
+        -- when shutting down throw
+        (checkShutdown >> pure False)
+        <|>
+        -- else wait for socket readiness and do non-blocking read
+        (sockWait >> pure True)
+    if ok then recv else pure ""
+  where
+    recv = receive sock pool
+    checkShutdown = do
+       check =<< readShuttingDownSTM shuttingDown
+       check . (<= 0) =<< getCountSTM appsInProgress
 
 -- | Run an 'Application' on the given port.
 -- This calls 'runSettings' with 'defaultSettings'.
@@ -168,16 +191,18 @@ runSettings set app =
 -- Note that the 'settingsPort' will still be passed to 'Application's via the
 -- 'serverPort' record.
 runSettingsSocket :: Settings -> Socket -> Application -> IO ()
-runSettingsSocket set@Settings{settingsAccept = accept'} socket app = do
-    settingsInstallShutdownHandler set closeListenSocket
-    runSettingsConnection set getConn app
+runSettingsSocket oldSettings@Settings{settingsAccept = accept'} socket app = do
+    settingsInstallShutdownHandler oldSettings closeListenSocket
+    (ServerState{serverShuttingDown}, newSettings) <- makeServerState oldSettings
+    let mkConn = getConn newSettings serverShuttingDown
+    runSettingsConnection newSettings mkConn app
   where
-    getConn = do
+    getConn newSettings shuttingDown = do
         (s, sa) <- accept' socket
         setSocketCloseOnExec s
         -- NoDelay causes an error for AF_UNIX.
         setSocketOption s NoDelay 1 `E.catch` throughAsync (return ())
-        conn <- socketConnection set s
+        conn <- socketConnection newSettings s shuttingDown
         return (conn, sa)
 
     closeListenSocket = close socket
@@ -218,12 +243,11 @@ runSettingsConnectionMaker x y =
 -- Since 2.1.4
 runSettingsConnectionMakerSecure
     :: Settings -> IO (IO (Connection, Transport), SockAddr) -> Application -> IO ()
-runSettingsConnectionMakerSecure set getConnMaker app = do
-    settingsBeforeMainLoop set
-    counter <- case settingsConnectionCounter set of
-        Just c -> pure c
-        Nothing -> newCounter
-    withII set $ acceptConnection set getConnMaker app counter
+runSettingsConnectionMakerSecure oldSettings getConnMaker app = do
+    settingsBeforeMainLoop oldSettings
+    (ServerState{serverConnectionCounter}, newSettings) <- makeServerState oldSettings
+    withII newSettings $
+        acceptConnection newSettings getConnMaker app serverConnectionCounter
 
 -- | Running an action with internal info.
 --
@@ -391,13 +415,19 @@ serveConnection conn ii th origAddr transport settings app = do
                 if "PRI " `S.isPrefixOf` bs0
                     then return (True, bs0)
                     else return (False, bs0)
+    let appsInProgress = connAppsInProgress conn
+        app' req rsp =
+            E.bracket_
+                (increase appsInProgress)
+                (decrease appsInProgress)
+                $ app req rsp
     if settingsHTTP2Enabled settings && h2
         then do
             labelThread tid ("Warp HTTP/2 " ++ show origAddr)
-            http2 settings ii conn transport app origAddr th bs
+            http2 settings ii conn transport app' origAddr th bs
         else do
             labelThread tid ("Warp HTTP/1.1 " ++ show origAddr)
-            http1 settings ii conn transport app origAddr th bs
+            http1 settings ii conn transport app' origAddr th bs
   where
     recv4 bs0 = do
         bs1 <- connRecv conn
@@ -430,11 +460,17 @@ setSocketCloseOnExec socket = do
 #endif
 
 gracefulShutdown :: Settings -> Counter -> IO ()
-gracefulShutdown set counter =
+gracefulShutdown set counter = do
+    setShuttingDown
     case settingsGracefulShutdownTimeout set of
         Nothing ->
             waitForZero counter
         (Just seconds) ->
             void (timeout (seconds * microsPerSecond) (waitForZero counter))
-          where
-            microsPerSecond = 1000000
+  where
+    microsPerSecond = 1000000
+    setShuttingDown =
+        case settingsServerState set of
+            Nothing -> pure ()
+            Just ServerState{serverShuttingDown} ->
+                writeShuttingDown serverShuttingDown True

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -9,13 +9,13 @@
 
 module Network.Wai.Handler.Warp.Settings where
 
-import Control.Exception (SomeException(..), fromException, throw)
+import Control.Concurrent.STM (STM)
+import Control.Exception (SomeException (..), fromException, throw)
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as C8
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import GHC.Conc (STM)
 import GHC.Exts (fork#)
 import GHC.IO (IO (IO), unsafeUnmask)
 import GHC.IO.Exception (IOErrorType (..))
@@ -193,6 +193,8 @@ data Settings = Settings
     --
     -- Default: 'Nothing' (warp creates an internal counter)
     --
+    -- /DEPRECATED in favor of 'settingsServerState'/
+    --
     -- Since 3.4.11
     , settingsServerState :: Maybe ServerState
     -- ^ Internal read-only server state.
@@ -282,7 +284,7 @@ currentShuttingDownState = readShuttingDown . serverShuttingDown
 
 -- | Check if the server is currently shutting down in an 'STM' transaction.
 --
--- (This way you can have a thread wait for server shutdown with 'GHC.Conc.retry')
+-- (This way you can have a thread wait for server shutdown with 'Control.Concurrent.STM.retry')
 --
 -- > False: Server is not shutting down
 -- > True:  Server is shutting down or has shut down.

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -15,6 +15,7 @@ import qualified Data.ByteString.Char8 as C8
 import Data.Streaming.Network (HostPreference)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import GHC.Conc (STM)
 import GHC.Exts (fork#)
 import GHC.IO (IO (IO), unsafeUnmask)
 import GHC.IO.Exception (IOErrorType (..))
@@ -25,8 +26,14 @@ import System.IO (stderr)
 import System.IO.Error (ioeGetErrorType)
 import System.TimeManager
 
-import Network.Wai.Handler.Warp.Counter (Counter, newCounter)
+import Network.Wai.Handler.Warp.Counter (Counter, getCount, newCounter, getCountSTM)
 import Network.Wai.Handler.Warp.Imports
+import Network.Wai.Handler.Warp.ShuttingDown (
+    ShuttingDown,
+    newShuttingDown,
+    readShuttingDown,
+    readShuttingDownSTM,
+ )
 import Network.Wai.Handler.Warp.Types
 #if WINDOWS
 import Network.Wai.Handler.Warp.Windows (windowsThreadBlockHack)
@@ -187,6 +194,15 @@ data Settings = Settings
     -- Default: 'Nothing' (warp creates an internal counter)
     --
     -- Since 3.4.11
+    , settingsServerState :: Maybe ServerState
+    -- ^ Internal read-only server state.
+    -- Use 'makeSettingsAndServerState' to gain access to the state of the server.
+    -- Using functions like 'currentOpenConnections' or 'currentShuttingDownState'
+    -- to gain insight into the current state of the server.
+    --
+    -- Default: 'Nothing' (warp creates its own internal state)
+    --
+    -- Since 3.4.13
     }
 
 -- | Specify usage of the PROXY protocol.
@@ -197,6 +213,83 @@ data ProxyProtocol
       ProxyProtocolRequired
     | -- | See @setProxyProtocolOptional@.
       ProxyProtocolOptional
+
+-- | Internal read-only state of the server
+--
+-- Since 3.4.13
+data ServerState = ServerState
+    { serverConnectionCounter :: Counter
+    , serverShuttingDown :: ShuttingDown
+    }
+
+-- | Takes 'Settings' and either returns the 'ServerState'
+-- that was already in there, or creates a new 'ServerState'.
+--
+-- The returned 'Settings' will always contain a 'ServerState'.
+--
+-- This makes it idempotent if care is taken that the @oldSettings@
+-- are not used after using this function.
+--
+-- Since 3.4.13
+makeServerState :: Settings -> IO (ServerState, Settings)
+makeServerState oldSettings =
+    case settingsServerState oldSettings of
+        Just serverState -> pure (serverState, oldSettings)
+        Nothing -> do
+            serverState <- newServerState
+            let counter = serverConnectionCounter serverState
+            pure
+                ( serverState
+                , oldSettings
+                    { settingsServerState = Just serverState
+                    , settingsConnectionCounter = Just counter
+                    }
+                )
+
+-- | Initialize a 'ServerState'
+--
+-- Since 3.4.13
+newServerState :: IO ServerState
+newServerState = do
+    counter <- newCounter
+    shuttingDown <- newShuttingDown
+    pure
+        ServerState
+            { serverConnectionCounter = counter
+            , serverShuttingDown = shuttingDown
+            }
+
+-- | Get the currently open connections of the server.
+--
+-- Since 3.4.13
+currentOpenConnections :: ServerState -> IO Int
+currentOpenConnections = getCount . serverConnectionCounter
+
+-- | Get the currently open connections of the server in an 'STM' transaction.
+--
+-- Since 3.4.13
+currentOpenConnectionsSTM :: ServerState -> STM Int
+currentOpenConnectionsSTM = getCountSTM . serverConnectionCounter
+
+-- | Check if the server is currently shutting down.
+--
+-- > False: Server is not shutting down
+-- > True:  Server is shutting down or has shut down.
+--
+-- Since 3.4.13
+currentShuttingDownState :: ServerState -> IO Bool
+currentShuttingDownState = readShuttingDown . serverShuttingDown
+
+-- | Check if the server is currently shutting down in an 'STM' transaction.
+--
+-- (This way you can have a thread wait for server shutdown with 'GHC.Conc.retry')
+--
+-- > False: Server is not shutting down
+-- > True:  Server is shutting down or has shut down.
+--
+-- Since 3.4.13
+currentShuttingDownStateSTM :: ServerState -> STM Bool
+currentShuttingDownStateSTM = readShuttingDownSTM . serverShuttingDown
 
 -- | The default settings for the Warp server. See the individual settings for
 -- the default value.
@@ -232,16 +325,27 @@ defaultSettings =
         , settingsAltSvc = Nothing
         , settingsMaxBuilderResponseBufferSize = 1049000000
         , settingsConnectionCounter = Nothing
+        , settingsServerState = Nothing
         }
 
--- | Create 'Settings' with a connection counter.
+-- | Create 'defaultSettings' with a connection counter.
 -- Use 'getCount' on the returned 'Counter' to check open connections.
+--
+-- /DEPRECATED in favor of 'makeSettingsAndServerState'/
 --
 -- Since 3.4.11
 makeSettingsAndCounter :: IO (Counter, Settings)
 makeSettingsAndCounter = do
-    counter <- newCounter
-    pure (counter, defaultSettings{settingsConnectionCounter = Just counter})
+    (serverState, settings) <- makeSettingsAndServerState
+    pure (serverConnectionCounter serverState, settings)
+
+-- | Create 'defaultSettings' with a 'ServerState'.
+-- Use functions like 'currentOpenConnections' and 'currentShuttingDownState'
+-- to gain insight into the state of the server.
+--
+-- Since 3.4.13
+makeSettingsAndServerState :: IO (ServerState, Settings)
+makeSettingsAndServerState = makeServerState defaultSettings
 
 -- | Apply the logic provided by 'defaultOnException' to determine if an
 -- exception should be shown or not. The goal is to hide exceptions which occur

--- a/warp/Network/Wai/Handler/Warp/ShuttingDown.hs
+++ b/warp/Network/Wai/Handler/Warp/ShuttingDown.hs
@@ -1,0 +1,34 @@
+-- Most important is to not export the data constructor
+-- and to not expose 'writeShuttingDown' to the end user.
+module Network.Wai.Handler.Warp.ShuttingDown (
+    ShuttingDown,
+    newShuttingDown,
+    readShuttingDown,
+    readShuttingDownSTM,
+    writeShuttingDown,
+) where
+
+import GHC.Conc (
+    STM,
+    TVar,
+    atomically,
+    newTVarIO,
+    readTVar,
+    readTVarIO,
+    writeTVar,
+ )
+
+newtype ShuttingDown = ShuttingDown (TVar Bool)
+
+newShuttingDown :: IO ShuttingDown
+newShuttingDown = ShuttingDown <$> newTVarIO False
+
+readShuttingDown :: ShuttingDown -> IO Bool
+readShuttingDown (ShuttingDown var) = readTVarIO var
+
+readShuttingDownSTM :: ShuttingDown -> STM Bool
+readShuttingDownSTM (ShuttingDown var) = readTVar var
+
+writeShuttingDown :: ShuttingDown -> Bool -> IO ()
+writeShuttingDown (ShuttingDown var) b =
+    atomically $ writeTVar var b

--- a/warp/Network/Wai/Handler/Warp/ShuttingDown.hs
+++ b/warp/Network/Wai/Handler/Warp/ShuttingDown.hs
@@ -1,4 +1,4 @@
--- Most important is to not export the data constructor
+-- Most important is to not export the data constructor from this module
 -- and to not expose 'writeShuttingDown' to the end user.
 module Network.Wai.Handler.Warp.ShuttingDown (
     ShuttingDown,
@@ -8,7 +8,7 @@ module Network.Wai.Handler.Warp.ShuttingDown (
     writeShuttingDown,
 ) where
 
-import GHC.Conc (
+import Control.Concurrent.STM (
     STM,
     TVar,
     atomically,

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -16,6 +16,7 @@ import Network.Socket.BufferPool
 import System.Posix.Types (Fd)
 import qualified System.TimeManager as T
 
+import Network.Wai.Handler.Warp.Counter (Counter)
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
 import qualified Network.Wai.Handler.Warp.FileInfoCache as I
@@ -130,6 +131,10 @@ data Connection = Connection
     , connHTTP2 :: IORef Bool
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
+    , connAppsInProgress :: Counter
+    -- ^ Amount of apps currently in progress on this connection.
+    --
+    -- /HTTP2 can handle more than one request concurrently/
     }
 
 getConnHTTP2 :: Connection -> IO Bool

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -4,14 +4,14 @@
 
 module Network.Wai.Handler.Warp.Types where
 
+import Control.Concurrent.STM (TVar)
+import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Typeable (Typeable)
-import qualified Control.Exception as E
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
-import GHC.Conc (TVar)
 import Network.Socket (SockAddr)
 import Network.Socket.BufferPool
 import System.Posix.Types (Fd)

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -11,12 +11,12 @@ import qualified Control.Exception as E
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
+import GHC.Conc (TVar)
 import Network.Socket (SockAddr)
 import Network.Socket.BufferPool
 import System.Posix.Types (Fd)
 import qualified System.TimeManager as T
 
-import Network.Wai.Handler.Warp.Counter (Counter)
 import qualified Network.Wai.Handler.Warp.Date as D
 import qualified Network.Wai.Handler.Warp.FdCache as F
 import qualified Network.Wai.Handler.Warp.FileInfoCache as I
@@ -131,7 +131,7 @@ data Connection = Connection
     , connHTTP2 :: IORef Bool
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
-    , connAppsInProgress :: Counter
+    , connAppsInProgress :: TVar Int
     -- ^ Amount of apps currently in progress on this connection.
     --
     -- /HTTP2 can handle more than one request concurrently/

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module GracefulShutdownSpec (spec) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Exception (bracket)
+import Control.Monad (void)
+import Network.HTTP.Client
+import Network.HTTP.Types (ok200, status200)
+import Network.Socket (close)
+import Network.Wai (responseLBS)
+import Network.Wai.Handler.Warp
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "graceful shutdown" $
+    it "serves the request in flight, then closes keep-alive connections and exits" $ do
+        shutdownSignal <- newEmptyMVar
+        allowResponse <- newEmptyMVar
+        receivedRequests <- newQSemN 0
+        allowSecondRequest <- newEmptyMVar
+
+        let installShutdownHandler closeListenSocket =
+                void . forkIO $ do
+                    readMVar shutdownSignal
+                    closeListenSocket
+
+            settings =
+                setInstallShutdownHandler installShutdownHandler defaultSettings
+
+            app _ respond = do
+                -- signal 1 received request
+                signalQSemN receivedRequests 1
+                -- block until signaled
+                readMVar allowResponse
+                respond $ responseLBS status200 [("Content-Length", "0")] ""
+
+            client sendRequest = do
+                -- first request should return OK
+                response <- sendRequest
+                responseStatus response `shouldBe` ok200
+                lookup "Connection" (responseHeaders response) `shouldBe` Just "close"
+                -- wait with the second request
+                void $ readMVar allowSecondRequest
+                -- second request should end with connection refused
+                sendRequest `shouldThrow` connectionRefused
+
+        bracket openFreePort (close . snd) $ \(testPort, sock) ->
+            withAsync (runSettingsSocket settings sock app) $ \server -> do
+                manager <- newManager defaultManagerSettings
+                request <- parseRequest ("http://127.0.0.1:" ++ show testPort)
+                withAsync
+                    -- start all clients
+                    ( replicateConcurrently_ numClients $
+                        client (httpNoBody request manager)
+                    )
+                    $ \clients -> do
+                        -- wait for all clients to send requests
+                        waitQSemN receivedRequests numClients
+                        -- shutdown the server before serving requests
+                        putMVar shutdownSignal ()
+                        -- wait a little - otherwise some requests might not get
+                        -- Connection: close response header
+                        threadDelay 100_000
+                        -- let requests be handled
+                        putMVar allowResponse ()
+                        -- server should exit
+                        timeout 5_000_000 (wait server)
+                            >>= maybe (expectationFailure "Timeout waiting for server shutdown") pure
+                        -- let clients proceed with the second request
+                        putMVar allowSecondRequest ()
+                        -- wait for all clients and propagate any exceptions
+                        wait clients
+  where
+    -- set number of clients to the number of keep-alive connections
+    numClients = managerConnCount defaultManagerSettings
+    connectionRefused = \case
+        (HttpExceptionRequest _ (ConnectionFailure _)) -> True
+        _ -> False

--- a/warp/test/ServerStateSpec.hs
+++ b/warp/test/ServerStateSpec.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ServerStateSpec where
+
+import Network.Wai.Handler.Warp (getServerState)
+import Network.Wai.Handler.Warp.Counter (getCount, increase)
+import Network.Wai.Handler.Warp.Settings (
+    ServerState (..),
+    currentOpenConnections,
+    currentShuttingDownState,
+    defaultSettings,
+    makeServerState,
+    newServerState,
+ )
+import Network.Wai.Handler.Warp.ShuttingDown (writeShuttingDown)
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+    describe "ServerState" $ do
+        it "has the correct initialization" $ do
+            ss <- newServerState
+            currentOpenConnections ss `shouldReturn` 0
+            currentShuttingDownState ss `shouldReturn` False
+    describe "makeServerState" $ do
+        it "has the same state in settings" $ do
+            (outerSS, set) <- makeServerState defaultSettings
+            case getServerState set of
+                Nothing -> expectationFailure "'makeServerState' should set the 'ServerState'"
+                Just innerSS -> do
+                    let bothCount i = do
+                            a <- currentOpenConnections outerSS
+                            b <- currentOpenConnections innerSS
+                            (a, b) `shouldBe` (i, i)
+                    increase $ serverConnectionCounter outerSS
+                    bothCount 1
+                    increase $ serverConnectionCounter innerSS
+                    bothCount 2
+                    let bothDown bool = do
+                            a <- currentShuttingDownState outerSS
+                            b <- currentShuttingDownState innerSS
+                            (a, b) `shouldBe` (bool, bool)
+                    writeShuttingDown (serverShuttingDown outerSS) True
+                    bothDown True
+                    writeShuttingDown (serverShuttingDown innerSS) False
+                    bothDown False
+        it "is idempotent" $ do
+            let incAndCheck ss i = do
+                    increase $ serverConnectionCounter ss
+                    currentOpenConnections ss `shouldReturn` i
+            (ss1, set1) <- makeServerState defaultSettings
+            incAndCheck ss1 1
+            (ss2, _set2) <- makeServerState set1
+            incAndCheck ss2 2
+            incAndCheck ss1 3

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -193,6 +193,7 @@ test-suite spec
         ResponseSpec
         RunSpec
         SendFileSpec
+        ServerStateSpec
         WithApplicationSpec
         Network.Wai.Handler.Warp
         Network.Wai.Handler.Warp.Internal

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -184,6 +184,7 @@ test-suite spec
         ExceptionSpec
         FdCacheSpec
         FileSpec
+        GracefulShutdownSpec
         HTTP
         PackIntSpec
         ReadIntSpec

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -86,6 +86,7 @@ library
         Network.Wai.Handler.Warp.Run
         Network.Wai.Handler.Warp.SendFile
         Network.Wai.Handler.Warp.Settings
+        Network.Wai.Handler.Warp.ShuttingDown
         Network.Wai.Handler.Warp.Types
         Network.Wai.Handler.Warp.Windows
         Network.Wai.Handler.Warp.WithApplication
@@ -221,6 +222,7 @@ test-suite spec
         Network.Wai.Handler.Warp.Run
         Network.Wai.Handler.Warp.SendFile
         Network.Wai.Handler.Warp.Settings
+        Network.Wai.Handler.Warp.ShuttingDown
         Network.Wai.Handler.Warp.Types
         Network.Wai.Handler.Warp.Windows
         Network.Wai.Handler.Warp.WithApplication

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.12
+version:            3.4.13
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

My attempt at showing what I meant with adding the `ShuttingDown` state to the `Settings`.
This breaks no APIs AFAICT, and the new `ServerState` can be used to give the end-user more insight into what the server is doing.
If at some point we'd want to track more metrics (e.g. "amount of active `Application`s"), this is a way to expose them in a read-only fashion.

It also makes some argument passing unnecessary, as you can get the `ServerState` with `makeServerState`.

It's unfortunate we can't change the `Settings` type without breaking backward compatibility, as I'd like to have the type reflect the presence of a `ServerState` or not. Though we could also remove `defaultSettings :: Settings` and only provide `initSettings :: IO Settings` so that the `settingsServerState` would not have to be a `Maybe`. (Maybe food for thought for a major version bump)

---

TL;DR

- I'm trying not to break any APIs (not even those in `.Internal`)
- `warp-tls` should build with older versions, so there's a bunch of CPP
- I've simplified `Response.hs` a bit
- Might want to rename `makeRecv`, doesn't describe what it's doing well. If anyone has suggestions?
- Would have liked to make `appsInProgress` a `Counter`, but we don't export `newCounter`, so we wouldn't be able to create it in `warp-tls`
- `makeServerState` is idempotent, so as long as it is used before anything that needs to use the `Counter` or `ShuttingDown`, it will keep the same variables.