### PR TITLE
Add requestSendEarlyHints and wire it through Warp's HTTP/2 handler

### DIFF
--- a/wai/ChangeLog.md
+++ b/wai/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for wai
 
+## 3.2.5
+
+* Add a `requestSendEarlyHints :: [Header] -> IO ()` field to `Request` for sending `103 Early Hints` responses. [#1085](https://github.com/yesodweb/wai/pull/1085)
+
 ## 3.2.4
 
 * Add helpers for modifying request headers: `modifyRequest` and `mapRequestHeaders`. [#710](https://github.com/yesodweb/wai/pull/710) [#952](https://github.com/yesodweb/wai/pull/952)

--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -61,6 +61,7 @@ module Network.Wai (
     requestHeaderRange,
     requestHeaderReferer,
     requestHeaderUserAgent,
+    requestSendEarlyHints,
     -- $streamingRequestBodies
     strictRequestBody,
     consumeRequestBodyStrict,
@@ -322,6 +323,7 @@ defaultRequest =
         , requestHeaderRange = Nothing
         , requestHeaderReferer = Nothing
         , requestHeaderUserAgent = Nothing
+        , requestSendEarlyHints = \_ -> return ()
         }
 
 -- | A @Middleware@ is a component that sits between the server and application.

--- a/wai/Network/Wai/Internal.hs
+++ b/wai/Network/Wai/Internal.hs
@@ -91,6 +91,16 @@ data Request = Request
     -- ^ The value of the User-Agent header in a HTTP request.
     --
     -- @since 3.2.0
+    , requestSendEarlyHints :: H.ResponseHeaders -> IO ()
+    -- ^ Send a @103 Early Hints@ informational response carrying the given
+    -- headers, ahead of the final response. This lets a client (typically over
+    -- HTTP\/2) start fetching resources named in @Link@ headers while the final
+    -- response is still being produced.
+    --
+    -- A handler (e.g. Warp over HTTP\/2) that supports early hints installs an
+    -- action here; otherwise it is a no-op.
+    --
+    -- @since 3.2.5
     }
 
 -- | Get the next chunk of the body. Returns 'B.empty' when the

--- a/wai/wai.cabal
+++ b/wai/wai.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:       >=1.10
 Name:                wai
-Version:             3.2.4
+Version:             3.2.5
 Synopsis:            Web Application Interface.
 Description:         Provides a common protocol for communication between web applications and web servers.
                      .

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -7,6 +7,11 @@
   `Network.Wai.Handler.Warp.Internal`, so this gets a minor version bump.
   [#1088](https://github.com/yesodweb/wai/pull/1088)
 
+* Support `103 Early Hints` over HTTP/2: the HTTP/2 handler installs
+  `requestSendEarlyHints`, so a WAI application can emit informational responses
+  ahead of the final response.
+  [#1085](https://github.com/yesodweb/wai/pull/1085).
+
 ## 3.4.14
 
 * Important bugfix to not deadlock on empty file descriptors if the cause of

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -28,6 +29,14 @@ import Network.Wai.Handler.Warp.HTTP2.Response
 import Network.Wai.Handler.Warp.Imports
 import qualified Network.Wai.Handler.Warp.Settings as S
 import Network.Wai.Handler.Warp.Types
+
+-- Early Hints wiring needs both the http-semantics 'auxSendInformational' field
+-- (0.4.1) and the http2 sender support that actually emits it (5.4.2).
+#define HAS_EARLY_HINTS_SUPPORT (MIN_VERSION_http_semantics(0,4,1) && MIN_VERSION_http2(5,4,2))
+
+#if HAS_EARLY_HINTS_SUPPORT
+import qualified Network.HTTP.Types as H
+#endif
 
 ----------------------------------------------------------------
 
@@ -89,7 +98,12 @@ http2server
 http2server label settings ii transport addr app h2req0 aux0 response = do
     tid <- myThreadId
     labelThread tid (label ++ " http2server " ++ show addr)
-    req <- toWAIRequest h2req0 aux0
+    req0 <- toWAIRequest h2req0 aux0
+#if HAS_EARLY_HINTS_SUPPORT
+    let req = req0{requestSendEarlyHints = H2.auxSendInformational aux0 (H.mkStatus 103 "Early Hints")}
+#else
+    let req = req0
+#endif
     ref <- I.newIORef Nothing
     eResponseReceived <- E.try $ app req $ \rsp -> do
         (h2rsp, st, hasBody) <- fromResponse settings ii req rsp

--- a/warp/test/EarlyHintsSpec.hs
+++ b/warp/test/EarlyHintsSpec.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module EarlyHintsSpec (spec) where
+
+import Test.Hspec
+
+#define HAS_EARLY_HINTS_SUPPORT (MIN_VERSION_http_semantics(0,4,1) && MIN_VERSION_http2(5,4,2))
+
+#if HAS_EARLY_HINTS_SUPPORT
+import Control.Exception (bracket)
+import Data.ByteString (ByteString)
+import Data.IORef
+import Network.HPACK (TokenHeaderTable, getFieldValue)
+import Network.HPACK.Token (toToken)
+import Network.HTTP.Types (Status, methodGet, ok200, status200, status404)
+import qualified Network.HTTP2.Client as C
+import Network.Socket
+import Network.Wai
+import Network.Wai.Handler.Warp (Port, testWithApplication)
+
+spec :: Spec
+spec = describe "HTTP/2 Early Hints" $
+    it "delivers a WAI app's 103 Early Hints to the client before the final response (h2c)" $
+        testWithApplication (pure app) $ \port -> do
+            hintsRef <- newIORef []
+            earlyHintsClient port hintsRef `shouldReturn` Just ok200
+            hints <- readIORef hintsRef
+            map (getFieldValue (toToken "link") . snd) hints
+                `shouldBe` (Just <$> earlyResponses)
+
+-- | The @Link@ header values delivered as Early Hints, in order.
+earlyResponses :: [ByteString]
+earlyResponses =
+    [ "</style.css>; rel=preload; as=style"
+    , "</app.js>; rel=preload; as=script"
+    ]
+
+-- | A WAI app that emits two Early Hints sections, then the final response.
+app :: Application
+app req respond
+    | pathInfo req == ["early"] = do
+        mapM_ (\link -> requestSendEarlyHints req [("link", link)]) earlyResponses
+        respond $ responseLBS status200 [("content-type", "text/plain")] "Hello"
+    | otherwise = respond $ responseLBS status404 [] ""
+
+-- | Drive Warp over h2c with the HTTP/2 client, recording each 103 Early Hints
+--   section via the client's informational handler, and return the final status.
+earlyHintsClient :: Port -> IORef [TokenHeaderTable] -> IO (Maybe Status)
+earlyHintsClient port hintsRef = withTCP "127.0.0.1" port $ \sock ->
+    bracket (C.allocSimpleConfig sock 4096) C.freeSimpleConfig $ \conf ->
+        C.run cliconf (conf{C.confOnInformational = onInformational}) $ \sendRequest _aux ->
+            sendRequest (C.requestNoBody methodGet "/early" []) (return . C.responseStatus)
+  where
+    cliconf = C.defaultClientConfig{C.authority = "127.0.0.1"}
+    onInformational _streamId tbl = modifyIORef' hintsRef (++ [tbl])
+
+-- | Connect to a TCP server, run an action, and close the socket afterwards.
+withTCP :: HostName -> Port -> (Socket -> IO a) -> IO a
+withTCP host port = bracket open close
+  where
+    open = do
+        addr : _ <- getAddrInfo (Just defaultHints{addrSocketType = Stream}) (Just host) (Just (show port))
+        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+        connect sock (addrAddress addr)
+        return sock
+#else
+spec :: Spec
+spec = describe "HTTP/2 Early Hints" $
+    it "delivers a WAI app's 103 Early Hints to the client before the final response (h2c)" $
+        pendingWith "requires http2 >= 5.4.2 and http-semantics >= 0.4.1"
+#endif

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -108,6 +108,7 @@ library
         hashable,
         http-date,
         http-types >=0.12 && <1,
+        http-semantics >=0.4 && <0.5,
         http2 >=5.4 && <5.5,
         iproute >=1.3.1,
         recv >=0.1.0 && <0.2.0,
@@ -117,7 +118,7 @@ library
         text,
         time-manager >=0.2 && <0.4,
         vault >=0.3,
-        wai >=3.2.4 && <3.3,
+        wai >=3.2.5 && <3.3,
         word8
 
     if flag(x509)
@@ -181,6 +182,7 @@ test-suite spec
     other-modules:
         ConduitSpec
         ConnectionSpec
+        EarlyHintsSpec
         ExceptionSpec
         FdCacheSpec
         FileSpec
@@ -250,6 +252,7 @@ test-suite spec
         http-client,
         http-date,
         http-types >=0.12,
+        http-semantics >=0.4 && <0.5,
         http2 >=5.4 && <5.5,
         iproute >=1.3.1,
         network,
@@ -261,7 +264,7 @@ test-suite spec
         text,
         time-manager,
         vault,
-        wai >=3.2.2.1 && <3.3,
+        wai >=3.2.5 && <3.3,
         -- workaround: this should be unnecessary
         warp,
         word8


### PR DESCRIPTION
Follow-on from
* https://github.com/kazu-yamamoto/http-semantics/pull/18
* https://github.com/kazu-yamamoto/http2/pull/168

Before submitting your PR, check that you've:

- [X] Bumped the version number
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
