### PR TITLE
fix: Warp crashes with "thread blocked indefinitely in an STM transaction" when receiving eMFILE from accept

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Counter.hs
+++ b/warp/Network/Wai/Handler/Warp/Counter.hs
@@ -6,6 +6,7 @@ module Network.Wai.Handler.Warp.Counter (
     waitForZero,
     increase,
     decrease,
+    waitForCounter,
     waitForDecreased,
     getCount,
     getCountSTM,
@@ -26,11 +27,14 @@ waitForZero (Counter var) = atomically $ do
     when (x > 0) retry
 
 waitForDecreased :: Counter -> IO ()
-waitForDecreased (Counter var) = do
-    n0 <- atomically $ readTVar var
+waitForDecreased = waitForCounter (>)
+
+waitForCounter :: (Int -> Int -> Bool) -> Counter -> IO ()
+waitForCounter condition (Counter var) = do
+    n0 <- readTVarIO var
     atomically $ do
         n <- readTVar var
-        check (n < n0)
+        check (condition n0 n)
 
 increase :: Counter -> IO ()
 increase (Counter var) = atomically $ modifyTVar' var $ \x -> x + 1

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -352,7 +352,8 @@ acceptConnection set getConnMaker app counter ii = do
                 if | isErrno eCONNABORTED -> acceptNewConnection
                    | isErrno eMFILE -> do
                        settingsOnException set Nothing $ E.toException e
-                       waitForDecreased counter
+                       -- if there are requests in flight wait for (at least) one to finish
+                       waitForCounter (\prev next -> prev <= 0 || prev > next) counter
                        acceptNewConnection
                    | otherwise -> do
                        settingsOnException set Nothing $ E.toException e


### PR DESCRIPTION
Fixes #1082 