### PR TITLE
Remove typeable deriving

### DIFF
--- a/wai-extra/Network/Wai/Middleware/Approot.hs
+++ b/wai-extra/Network/Wai/Middleware/Approot.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | Middleware for establishing the root of the application.
 --
 -- Many application need the ability to create URLs referring back to the
@@ -33,7 +31,6 @@ import Control.Exception (Exception, throw)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as S8
 import Data.Maybe (fromMaybe)
-import Data.Typeable (Typeable)
 import qualified Data.Vault.Lazy as V
 import Network.Wai (Middleware, Request, vault)
 import System.Environment (lookupEnv)
@@ -108,7 +105,7 @@ fromRequest :: Middleware
 fromRequest = approotMiddleware (return . guessApproot)
 
 data ApprootMiddlewareNotSetup = ApprootMiddlewareNotSetup
-    deriving (Show, Typeable)
+    deriving (Show)
 instance Exception ApprootMiddlewareNotSetup
 
 -- | Get the approot set by the middleware. If the middleware is not in use,

--- a/wai-extra/Network/Wai/Parse.hs
+++ b/wai-extra/Network/Wai/Parse.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
@@ -76,7 +75,6 @@ import Data.IORef
 import Data.Int (Int64)
 import Data.List (sortBy)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.Typeable
 import Data.Word8
 import Network.HTTP.Types (hContentType)
 import qualified Network.HTTP.Types as H
@@ -660,7 +658,7 @@ data RequestParseException
     | MaxFileNumberExceeded Int
     | FilenameTooLong S.ByteString Int
     | TooManyHeaderLines Int
-    deriving (Eq, Typeable)
+    deriving (Eq)
 
 instance E.Exception RequestParseException
 instance Show RequestParseException where
@@ -806,7 +804,7 @@ parseContentDispositionAttrs = parseTokenValues
         let (token, rest) = parseToken $ dropSpace input
          in case S.uncons rest of
             Just (c, rest')
-                | c == _equal -> 
+                | c == _equal ->
                     let (value, rest'') = parseValue rest'
                      in (token, value) : parseTokenValues (S.drop 1 rest'')
                 | otherwise -> (token, S.empty) : parseTokenValues rest'

--- a/wai-extra/Network/Wai/Request.hs
+++ b/wai-extra/Network/Wai/Request.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-
 -- | Some helpers for interrogating a WAI 'Request'.
 module Network.Wai.Request (
     appearsSecure,
@@ -14,7 +12,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
 import Data.IORef (atomicModifyIORef', newIORef)
 import Data.Maybe (fromMaybe)
-import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import Network.HTTP.Types (HeaderName)
 import Network.Wai
@@ -63,7 +60,7 @@ guessApproot req =
 -- @since 3.0.15
 newtype RequestSizeException
     = RequestSizeException Word64
-    deriving (Eq, Ord, Typeable)
+    deriving (Eq, Ord)
 
 instance Exception RequestSizeException
 

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -9,7 +9,6 @@ import qualified Data.ByteString as B
 import Data.ByteString.Builder (Builder)
 import Data.List (intercalate)
 import Data.Text (Text)
-import Data.Typeable (Typeable)
 import Data.Vault.Lazy (Vault)
 import Data.Word (Word64)
 import qualified Network.HTTP.Types as H
@@ -93,7 +92,6 @@ data Request = Request
     --
     -- @since 3.2.0
     }
-    deriving (Typeable)
 
 -- | Get the next chunk of the body. Returns 'B.empty' when the
 -- body is fully consumed.
@@ -138,7 +136,6 @@ data Response
     | ResponseBuilder H.Status H.ResponseHeaders Builder
     | ResponseStream H.Status H.ResponseHeaders StreamingBody
     | ResponseRaw (IO B.ByteString -> (B.ByteString -> IO ()) -> IO ()) Response
-    deriving (Typeable)
 
 -- | Represents a streaming HTTP response body. It's a function of two
 -- parameters; the first parameter provides a means of sending another chunk of
@@ -175,4 +172,3 @@ data FilePart = FilePart
 --
 -- @since 3.0.0
 data ResponseReceived = ResponseReceived
-    deriving (Typeable)

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
@@ -81,7 +80,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.IORef as I
 import Data.Streaming.Network (bindPortTCP, safeRecv)
-import Data.Typeable (Typeable)
 import GHC.IO.Exception (IOErrorType (..))
 import Network.Socket (
     SockAddr,
@@ -588,5 +586,5 @@ recvPlain ref fallback = do
 data WarpTLSException
     = InsecureConnectionDenied
     | ClientClosedConnectionPrematurely
-    deriving (Show, Typeable)
+    deriving (Show)
 instance Exception WarpTLSException

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
@@ -21,7 +20,6 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Unsafe as SU
 import qualified Data.CaseInsensitive as CI
 import qualified Data.IORef as I
-import Data.Typeable (Typeable)
 import qualified Data.Vault.Lazy as Vault
 import Data.Word8 (_cr, _lf)
 #ifdef MIN_VERSION_crypton_x509
@@ -136,7 +134,7 @@ headerLines maxTotalHeaderLength firstRequest src = do
         else push maxTotalHeaderLength src (THStatus 0 0 id id) bs
 
 data NoKeepAliveRequest = NoKeepAliveRequest
-    deriving (Show, Typeable)
+    deriving (Show)
 instance Exception NoKeepAliveRequest
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Wai.Handler.Warp.Types where
@@ -8,7 +7,6 @@ import Control.Concurrent.STM (TVar)
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Data.Typeable (Typeable)
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
@@ -47,7 +45,7 @@ data InvalidRequest
       PayloadTooLarge
     | -- | Since 3.3.22
       RequestHeaderFieldsTooLarge
-    deriving (Eq, Typeable)
+    deriving (Eq)
 
 instance Show InvalidRequest where
     show (NotEnoughLines xs) = "Warp: Incomplete request headers, received: " ++ show xs
@@ -72,7 +70,7 @@ instance E.Exception InvalidRequest
 -- Used to determine whether keeping the HTTP1.1 connection / HTTP2 stream alive is safe
 -- or irrecoverable.
 newtype ExceptionInsideResponseBody = ExceptionInsideResponseBody E.SomeException
-    deriving (Show, Typeable)
+    deriving (Show)
 
 instance E.Exception ExceptionInsideResponseBody
 


### PR DESCRIPTION
Since we don't build on any GHC < 8.6 (because of the `base >= 4.12` constraint) all the `Typeable` deriving is automatic, so I've removed the explicit deriving.