### PR TITLE
Require network >= 3.2.3.0 in warp.cabal (refs #1079)

### DIFF
--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -132,7 +132,7 @@ library
             network-bytestring >=0.1.3 && <0.1.4
 
     else
-        build-depends: network >=2.3
+        build-depends: network >=3.2.3.0
 
     if flag(warp-debug)
         cpp-options: -DWARP_DEBUG

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.13
+version:            3.4.14
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com


### PR DESCRIPTION
This PR updates warp.cabal to require **network >= 3.2.3.0**, which appears to fix the compilation error reported in #1079. I have realized that requiring exactly network-3.2.2.0 also caused a dependency conflict, and thus further bumped the lower bound for network. 

I have confirmed that `stack build`, `stack build --stack-yaml stack-lts-22.yaml`, `stack build --stack-yaml stack-lts-21.yaml`, `stack build --stack-yaml stack-lts-20.yaml`, and `cabal build all` succeeded in my local environment. 

---

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->