### PR TITLE
Revise keepalive and count streaming bodies (and more small stuff)

### DIFF
--- a/wai/Network/Wai.hs
+++ b/wai/Network/Wai.hs
@@ -120,6 +120,14 @@ import System.IO.Unsafe (unsafeInterleaveIO)
 
 -- | Creating 'Response' from a file.
 --
+-- Server implementations like @warp@ might disregard the t'Status' when
+-- using 'responseFile', since the server might rework the response based on
+-- headers or presence/absence of the file.
+-- @warp@ does not do do any extra processing when sending file parts, though,
+-- so be mindful of how each server implementation handles file responses.
+--
+-- /The above was written when @warp-3.4.14@ was the newest version/
+--
 -- @since 2.0.0
 responseFile
     :: H.Status -> H.ResponseHeaders -> FilePath -> Maybe FilePart -> Response

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -15,12 +15,8 @@
 * Also counts bytes for streaming responses for `settingsLogger`'s size argument.
   And fixed size for builder responses, since those included the status and header
   lines. Now the `Maybe Integer` argument in `settingsLogger` is consistently
-  just the message body's bytes.
+  just the amount of bytes of the sent message body.
   [#1086](https://github.com/yesodweb/wai/pull/1086)
-* Add phantom type parameter to `IndexedHeader` to catch request/response
-  mismatches at compile time.
-  [#1088](https://github.com/yesodweb/wai/pull/1088)
-
 * Reworked internal indexed headers to records for performance and to remove
   dependencies on `array`.
   [#1092](https://github.com/yesodweb/wai/pull/1092) [#1093](https://github.com/yesodweb/wai/pull/1093)

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -14,8 +14,9 @@
   with spaces. (as per RFC 9110 section 5.5)
 * Also counts bytes for streaming responses for `settingsLogger`'s size argument.
   And fixed size for builder responses, since those included the status and header
-  lines. Now the `Maybe Integer` argument in `settingsLogger` is consistently
-  just the amount of bytes of the sent message body.
+  lines, and large `ByteString` chunks would not get counted.
+  Now the `Maybe Integer` argument in `settingsLogger` is consistently the
+  amount of bytes of the sent raw message body.
   [#1086](https://github.com/yesodweb/wai/pull/1086)
 * Reworked internal indexed headers to records for performance and to remove
   dependencies on `array`.

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -10,15 +10,21 @@
   closed on HEAD requests anymore. Should conform more to spec in general.
   Should also reliably close connection when user created `Response` headers
   contain a `Connection: close` entry (HTTP/1.1).
+  [#1086](https://github.com/yesodweb/wai/pull/1086)
 * Replace multiline header value support with sanitizing newlines and NUL bytes
   with spaces. (as per RFC 9110 section 5.5)
-* Also counts bytes for streaming responses for `settingsLogger`'s size argument.
-  And fixed size for builder responses, since those included the status and header
-  lines, and large `ByteString` chunks would not get counted.
-  Now the `Maybe Integer` argument in `settingsLogger` is consistently the
-  amount of bytes of the sent raw message body.
   [#1086](https://github.com/yesodweb/wai/pull/1086)
-* Reworked internal indexed headers to records for performance and to remove
+* Size for responses in `Maybe Integer` argument of `settingsLogger` now
+  consistently and always gives amount of bytes of the sent raw __message body__.
+  It will only be `Nothing` when using `responseRaw` (mostly used for websockets)
+  [#1086](https://github.com/yesodweb/wai/pull/1086)
+    * `responseFile`: no change, gives size of file (part)
+    * `responseBuilder/responseLBS`:
+        * included the status and header lines, now fixed
+        * large `ByteString` chunks would not get counted, now fixed
+    * `responseStream`: now counts bytes of body sent
+    * `responseRaw`: will always be `Nothing`
+* Rework internal indexed headers to records for performance and to remove
   dependencies on `array`.
   [#1092](https://github.com/yesodweb/wai/pull/1092) [#1093](https://github.com/yesodweb/wai/pull/1093)
 

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -6,6 +6,20 @@
   `requestSendEarlyHints`, so a WAI application can emit informational responses
   ahead of the final response.
   [#1085](https://github.com/yesodweb/wai/pull/1085).
+* Rework keep alive logic for HTTP/1.X so connections won't be automatically
+  closed on HEAD requests anymore. Should conform more to spec in general.
+  Should also reliably close connection when user created `Response` headers
+  contain a `Connection: close` entry (HTTP/1.1).
+* Replace multiline header value support with sanitizing newlines and NUL bytes
+  with spaces. (as per RFC 9110 section 5.5)
+* Also counts bytes for streaming responses for `settingsLogger`'s size argument.
+  And fixed size for builder responses, since those included the status and header
+  lines. Now the `Maybe Integer` argument in `settingsLogger` is consistently
+  just the message body's bytes.
+  [#1086](https://github.com/yesodweb/wai/pull/1086)
+* Add phantom type parameter to `IndexedHeader` to catch request/response
+  mismatches at compile time.
+  [#1088](https://github.com/yesodweb/wai/pull/1088)
 
 * Reworked internal indexed headers to records for performance and to remove
   dependencies on `array`.

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -16,7 +16,7 @@ import Network.Wai (FilePart (..))
 
 import qualified Network.Wai.Handler.Warp.FileInfoCache as I
 import Network.Wai.Handler.Warp.Header (
-    IndexedRequestHeader,
+    IndexedRequestHeader (..),
     ResponseHeaderPresence (..),
  )
 import Network.Wai.Handler.Warp.Imports

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Wai.Handler.Warp.File (
@@ -10,15 +9,18 @@ module Network.Wai.Handler.Warp.File (
 ) where
 
 import qualified Data.ByteString.Char8 as C8 (pack)
-import Network.HTTP.Date
+import Network.HTTP.Date (HTTPDate, parseHTTPDate)
 import qualified Network.HTTP.Types as H
-import qualified Network.HTTP.Types.Header as H
-import Network.Wai
+import qualified Network.HTTP.Types.Header as Header
+import Network.Wai (FilePart (..))
 
 import qualified Network.Wai.Handler.Warp.FileInfoCache as I
-import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Header (
+    IndexedRequestHeader,
+    ResponseHeaderPresence (..),
+ )
 import Network.Wai.Handler.Warp.Imports
-import Network.Wai.Handler.Warp.PackInt
+import Network.Wai.Handler.Warp.PackInt (packIntegral)
 
 ----------------------------------------------------------------
 
@@ -158,7 +160,7 @@ checkRange (H.ByteRangeSuffix count) size = (max 0 (size - count), size - 1)
 -- | @contentRangeHeader beg end total@ constructs a Content-Range 'H.Header'
 -- for the range specified.
 contentRangeHeader :: Integer -> Integer -> Integer -> H.Header
-contentRangeHeader beg end total = (H.hContentRange, range)
+contentRangeHeader beg end total = (Header.hContentRange, range)
   where
     range =
         C8.pack
@@ -190,7 +192,10 @@ addContentHeaders hs off len size
          in ctrng : hs'
   where
     !lengthBS = packIntegral len
-    !hs' = (H.hContentLength, lengthBS) : (H.hAcceptRanges, "bytes") : hs
+    !hs' =
+        (Header.hContentLength, lengthBS)
+            : (Header.hAcceptRanges, "bytes")
+            : filter (\(h, _) -> h /= Header.hContentLength && h /= Header.hAcceptRanges) hs
 
 -- |
 --

--- a/warp/Network/Wai/Handler/Warp/HTTP2.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2.hs
@@ -164,7 +164,7 @@ wrappedRecvN th slowlorisSize readN bufsize = do
     handler = throughAsync (return "")
 
 -- connClose must not be called here since Run:fork calls it
-goaway :: Connection -> H2.ErrorCodeId -> ByteString -> IO ()
+goaway :: Connection -> H2.ErrorCode -> ByteString -> IO ()
 goaway Connection{..} etype debugmsg = connSendAll bytestream
   where
     einfo = H2.encodeInfo id 0

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -85,13 +85,13 @@ toRequest' ii settings addr ref (reqths, reqvt) bodylen body th transport =
             Nothing -> case mAuth of
                 Just auth -> (tokenHost, auth) : reqths
                 _ -> reqths
-    !mPath = getHeaderValue tokenPath reqvt -- SHOULD
-    !colonMethod = fromJust $ getHeaderValue tokenMethod reqvt -- MUST
-    !mAuth = getHeaderValue tokenAuthority reqvt -- SHOULD
-    !mHost = getHeaderValue tokenHost reqvt
-    !mRange = getHeaderValue tokenRange reqvt
-    !mReferer = getHeaderValue tokenReferer reqvt
-    !mUserAgent = getHeaderValue tokenUserAgent reqvt
+    !mPath = getFieldValue tokenPath reqvt -- SHOULD
+    !colonMethod = fromJust $ getFieldValue tokenMethod reqvt -- MUST
+    !mAuth = getFieldValue tokenAuthority reqvt -- SHOULD
+    !mHost = getFieldValue tokenHost reqvt
+    !mRange = getFieldValue tokenRange reqvt
+    !mReferer = getFieldValue tokenReferer reqvt
+    !mUserAgent = getFieldValue tokenUserAgent reqvt
     -- CONNECT request will have ":path" omitted, use ":authority" as unparsed
     -- path instead so that it will have consistent behavior compare to HTTP 1.0
     (unparsedPath, query) = C8.break (== '?') $ fromJust (mPath <|> mAuth)

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -90,18 +90,22 @@ data ResponseHeaderPresence = ResponseHeaderPresence
     , hasServer :: Bool
     , hasDate :: Bool
     , hasLastModified :: Bool
+    , hasTransferEncoding :: Maybe HeaderValue
+    , hasConnection :: Maybe HeaderValue
     }
 
 indexResponseHeader :: ResponseHeaders -> ResponseHeaderPresence
 indexResponseHeader = go emptyResponseHeaderPresence
   where
     go ix [] = ix
-    go ix ((key, _) : rest) = go (insert ix key) rest
-    insert ix key = case BS.length bs of
+    go ix (tup : rest) = go (insert ix tup) rest
+    insert ix (key, val) = case BS.length bs of
         4 | bs == "date" -> ix{hasDate = True}
         6 | bs == "server" -> ix{hasServer = True}
+        10 | bs == "connection" -> ix{hasConnection = Just val}
         13 | bs == "last-modified" -> ix{hasLastModified = True}
         14 | bs == "content-length" -> ix{hasContentLength = True}
+        17 | bs == "transfer-encoding" -> ix{hasTransferEncoding = Just val}
         _ -> ix
       where
         bs = foldedCase key
@@ -113,4 +117,6 @@ emptyResponseHeaderPresence =
         , hasServer = False
         , hasDate = False
         , hasLastModified = False
+        , hasTransferEncoding = Nothing
+        , hasConnection = Nothing
         }

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -1,6 +1,7 @@
 module Network.Wai.Handler.Warp.IO where
 
 import Control.Exception (mask_)
+import qualified Data.ByteString as B (length)
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Extra (Next (Chunk, Done, More), runBuilder)
 import Data.IORef (IORef, readIORef, writeIORef)
@@ -47,4 +48,4 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
                 | otherwise -> loop writeBuffer next totalBytesSent
             Chunk bs next -> do
                 io bs
-                loop writeBuffer next totalBytesSent
+                loop writeBuffer next $ totalBytesSent + fromIntegral (B.length bs)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -426,6 +426,8 @@ sendRspFile2XX
     -> IO (Maybe H.Status, Maybe Integer)
 sendRspFile2XX conn ii th ver s hs rspidxhdr maxRspBufSize method path beg len hook
     | method == H.methodHead =
+        -- FIXME: We could check the size of the file and add a
+        -- 'Content-Length' header to give the requester more information?
         sendRsp conn ii th ver s hs rspidxhdr maxRspBufSize method RspNoBody
     | otherwise = do
         lheader <- composeHeader ver s hs

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -26,8 +26,7 @@ import Data.ByteString.Builder.HTTP.Chunked (
     chunkedTransferTerminator,
  )
 import qualified Data.CaseInsensitive as CI
-import Data.Function (on)
-import Data.List (deleteBy)
+import Data.Foldable (for_)
 import Data.Streaming.ByteString.Builder (
     newByteStringBuilderRecv,
     reuseBufferStrategy,
@@ -492,8 +491,15 @@ hasBody s =
 
 ----------------------------------------------------------------
 
-addTransferEncoding :: H.ResponseHeaders -> H.ResponseHeaders
-addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
+-- | We ASSUME there's no middleware that will chunk the transfer, so
+-- we'll add it to the headers if there's no other encoding, or add it
+-- to the end in case it is.
+-- (e.g. if a 'Middleware' were to add "Transfer-Encoding: gzip")
+addTransferEncoding :: IndexedHeader -> H.ResponseHeaders -> H.ResponseHeaders
+addTransferEncoding rspidxhdr =
+    case rspidxhdr ! fromEnum ResTransferEncoding of
+        Nothing -> ((Header.hTransferEncoding, "chunked") :)
+        Just value -> replaceHeader Header.hTransferEncoding (value <> ", chunked")
 
 addDate
     :: IO D.GMTDate -> ResponseHeaderPresence -> H.ResponseHeaders -> IO H.ResponseHeaders
@@ -522,13 +528,14 @@ addAltSvc settings hs = case settingsAltSvc settings of
 
 ----------------------------------------------------------------
 
--- |
+-- | Replaces a header, instead of just adding it which might lead to
+-- duplicate entries of the same header name.
 --
 -- >>> replaceHeader "Content-Type" "new" [("content-type","old")]
 -- [("Content-Type","new")]
 replaceHeader
     :: H.HeaderName -> HeaderValue -> H.ResponseHeaders -> H.ResponseHeaders
-replaceHeader k v hdrs = (k, v) : deleteBy ((==) `on` fst) (k, v) hdrs
+replaceHeader k v hdrs = (k, v) : filter ((/= k) . fst) hdrs
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -516,12 +516,17 @@ addDate getdate rspidxhdr hdrs
 {-# INLINE addServer #-}
 addServer
     :: HeaderValue -> ResponseHeaderPresence -> H.ResponseHeaders -> H.ResponseHeaders
-addServer "" rspidxhdr hdrs
-    | hasServer rspidxhdr = filter ((/= H.hServer) . fst) hdrs
-    | otherwise = hdrs
-addServer serverName rspidxhdr hdrs
-    | hasServer rspidxhdr = hdrs
-    | otherwise = (H.hServer, serverName) : hdrs
+addServer serverName rspidxhdr hdrs =
+    case serverName of
+        -- empty string means there shouldn't be a "Server" header
+        "" | serverPresent ->
+            filter ((/= Header.hServer) . fst) hdrs
+        -- Anything else should set the "Server" header if it isn't already set
+        _ | not serverPresent ->
+            (Header.hServer, serverName) : hdrs
+        _ -> hdrs
+  where
+    serverPresent = hasServer rspidxhdr
 
 addAltSvc :: Settings -> H.ResponseHeaders -> H.ResponseHeaders
 addAltSvc settings hs = case settingsAltSvc settings of

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -284,7 +284,7 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
     -- Not adding Content-Length.
     -- User agents treats it as Content-Length: 0.
     composeHeader ver s hs >>= connSendAll conn
-    return (Just s, Nothing)
+    return (Just s, Just 0)
 
 ----------------------------------------------------------------
 
@@ -317,14 +317,16 @@ sendRsp conn _ th ver s hs rspidxhdr _ _ (RspStream streamingBody needsChunked) 
                     connWriteBuffer conn
     -- We'll be counting how many bytes we send with this 'IORef'
     sizeCounter <- newIORef (0 :: Integer)
+    let sendFragmentAndCount bs = do
+            sendFragment conn th bs
+            -- add amount of bytes to count
+            S.length bs `addToCounter` sizeCounter
     let send builder = do
             popper <- recv builder
             let loop = do
                     bs <- popper
                     unless (S.null bs) $ do
-                        sendFragment conn th bs
-                        -- add amount of bytes to count
-                        S.length bs `addToCounter` sizeCounter
+                        sendFragmentAndCount bs
                         loop
             loop
         sendChunk
@@ -333,8 +335,8 @@ sendRsp conn _ th ver s hs rspidxhdr _ _ (RspStream streamingBody needsChunked) 
     send header
     streamingBody sendChunk (sendChunk flush)
     when needsChunked $ send chunkedTransferTerminator
-    mbs <- finish
-    maybe (return ()) (sendFragment conn th) mbs
+    -- final flush
+    finish >>= mapM_ sendFragmentAndCount
     finalSize <- readIORef sizeCounter
     --              small adjustment to only count the body
     return (Just s, Just $ finalSize - fromIntegral hdrLen)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -172,9 +172,9 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     s = responseStatus response
     hs0 = sanitizeHeaders $ responseHeaders response
     rspidxhdr = indexResponseHeader hs0
-    hasLength = isJust $ rspidxhdr ! ResContentLength
+    hasLength = hasContentLength rspidxhdr
     responseWantsToClose =
-        case rspidxhdr ! ResConnection of
+        case hasConnection rspidxhdr of
             Nothing -> False
             Just v -> CI.foldCase v == "close"
     isPersist = reqSaysPersist && not responseWantsToClose
@@ -516,11 +516,11 @@ hasBody s =
 -- we'll add it to the headers if there's no other encoding, or add it
 -- to the end in case it is.
 -- (e.g. if a 'Middleware' were to add "Transfer-Encoding: gzip")
-addTransferEncoding :: IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
+addTransferEncoding :: ResponseHeaderPresence -> H.ResponseHeaders -> H.ResponseHeaders
 addTransferEncoding rspidxhdr =
-    case rspidxhdr ! ResTransferEncoding of
-        Nothing -> ((Header.hTransferEncoding, "chunked") :)
+    case hasTransferEncoding rspidxhdr of
         Just value -> replaceHeader Header.hTransferEncoding (value <> ", chunked")
+        Nothing -> ((Header.hTransferEncoding, "chunked") :)
 
 addDate
     :: IO D.GMTDate -> ResponseHeaderPresence -> H.ResponseHeaders -> IO H.ResponseHeaders
@@ -538,12 +538,13 @@ addServer
 addServer serverName rspidxhdr hdrs =
     case serverName of
         -- empty string means there shouldn't be a "Server" header
-        "" | serverPresent ->
-            filter ((/= Header.hServer) . fst) hdrs
+        ""
+            | serverPresent -> filter ((/= Header.hServer) . fst) hdrs
+            | otherwise -> hdrs
         -- Anything else should set the "Server" header if it isn't already set
-        _ | not serverPresent ->
-            (Header.hServer, serverName) : hdrs
-        _ -> hdrs
+        _
+            | not serverPresent -> (Header.hServer, serverName) : hdrs
+            | otherwise -> hdrs
   where
     serverPresent = hasServer rspidxhdr
 
@@ -566,7 +567,7 @@ replaceHeader k v hdrs = (k, v) : filter ((/= k) . fst) hdrs
 ----------------------------------------------------------------
 
 composeHeaderBuilder
-    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IndexedResponseHeader -> Bool -> IO (Builder, Int)
+    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> ResponseHeaderPresence -> Bool -> IO (Builder, Int)
 composeHeaderBuilder ver s hs rspidxhdr shouldChunk = do
     bs <- composeHeader ver s finalHdrs
     pure (byteString bs, S.length bs)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -34,7 +34,7 @@ import Data.Streaming.ByteString.Builder (
  )
 import Data.Word8 (_cr, _lf, _space, _tab)
 import qualified Network.HTTP.Types as H
-import qualified Network.HTTP.Types.Header as H
+import qualified Network.HTTP.Types.Header as Header
 import Network.Wai
 import Network.Wai.Internal
 import qualified System.TimeManager as T
@@ -129,7 +129,7 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     let shouldPersist =
             not isShuttingDown && if hasBody s then ret else isPersist
         addConnection hs =
-            if shouldPersist then hs else (H.hConnection, "close") : hs
+            if shouldPersist then hs else (Header.hConnection, "close") : hs
     hs <- addConnection . addAltSvc settings <$> addServerAndDate hs0
     if hasBody s
         then do
@@ -405,7 +405,7 @@ sendRspFile404 conn ii th ver hs0 rspidxhdr maxRspBufSize method =
         (RspBuilder body True)
   where
     s = H.notFound404
-    hs = replaceHeader H.hContentType "text/plain; charset=utf-8" hs0
+    hs = replaceHeader Header.hContentType "text/plain; charset=utf-8" hs0
     body = byteString "File not found"
 
 ----------------------------------------------------------------
@@ -487,7 +487,7 @@ addDate getdate rspidxhdr hdrs
     | hasDate rspidxhdr = return hdrs
     | otherwise = do
         gmtdate <- getdate
-        return $ (H.hDate, gmtdate) : hdrs
+        return $ (Header.hDate, gmtdate) : hdrs
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -172,9 +172,9 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     s = responseStatus response
     hs0 = sanitizeHeaders $ responseHeaders response
     rspidxhdr = indexResponseHeader hs0
-    hasLength = isJust $ rspidxhdr ! fromEnum ResContentLength
+    hasLength = isJust $ rspidxhdr ! ResContentLength
     responseWantsToClose =
-        case rspidxhdr ! fromEnum ResConnection of
+        case rspidxhdr ! ResConnection of
             Nothing -> False
             Just v -> CI.foldCase v == "close"
     isPersist = reqSaysPersist && not responseWantsToClose
@@ -512,9 +512,9 @@ hasBody s =
 -- we'll add it to the headers if there's no other encoding, or add it
 -- to the end in case it is.
 -- (e.g. if a 'Middleware' were to add "Transfer-Encoding: gzip")
-addTransferEncoding :: IndexedHeader -> H.ResponseHeaders -> H.ResponseHeaders
+addTransferEncoding :: IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
 addTransferEncoding rspidxhdr =
-    case rspidxhdr ! fromEnum ResTransferEncoding of
+    case rspidxhdr ! ResTransferEncoding of
         Nothing -> ((Header.hTransferEncoding, "chunked") :)
         Just value -> replaceHeader Header.hTransferEncoding (value <> ", chunked")
 
@@ -562,7 +562,7 @@ replaceHeader k v hdrs = (k, v) : filter ((/= k) . fst) hdrs
 ----------------------------------------------------------------
 
 composeHeaderBuilder
-    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IndexedHeader -> Bool -> IO (Builder, Int)
+    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IndexedResponseHeader -> Bool -> IO (Builder, Int)
 composeHeaderBuilder ver s hs rspidxhdr shouldChunk = do
     bs <- composeHeader ver s finalHdrs
     pure (byteString bs, S.length bs)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -7,7 +7,7 @@
 module Network.Wai.Handler.Warp.Response (
     sendResponse,
     sanitizeHeaderValue, -- for testing
-    containsNewlines, -- for benchmarking
+    containsRecoverableWhitespace, -- for benchmarking
     --  Provided here for backwards compatibility.
     warpVersion,
     hasBody,
@@ -210,21 +210,25 @@ sendResponse settings conn ii th req reqidxhdr src response = do
 
 ----------------------------------------------------------------
 
--- Values without CR/LF (the overwhelmingly common case) leave the
+-- | As per RFC 9110 we replace any newlines (\r\n) or \NUL with spaces
+-- Values without CR/LF/NUL (the overwhelmingly common case) leave the
 -- header list untouched; only a dirty value triggers a rebuild.
 sanitizeHeaders :: H.ResponseHeaders -> H.ResponseHeaders
-sanitizeHeaders hs
-    | any (containsNewlines . snd) hs = map (sanitize <$>) hs -- slow path
-    | otherwise = hs -- fast path
+sanitizeHeaders hdrs
+      -- slow path
+    | any (containsRecoverableWhitespace . snd) hdrs = map (sanitize <$>) hdrs
+      -- fast path
+    | otherwise = hdrs
   where
-    sanitize v
-        | containsNewlines v = sanitizeHeaderValue v
-        | otherwise = v
+    sanitize bs
+        | containsRecoverableWhitespace bs = sanitizeHeaderValue bs
+        | otherwise = bs
 
-{-# INLINE containsNewlines #-}
-containsNewlines :: ByteString -> Bool
--- Each 'S.any (w ==)' is rewritten to a memchr via bytestring's 'anyByte' rule.
-containsNewlines v = S.any (_lf ==) v || S.any (_cr ==) v
+-- Yes, this is quicker than @S.any (\w -> w == _lf || w == _cr || w == _nul)@
+-- because of `bytestring`'s rewrite rules.
+containsRecoverableWhitespace :: ByteString -> Bool
+containsRecoverableWhitespace bs =
+    S.any (_lf ==) bs || S.any (_cr ==) bs || S.any (_nul ==) bs
 
 {-# INLINE isRecoverableWhitespace #-}
 -- | CR, LF and NUL can safely be replaced with a SP according to RFC 9110

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -259,7 +259,7 @@ sanitizeHeaderValue v =
 
 data Rsp
     = RspNoBody
-    | RspFile FilePath (Maybe FilePart) (IndexedRequestHeader) (IO ())
+    | RspFile FilePath (Maybe FilePart) IndexedRequestHeader (IO ())
     | RspBuilder Builder Bool
     | RspStream StreamingBody Bool
     | RspRaw (IO ByteString -> (ByteString -> IO ()) -> IO ()) (IO ByteString)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -27,6 +27,7 @@ import Data.ByteString.Builder.HTTP.Chunked (
  )
 import qualified Data.CaseInsensitive as CI
 import Data.Foldable (for_)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
 import Data.Streaming.ByteString.Builder (
     newByteStringBuilderRecv,
     reuseBufferStrategy,
@@ -283,8 +284,8 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 
 ----------------------------------------------------------------
 
-sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
-    header <- composeHeaderBuilder ver s hs needsChunked
+sendRsp conn _ th ver s hs rspidxhdr maxRspBufSize _ (RspBuilder body needsChunked) = do
+    (header, hdrLen) <- composeHeaderBuilder ver s hs rspidxhdr needsChunked
     let hdrBdy
             | needsChunked =
                 header
@@ -298,23 +299,28 @@ sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
             writeBufferRef
             (\bs -> connSendAll conn bs >> T.tickle th)
             hdrBdy
-    return (Just s, Just len)
+    --              small adjustment to only count the body
+    return (Just s, Just $ len - fromIntegral hdrLen)
 
 ----------------------------------------------------------------
 
-sendRsp conn _ th ver s hs _ _ _ (RspStream streamingBody needsChunked) = do
-    header <- composeHeaderBuilder ver s hs needsChunked
+sendRsp conn _ th ver s hs rspidxhdr _ _ (RspStream streamingBody needsChunked) = do
+    (header, hdrLen) <- composeHeaderBuilder ver s hs rspidxhdr needsChunked
     (recv, finish) <-
         newByteStringBuilderRecv $
             reuseBufferStrategy $
                 toBuilderBuffer $
                     connWriteBuffer conn
+    -- We'll be counting how many bytes we send with this 'IORef'
+    sizeCounter <- newIORef (0 :: Integer)
     let send builder = do
             popper <- recv builder
             let loop = do
                     bs <- popper
                     unless (S.null bs) $ do
                         sendFragment conn th bs
+                        -- add amount of bytes to count
+                        S.length bs `addToCounter` sizeCounter
                         loop
             loop
         sendChunk
@@ -325,7 +331,14 @@ sendRsp conn _ th ver s hs _ _ _ (RspStream streamingBody needsChunked) = do
     when needsChunked $ send chunkedTransferTerminator
     mbs <- finish
     maybe (return ()) (sendFragment conn th) mbs
-    return (Just s, Nothing) -- fixme: can we tell the actual sent bytes?
+    finalSize <- readIORef sizeCounter
+    --              small adjustment to only count the body
+    return (Just s, Just $ finalSize - fromIntegral hdrLen)
+  where
+    addToCounter :: Int -> IORef Integer -> IO ()
+    addToCounter bytes ref =
+        atomicModifyIORef' ref $ \old ->
+            (old + fromIntegral bytes, ())
 
 ----------------------------------------------------------------
 
@@ -547,8 +560,11 @@ replaceHeader k v hdrs = (k, v) : filter ((/= k) . fst) hdrs
 ----------------------------------------------------------------
 
 composeHeaderBuilder
-    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> Bool -> IO Builder
-composeHeaderBuilder ver s hs True =
-    byteString <$> composeHeader ver s (addTransferEncoding hs)
-composeHeaderBuilder ver s hs False =
-    byteString <$> composeHeader ver s hs
+    :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IndexedHeader -> Bool -> IO (Builder, Int)
+composeHeaderBuilder ver s hs rspidxhdr shouldChunk = do
+    bs <- composeHeader ver s finalHdrs
+    pure (byteString bs, S.length bs)
+  where
+    finalHdrs
+        | shouldChunk = addTransferEncoding rspidxhdr hs
+        | otherwise = hs

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -120,17 +120,23 @@ sendResponse
     -> IO Bool
     -- ^ Returing True if the connection is persistent.
 sendResponse settings conn ii th req reqidxhdr src response = do
+    -- Decide connection persistence
     isShuttingDown <-
         case settingsServerState settings of
             Just serverState -> currentShuttingDownState serverState
             -- Should never be reached!
             -- (cf. 'makeServerState' in 'runSettingsConnectionMakerSecure')
             Nothing -> pure False
-    let shouldPersist =
-            not isShuttingDown && if hasBody s then ret else isPersist
+    let shouldPersist = not isShuttingDown && ret
         addConnection hs =
-            if shouldPersist then hs else (Header.hConnection, "close") : hs
+            if shouldPersist || responseWantsToClose
+                then hs
+                else (Header.hConnection, "close") : hs
+
+    -- Adjust headers
     hs <- addConnection . addAltSvc settings <$> addServerAndDate hs0
+
+    -- Start response logic
     if hasBody s
         then do
             -- The response to HEAD does not have body.
@@ -149,20 +155,33 @@ sendResponse settings conn ii th req reqidxhdr src response = do
     T.tickle th
     return shouldPersist
   where
+    -- From Settings --
     defServer = settingsServerName settings
     logger = settingsLogger settings
     maxRspBufSize = settingsMaxBuilderResponseBufferSize settings
+
+    -- From Request --
+    method = requestMethod req
+    isHead = method == H.methodHead
     ver = httpVersion req
+    isHttp11 = ver == H.http11
+    reqSaysPersist = checkReqConnectionHeader isHttp11 reqidxhdr
+
+    -- From Response --
     s = responseStatus response
     hs0 = sanitizeHeaders $ responseHeaders response
     rspidxhdr = indexResponseHeader hs0
+    hasLength = isJust $ rspidxhdr ! fromEnum ResContentLength
+    responseWantsToClose =
+        case rspidxhdr ! fromEnum ResConnection of
+            Nothing -> False
+            Just v -> CI.foldCase v == "close"
+    isPersist = reqSaysPersist && not responseWantsToClose
+
+    -- Other --
     getdate = getDate ii
     addServerAndDate = addDate getdate rspidxhdr . addServer defServer rspidxhdr
-    (isPersist, isChunked0) = infoFromRequest req reqidxhdr
-    isChunked = not isHead && isChunked0
-    (isKeepAlive, needsChunked) = infoFromResponse rspidxhdr (isPersist, isChunked)
-    method = requestMethod req
-    isHead = method == H.methodHead
+    needsChunked = isHttp11 && not hasLength
     rsp = case response of
         ResponseFile _ _ path mPart -> RspFile path mPart reqidxhdr (T.tickle th)
         ResponseBuilder _ _ b
@@ -172,11 +191,20 @@ sendResponse settings conn ii th req reqidxhdr src response = do
             | isHead -> RspNoBody
             | otherwise -> RspStream fb needsChunked
         ResponseRaw raw _ -> RspRaw raw src
+    -- Should be False if (http10 && not hasLength), regardless of what
+    -- the 'Connection' header says. (as long as the response should have a body)
+    isKeepAlive =
+        isPersist && (isHttp11 || hasLength || isHead || not (hasBody s))
     -- Make sure we don't hang on to 'response' (avoid space leak)
     !ret = case response of
+        -- Will get 'Content-Length' header later on using the
+        -- 'addContentHeaders(ForFilePart)' functions, so if the
+        -- 'Connection' header says we persist, we persist.
         ResponseFile{} -> isPersist
         ResponseBuilder{} -> isKeepAlive
         ResponseStream{} -> isKeepAlive
+        -- Is already an ongoing open connection, so if it is done,
+        -- the connection should be closed.
         ResponseRaw{} -> False
 
 ----------------------------------------------------------------
@@ -438,49 +466,23 @@ sendFragment Connection{connSendAll = send} th bs = do
 
 ----------------------------------------------------------------
 
-infoFromRequest
-    :: Request
-    -> IndexedRequestHeader
-    -> ( Bool -- isPersist
-       , Bool -- isChunked
-       )
-infoFromRequest req reqidxhdr = (checkPersist req reqidxhdr, checkChunk req)
-
-checkPersist :: Request -> IndexedRequestHeader -> Bool
-checkPersist req reqidxhdr
-    | ver == H.http11 = checkPersist11 conn
-    | otherwise = checkPersist10 conn
-  where
-    ver = httpVersion req
-    conn = reqidxConnection reqidxhdr
-    checkPersist11 (Just x)
-        | CI.foldCase x == "close" = False
-    checkPersist11 _ = True
-    checkPersist10 (Just x)
-        | CI.foldCase x == "keep-alive" = True
-    checkPersist10 _ = False
-
-checkChunk :: Request -> Bool
-checkChunk req = httpVersion req == H.http11
+-- | We infer from the request whether the connection should be persisted.
+checkReqConnectionHeader :: Bool -> IndexedRequestHeader -> Bool
+checkReqConnectionHeader isHttp11 reqidxhdr =
+    case reqidxConnection reqidxhdr of
+        -- If no "Connection" header, then default: HTTP/1.1 == persist
+        Nothing -> isHttp11
+        Just val ->
+            let connValue = CI.foldCase val
+             in if isHttp11
+                    then connValue /= "close"
+                    else connValue == "keep-alive"
 
 ----------------------------------------------------------------
 
--- Used for ResponseBuilder and ResponseSource.
--- Don't use this for ResponseFile since this logic does not fit
--- for ResponseFile. For instance, isKeepAlive should be True in some cases
--- even if the response header does not have Content-Length.
+-- | Only checks for status codes, NOT for methods.
 --
--- Content-Length is specified by a reverse proxy.
--- Note that CGI does not specify Content-Length.
-infoFromResponse :: ResponseHeaderPresence -> (Bool, Bool) -> (Bool, Bool)
-infoFromResponse rspidxhdr (isPersist, isChunked) = (isKeepAlive, needsChunked)
-  where
-    needsChunked = isChunked && not hasLength
-    isKeepAlive = isPersist && (isChunked || hasLength)
-    hasLength = hasContentLength rspidxhdr
-
-----------------------------------------------------------------
-
+-- This is by design and some handling relies on HEAD being a separate check.
 hasBody :: H.Status -> Bool
 hasBody s =
     sc /= 204

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -18,13 +18,13 @@ module Network.Wai.Handler.Warp.Response (
 
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
+import Data.ByteString.Internal (toForeignPtr, unsafeCreate)
 import Data.ByteString.Builder (Builder, byteString)
 import Data.ByteString.Builder.Extra (flush)
 import Data.ByteString.Builder.HTTP.Chunked (
     chunkedTransferEncoding,
     chunkedTransferTerminator,
  )
-import qualified Data.ByteString.Char8 as C8
 import qualified Data.CaseInsensitive as CI
 import Data.Function (on)
 import Data.List (deleteBy)
@@ -32,7 +32,8 @@ import Data.Streaming.ByteString.Builder (
     newByteStringBuilderRecv,
     reuseBufferStrategy,
  )
-import Data.Word8 (_cr, _lf, _space, _tab)
+import Data.Word8 (_cr, _lf, _nul, _space)
+import Foreign (copyBytes, plusForeignPtr, pokeByteOff, withForeignPtr)
 import qualified Network.HTTP.Types as H
 import qualified Network.HTTP.Types.Header as Header
 import Network.Wai
@@ -197,17 +198,30 @@ containsNewlines :: ByteString -> Bool
 -- Each 'S.any (w ==)' is rewritten to a memchr via bytestring's 'anyByte' rule.
 containsNewlines v = S.any (_lf ==) v || S.any (_cr ==) v
 
-{-# INLINE sanitizeHeaderValue #-}
+{-# INLINE isRecoverableWhitespace #-}
+-- | CR, LF and NUL can safely be replaced with a SP according to RFC 9110
+-- <https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-5>
+isRecoverableWhitespace :: Word8 -> Bool
+isRecoverableWhitespace w = w == _cr || w == _lf || w == _nul
+
 sanitizeHeaderValue :: ByteString -> ByteString
-sanitizeHeaderValue v = case C8.lines $ S.filter (/= _cr) v of
-    [] -> ""
-    x : xs -> C8.intercalate "\r\n" (x : mapMaybe addSpaceIfMissing xs)
+sanitizeHeaderValue v =
+    case S.findIndices isRecoverableWhitespace v of
+        -- Nothing to replace
+        [] -> v
+        -- Found CR, LF or NUL.
+        ixs ->
+            unsafeCreate len $ \dst -> do
+                withForeignPtr fptr $ \src -> do
+                    -- copy the bytestring
+                    copyBytes dst src len
+                    -- and then replace the offending bytes
+                    for_ ixs $ \ix -> pokeByteOff dst ix _space
   where
-    addSpaceIfMissing line = case S.uncons line of
-        Nothing -> Nothing
-        Just (first, _)
-            | first == _space || first == _tab -> Just line
-            | otherwise -> Just $ _space `S.cons` line
+    (fptr', offset, len) = toForeignPtr v
+    -- We need to use the offset for backwards compatibility with
+    -- "bytestring < 0.11"
+    fptr = fptr' `plusForeignPtr` offset
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -6,7 +6,7 @@ module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
 import qualified Data.CaseInsensitive as CI
-import Data.List as L (foldl')
+import Data.List as List (foldl')
 import Data.Word8
 import Foreign.Ptr
 import GHC.Storable
@@ -23,7 +23,7 @@ composeHeader !httpversion !status !responseHeaders = create len $ \ptr -> do
     ptr2 <- copyHeaders ptr1 responseHeaders
     void $ copyCRLF ptr2
   where
-    !len = 17 + slen + L.foldl' fieldLength 0 responseHeaders
+    !len = 17 + slen + List.foldl' fieldLength 0 responseHeaders
     fieldLength !l (!k, !v) = l + S.length (CI.original k) + S.length v + 4
     !slen = S.length $ H.statusMessage status
 

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -140,6 +140,13 @@ data Settings = Settings
     , settingsLogger :: Request -> H.Status -> Maybe Integer -> IO ()
     -- ^ A log function. Default: no action.
     --
+    -- @settingsLogger req status mSentBytes@
+    --
+    -- /N.B. @Maybe Integer@ is the concrete bytes of the message body/
+    -- /after all the headers have been sent. This is 'Nothing' when the/
+    -- /response has either no body, or 'responseRaw' is used./
+    -- /(e.g. when using websockets)/
+    --
     -- Since 3.1.10
     , settingsServerPushLogger :: Request -> ByteString -> Integer -> IO ()
     -- ^ A HTTP/2 server push log function. Default: no action.

--- a/warp/Network/Wai/Handler/Warp/Settings.hs
+++ b/warp/Network/Wai/Handler/Warp/Settings.hs
@@ -143,9 +143,8 @@ data Settings = Settings
     -- @settingsLogger req status mSentBytes@
     --
     -- /N.B. @Maybe Integer@ is the concrete bytes of the message body/
-    -- /after all the headers have been sent. This is 'Nothing' when the/
-    -- /response has either no body, or 'responseRaw' is used./
-    -- /(e.g. when using websockets)/
+    -- /after all the headers have been sent. This is 'Nothing' when/
+    -- /'responseRaw' is used. (e.g. when using websockets)/
     --
     -- Since 3.1.10
     , settingsServerPushLogger :: Request -> ByteString -> Integer -> IO ()

--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -19,7 +19,7 @@ import qualified Network.HTTP.Types as H
 import Prelude hiding (lines)
 
 import Network.Wai.Handler.Warp.Request (FirstRequest (..), headerLines)
-import Network.Wai.Handler.Warp.Response (containsNewlines)
+import Network.Wai.Handler.Warp.Response (containsRecoverableWhitespace)
 import Network.Wai.Handler.Warp.Types
 
 import Criterion.Main
@@ -56,13 +56,14 @@ main = do
             , bench "new parsing 100" $ whnfAppIO testIt (chunkRequest 100)
             ]
         , bgroup
-            "containsNewlines"
-            -- Clean values (no CR/LF) are the overwhelmingly common case and
+            "containsRecoverableWhitespace"
+            -- Clean values (no CR/LF/NUL) are the overwhelmingly common case and
             -- the one the fast path must stay cheap for; the dirty case is
             -- what forces a rebuild in 'sanitizeHeaders'.
-            [ bench "clean short" $ whnf containsNewlines "Mighttpd/2.5.8"
-            , bench "clean long" $ whnf containsNewlines cleanLong
-            , bench "dirty" $ whnf containsNewlines "text/html\r\nInjected: header"
+            [ bench "clean short" $ whnf containsRecoverableWhitespace "Mighttpd/2.5.8"
+            , bench "clean long" $ whnf containsRecoverableWhitespace cleanLong
+            , bench "dirty" $
+                whnf containsRecoverableWhitespace "text/html\r\nInjected: header"
             ]
         ]
   where

--- a/warp/test/BufferSpec.hs
+++ b/warp/test/BufferSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module BufferSpec (main, spec) where
+
+import qualified Data.ByteString as S
+import qualified Data.ByteString.Builder as BLD
+import Data.IORef as I
+import Network.Wai.Handler.Warp.Buffer (createWriteBuffer)
+import Network.Wai.Handler.Warp.IO (toBufIOWith)
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck (NonNegative (..), withMaxSize)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = describe "toBufIOWith" $ do
+    it "counts short bytestrings" $
+        testBufIOWith 10
+    -- This failed before fixing 'toBufIOWith'
+    it "counts long bytestrings" $ do
+        testBufIOWith 1000000
+    prop "counts bytestrings of different sizes" . withMaxSize 10000000 $
+        \(NonNegative i) -> testBufIOWith i
+
+testBufIOWith :: Int -> Expectation
+testBufIOWith bsLen = do
+    len <- toBufIOWithBuilder $ BLD.byteString $ S.replicate bsLen 0
+    len `shouldBe` fromIntegral bsLen
+
+toBufIOWithBuilder :: BLD.Builder -> IO Integer
+toBufIOWithBuilder bld = do
+    countRef <- newIORef 0 :: IO (IORef Int)
+    buf <- createWriteBuffer 16384
+    bufRef <- newIORef buf
+    let go bs = modifyIORef' countRef (+ S.length bs)
+    toBufIOWith 1049000000 bufRef go bld

--- a/warp/test/BufferSpec.hs
+++ b/warp/test/BufferSpec.hs
@@ -9,7 +9,7 @@ import Network.Wai.Handler.Warp.Buffer (createWriteBuffer)
 import Network.Wai.Handler.Warp.IO (toBufIOWith)
 import Test.Hspec
 import Test.Hspec.QuickCheck
-import Test.QuickCheck (NonNegative (..), withMaxSize)
+import Test.QuickCheck (NonNegative (..))
 
 main :: IO ()
 main = hspec spec
@@ -21,7 +21,7 @@ spec = describe "toBufIOWith" $ do
     -- This failed before fixing 'toBufIOWith'
     it "counts long bytestrings" $ do
         testBufIOWith 1000000
-    prop "counts bytestrings of different sizes" . withMaxSize 10000000 $
+    modifyMaxSize (const 10000000) . prop "counts bytestrings of different sizes" $
         \(NonNegative i) -> testBufIOWith i
 
 testBufIOWith :: Int -> Expectation

--- a/warp/test/ConnectionSpec.hs
+++ b/warp/test/ConnectionSpec.hs
@@ -2,73 +2,80 @@
 
 module ConnectionSpec (spec) where
 
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as S8
 import Network.HTTP.Types
 import Network.Wai
 import Network.Wai.Handler.Warp
-import RunSpec (withApp, withMySocket, msWrite, msRead)
+import RunSpec (msRead, msWrite, withApp, withMySocket)
 import Test.Hspec
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as S8
 
 spec :: Spec
 spec = describe "Connection header" $ do
-        it "sends Connection: close when response implies close (HTTP/1.0 Keep-Alive, no Content-Length)" $ do
-            let app _ f = f $ responseLBS status200 [] "foo"
+    describe "HTTP/1.0 Connection: close behavior" $ do
+        -- HTTP/1.0 defaults to close. We ask for Keep-Alive.
+        -- But we provide no Content-Length in response.
+        -- So Warp should decide to close (because it can't keep alive without length or chunking),
+        -- and MUST send "Connection: close" to inform the client.
+        -- (In HTTP/1.0 this requires closing the connection to delimit the
+        -- response; or rather, lack of persistence info)
+        testClose
+            "when response implies close (HTTP/1.0 Keep-Alive, but no Content-Length)"
+            (responseLBS status200 [] "foo")
+            "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
+        testClose
+            "sends \"Connection: close\" on regular HTTP/1.0 GET request"
+            (responseBuilder status200 [] "foo")
+            "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"
+
+    describe "HTTP/1.1 Connection: close behavior" $ do
+        -- Response has no Content-Length and is not chunked (HEAD implies no body).
+        it "does NOT send \"Connection: close\" for HTTP/1.1 HEAD request" $ do
+            let app _ f = f $ responseBuilder status200 [] "foo"
             withApp defaultSettings app $ withMySocket $ \ms -> do
-                -- HTTP/1.0 defaults to close. We ask for Keep-Alive.
-                -- But we provide no Content-Length in response.
-                -- So Warp should decide to close (because it can't keep alive without length or chunking),
-                -- and MUST send "Connection: close" to inform the client.
-                msWrite ms "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
-                
-                -- We expect the connection to be closed by the server, so reading a large amount 
+                msWrite ms "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                -- Should include the Connection header if present and also
+                -- should be less then all headers when it's absent, so we
+                -- don't wait for nothing.
+                response <- msRead ms 73
+                let headers = parseHeaders response
+                lookup "Connection" headers `shouldBe` Nothing
+        testClose
+            "when GET request has \"Connection: close\" (200 OK)"
+            (responseLBS status200 [] "foo")
+            "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        testClose
+            "when HEAD request has \"Connection: close\" (200 OK)"
+            (responseLBS status200 [] "foo")
+            "HEAD / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        testClose
+            "when request has \"Connection: close\" (204 No Content)"
+            (responseLBS status204 [] "")
+            "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        testClose
+            "when request has \"Connection: close\" (500 Internal Server Error)"
+            (responseLBS status500 [] "error")
+            "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+  where
+    testClose name res input = do
+        let prefix = "sends \"Connection: close\" "
+        it (prefix <> name) $ do
+            let app _ f = f res
+            withApp defaultSettings app $ withMySocket $ \ms -> do
+                msWrite ms input
+                -- We expect the connection to be closed by the server, so reading a large amount
                 -- should return whatever was sent and then finish.
                 response <- msRead ms 4096
-                
                 let headers = parseHeaders response
                 lookup "Connection" headers `shouldBe` Just "close"
-    
-        describe "HTTP/1.1 Connection: close behavior" $ do
-            it "sends Connection: close for HEAD request without Content-Length" $ do
-                -- Response has no Content-Length and is not chunked (HEAD implies no body).
-                -- In HTTP/1.1 this requires closing the connection to delimit the response (or rather, lack of persistence info).
-                let app _ f = f $ responseBuilder status200 [] "foo"
-                withApp defaultSettings app $ withMySocket $ \ms -> do
-                    msWrite ms "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n"
-                    response <- msRead ms 4096
-                    let headers = parseHeaders response
-                    lookup "Connection" headers `shouldBe` Just "close"
-    
-            it "sends Connection: close when request has Connection: close (200 OK)" $ do
-                let app _ f = f $ responseLBS status200 [] "foo"
-                withApp defaultSettings app $ withMySocket $ \ms -> do
-                    msWrite ms "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-                    response <- msRead ms 4096
-                    let headers = parseHeaders response
-                    lookup "Connection" headers `shouldBe` Just "close"
-    
-            it "sends Connection: close when request has Connection: close (204 No Content)" $ do
-                let app _ f = f $ responseLBS status204 [] ""
-                withApp defaultSettings app $ withMySocket $ \ms -> do
-                    msWrite ms "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-                    response <- msRead ms 4096
-                    let headers = parseHeaders response
-                    lookup "Connection" headers `shouldBe` Just "close"
-    
-            it "sends Connection: close when request has Connection: close (500 Internal Server Error)" $ do
-                let app _ f = f $ responseLBS status500 [] "error"
-                withApp defaultSettings app $ withMySocket $ \ms -> do
-                    msWrite ms "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
-                    response <- msRead ms 4096
-                    let headers = parseHeaders response
-                    lookup "Connection" headers `shouldBe` Just "close"
+
 parseHeaders :: ByteString -> [(ByteString, ByteString)]
-parseHeaders bs = 
-    let ls = S8.lines bs
+parseHeaders bs =
+    let allLines = S8.lines bs
         -- Drop status line
-        headerLines = takeWhile (not . S8.null . S8.filter (/= '\r')) $ drop 1 ls
-        parseLine line = 
+        headerLines = takeWhile (not . S8.null . S8.filter (/= '\r')) $ drop 1 allLines
+        parseLine line =
             let (k, v) = S8.break (== ':') line
                 v' = S8.takeWhile (/= '\r') v
-            in (k, S8.dropWhile (== ' ') $ S8.drop 1 v')
-    in map parseLine headerLines
+             in (k, S8.dropWhile (== ' ') $ S8.drop 1 v')
+     in map parseLine headerLines

--- a/warp/test/ResponseSpec.hs
+++ b/warp/test/ResponseSpec.hs
@@ -73,35 +73,15 @@ testPartial size offset count out = it title $ withApp defaultSettings app $ wit
 
 spec :: Spec
 spec = do
-    {- http-client does not support this.
-        describe "preventing response splitting attack" $ do
-            it "sanitizes header values" $ do
-                let app _ respond = respond $ responseLBS status200 [("foo", "foo\r\nbar")] "Hello"
-                withApp defaultSettings app $ \port -> do
-                    res <- sendGET $ "http://127.0.0.1:" ++ show port
-                    getHeaderValue "foo" (responseHeaders res) `shouldBe`
-                      Just "foo   bar" -- HTTP inserts two spaces for \r\n.
-    -}
-
     describe "sanitizeHeaderValue" $ do
-        it "doesn't alter valid multiline header values" $ do
-            sanitizeHeaderValue "foo\r\n bar" `shouldBe` "foo\r\n bar"
-
-        it "adds missing spaces after \r\n" $ do
-            sanitizeHeaderValue "foo\r\nbar" `shouldBe` "foo\r\n bar"
-
-        it "discards empty lines" $ do
-            sanitizeHeaderValue "foo\r\n\r\nbar" `shouldBe` "foo\r\n bar"
-
-        context "when sanitizing single occurrences of \n" $ do
-            it "replaces \n with \r\n" $ do
-                sanitizeHeaderValue "foo\n bar" `shouldBe` "foo\r\n bar"
-
-            it "adds missing spaces after \n" $ do
-                sanitizeHeaderValue "foo\nbar" `shouldBe` "foo\r\n bar"
-
-        it "discards single occurrences of \r" $ do
-            sanitizeHeaderValue "foo\rbar" `shouldBe` "foobar"
+        it "replaces multiline header value's [CR LF NUL] with SP" $ do
+            sanitizeHeaderValue "foo\r\n bar" `shouldBe` "foo   bar"
+            sanitizeHeaderValue "foo\r\n\NULbar" `shouldBe` "foo   bar"
+            sanitizeHeaderValue "foo\r\n\r\nbar" `shouldBe` "foo    bar"
+            sanitizeHeaderValue "foo\n bar" `shouldBe` "foo  bar"
+            sanitizeHeaderValue "foo\nbar" `shouldBe` "foo bar"
+            sanitizeHeaderValue "foo\rbar" `shouldBe` "foo bar"
+            sanitizeHeaderValue "foo\NULbar" `shouldBe` "foo bar"
 
     describe "range requests" $ do
         testRange "2-3" "23" $ Just "2-3/16"

--- a/warp/test/RunSpec.hs
+++ b/warp/test/RunSpec.hs
@@ -150,7 +150,7 @@ withApp settings app f = do
         ( const $ do
             takeMVar baton
             -- use timeout to make sure we don't take too long
-            mres <- timeout (60 * 1000 * 1000) (f port)
+            mres <- timeout (3 * 1000 * 1000) (f port)
             case mres of
                 Nothing -> error "Timeout triggered, too slow!"
                 Just a -> pure a
@@ -392,7 +392,7 @@ spec = do
                             `onException` liftIO
                                 (I.atomicModifyIORef ifront (\front -> (front . ("consume interrupted" :), ())))
                     liftIO $
-                        threadDelay 4000000 `E.catch` \e -> do
+                        threadDelay 500000 `E.catch` \e -> do
                             I.atomicModifyIORef
                                 ifront
                                 ( \front ->
@@ -415,7 +415,7 @@ spec = do
                 msWrite ms bs1
                 threadDelay 100000
                 msWrite ms bs2
-                threadDelay 5000000
+                threadDelay 1000000
                 front <- I.readIORef ifront
                 S.concat (front []) `shouldBe` bs
     describe "raw body" $ do

--- a/warp/test/WithApplicationSpec.hs
+++ b/warp/test/WithApplicationSpec.hs
@@ -9,6 +9,7 @@ import System.Environment
 import System.Process
 import Test.Hspec
 
+import Network.Wai.Handler.Warp (defaultSettings, setOnException)
 import Network.Wai.Handler.Warp.WithApplication
 
 -- All these tests assume the "curl" process can be called directly.
@@ -31,16 +32,21 @@ spec = do
 
         it "does not propagate exceptions from the server to the executing thread" $ do
             let mkApp = return $ \_request _respond -> throwIO $ ErrorCall "foo"
-            withApplication mkApp $ \port -> do
+            withApplicationSettings silentSettings mkApp $ \port -> do
                 output <- readProcess "curl" ["-s", "localhost:" ++ show port] ""
-                output `shouldContain` "Something went wron"
+                output `shouldContain` "Something went wrong"
 
     describe "testWithApplication" $ do
         it "propagates exceptions from the server to the executing thread" $ do
             let mkApp = return $ \_request _respond -> throwIO $ ErrorCall "foo"
-            testWithApplication
+            testWithApplicationSettings
+                silentSettings
                 mkApp
                 ( \port -> do
                     readProcess "curl" ["-s", "localhost:" ++ show port] ""
                 )
                 `shouldThrow` (errorCall "foo")
+  where
+    -- So that we don't muddy the test result screen.
+    -- (normally, 'defaultSettings' use 'defaultOnException', sending to 'stderr')
+    silentSettings = setOnException (\_ _ -> pure ()) defaultSettings

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -179,6 +179,7 @@ test-suite spec
     build-tool-depends: hspec-discover:hspec-discover
     hs-source-dirs:     test .
     other-modules:
+        BufferSpec
         ConduitSpec
         ConnectionSpec
         EarlyHintsSpec


### PR DESCRIPTION
- [x] Bumped the version number
- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Wanted to tackle #956 and ended up encountering more small instances that were either outdated or (technically) wrong.

So from largest changes to smallest:
- Revised keep alive / persistence logic
- Replaced sanitization of header values (no more multiline folding, as per RFC 9110)
- Count message bodies better for `settingsLogger` purposes
- Only add headers if not already set, AND handle "Transfer-Encoding" better
- Documentation/comments