### PR TITLE
upper bound for 'http-types'

### DIFF
--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -27,7 +27,7 @@ library
     build-depends:   base                      >= 4.12     && < 5
                    , wai                       >= 3.0      && < 3.3
                    , bytestring                >= 0.10.4
-                   , http-types                >= 0.7
+                   , http-types                >= 0.7      && < 1
                    , transformers              >= 0.2.2
                    , unix-compat               >= 0.2
                    , directory                 >= 1.0.1

--- a/wai-conduit/Network/Wai/Conduit.hs
+++ b/wai-conduit/Network/Wai/Conduit.hs
@@ -18,7 +18,7 @@ import qualified Data.ByteString as S
 import Data.ByteString.Builder (Builder)
 import Data.Conduit
 import qualified Data.Conduit.List as CL
-import Network.HTTP.Types
+import Network.HTTP.Types (ResponseHeaders, Status)
 import Network.Wai
 
 -- | Stream the request body.

--- a/wai-extra/wai-extra.cabal
+++ b/wai-extra/wai-extra.cabal
@@ -113,7 +113,7 @@ Library
                    , data-default
                    , directory                 >= 1.2.7.0
                    , fast-logger               >= 2.4.5
-                   , http-types                >= 0.7
+                   , http-types                >= 0.7      && < 1
                    , HUnit
                    , iproute                   >= 1.7.8
                    , network                   >= 2.6.1.0

--- a/wai-websockets/wai-websockets.cabal
+++ b/wai-websockets/wai-websockets.cabal
@@ -24,7 +24,7 @@ Library
                    , case-insensitive   >= 0.2
                    , transformers       >= 0.2
                    , websockets         >= 0.9
-                   , http-types
+                   , http-types                        < 1
   Exposed-modules:   Network.Wai.Handler.WebSockets
   ghc-options:       -Wall
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -107,7 +107,7 @@ library
         containers,
         hashable,
         http-date,
-        http-types >=0.12,
+        http-types >=0.12 && <1,
         http2 >=5.4 && <5.5,
         iproute >=1.3.1,
         recv >=0.1.0 && <0.2.0,


### PR DESCRIPTION
Because I'm preparing for a major-major rework of headers (in the far future), we should add upper bounds in future releases ASAP. The packages that do not use headers from 'http-types' do not need an upper bound. ('wai' uses type synonyms only, which is forwards-compatible)

I have not bumped any versions, since this can just be updated when a new release is made.
We're going to have to revise a bunch of older versions anyway if an `http-types-1.x` is released.