### PR TITLE
Safer IndexedHeader 

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog for warp
 
+## 3.4.15
+
+* Add phantom type parameter to `IndexedHeader` to catch request/response
+  mismatches at compile time. This does change the API of
+  `Network.Wai.Handler.Warp.Internal`, so this gets a minor version bump.
+  [#1088](https://github.com/yesodweb/wai/pull/1088)
+
 ## 3.4.14
 
 * Important bugfix to not deadlock on empty file descriptors if the cause of

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -9,7 +9,6 @@ module Network.Wai.Handler.Warp.File (
     H.parseByteRanges,
 ) where
 
-import Data.Array ((!))
 import qualified Data.ByteString.Char8 as C8 (pack)
 import Network.HTTP.Date
 import qualified Network.HTTP.Types as H
@@ -34,16 +33,14 @@ conditionalRequest
     :: I.FileInfo
     -> H.ResponseHeaders
     -> H.Method
-    -> IndexedHeader
-    -- ^ Response
-    -> IndexedHeader
-    -- ^ Request
+    -> IndexedResponseHeader
+    -> IndexedRequestHeader
     -> RspFileInfo
 conditionalRequest finfo hs0 method rspidx reqidx = case condition of
     nobody@(WithoutBody _) -> nobody
     WithBody s _ off len ->
         let !hs1 = addContentHeaders hs0 off len size
-            !hs = case rspidx ! fromEnum ResLastModified of
+            !hs = case rspidx ! ResLastModified of
                 Just _ -> hs1
                 Nothing -> (H.hLastModified, date) : hs1
          in WithBody s hs off len
@@ -72,57 +69,67 @@ conditionalRequest finfo hs0 method rspidx reqidx = case condition of
 
 ----------------------------------------------------------------
 
-ifModifiedSince :: IndexedHeader -> Maybe HTTPDate
-ifModifiedSince reqidx = reqidx ! fromEnum ReqIfModifiedSince >>= parseHTTPDate
+ifModifiedSince :: IndexedRequestHeader -> Maybe HTTPDate
+ifModifiedSince reqidx = reqidx ! ReqIfModifiedSince >>= parseHTTPDate
 
-ifUnmodifiedSince :: IndexedHeader -> Maybe HTTPDate
-ifUnmodifiedSince reqidx = reqidx ! fromEnum ReqIfUnmodifiedSince >>= parseHTTPDate
+ifUnmodifiedSince :: IndexedRequestHeader -> Maybe HTTPDate
+ifUnmodifiedSince reqidx = reqidx ! ReqIfUnmodifiedSince >>= parseHTTPDate
 
-ifRange :: IndexedHeader -> Maybe HTTPDate
-ifRange reqidx = reqidx ! fromEnum ReqIfRange >>= parseHTTPDate
+ifRange :: IndexedRequestHeader -> Maybe HTTPDate
+ifRange reqidx = reqidx ! ReqIfRange >>= parseHTTPDate
 
 ----------------------------------------------------------------
 
-ifmodified :: IndexedHeader -> HTTPDate -> H.Method -> Maybe RspFileInfo
+ifmodified
+    :: IndexedRequestHeader
+    -> HTTPDate
+    -> H.Method
+    -> Maybe RspFileInfo
 ifmodified reqidx mtime method = do
     date <- ifModifiedSince reqidx
     -- According to RFC 9110:
     -- "A recipient MUST ignore If-Modified-Since if the request
     -- contains an If-None-Match header field; [...]"
-    guard . isNothing $ reqidx ! fromEnum ReqIfNoneMatch
+    guard . isNothing $ reqidx ! ReqIfNoneMatch
     -- "A recipient MUST ignore the If-Modified-Since header field
     -- if [...] the request method is neither GET nor HEAD."
     guard $ method == H.methodGet || method == H.methodHead
     guard $ date == mtime || date > mtime
     Just $ WithoutBody H.notModified304
 
-ifunmodified :: IndexedHeader -> HTTPDate -> Maybe RspFileInfo
+ifunmodified
+    :: IndexedRequestHeader -> HTTPDate -> Maybe RspFileInfo
 ifunmodified reqidx mtime = do
     date <- ifUnmodifiedSince reqidx
     -- According to RFC 9110:
     -- "A recipient MUST ignore If-Unmodified-Since if the request
     -- contains an If-Match header field; [...]"
-    guard . isNothing $ reqidx ! fromEnum ReqIfMatch
+    guard . isNothing $ reqidx ! ReqIfMatch
     guard $ date /= mtime && date < mtime
     Just $ WithoutBody H.preconditionFailed412
 
 -- TODO: Should technically also strongly match on ETags.
-ifrange :: IndexedHeader -> HTTPDate -> H.Method -> Integer -> Maybe RspFileInfo
+ifrange
+    :: IndexedRequestHeader
+    -> HTTPDate
+    -> H.Method
+    -> Integer
+    -> Maybe RspFileInfo
 ifrange reqidx mtime method size = do
     -- According to RFC 9110:
     -- "When the method is GET and both Range and If-Range are
     -- present, evaluate the If-Range precondition:"
     date <- ifRange reqidx
-    rng <- reqidx ! fromEnum ReqRange
+    rng <- reqidx ! ReqRange
     guard $ method == H.methodGet
     return $
         if date == mtime
             then parseRange rng size
             else WithBody H.ok200 [] 0 size
 
-unconditional :: IndexedHeader -> Integer -> RspFileInfo
+unconditional :: IndexedRequestHeader -> Integer -> RspFileInfo
 unconditional reqidx =
-    case reqidx ! fromEnum ReqRange of
+    case reqidx ! ReqRange of
         Nothing -> WithBody H.ok200 [] 0
         Just rng -> parseRange rng
 

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -181,7 +181,7 @@ processRequest
     -> Source
     -> Request
     -> Maybe (IORef Int)
-    -> IndexedHeader
+    -> IndexedRequestHeader
     -> IO ByteString
     -> IO ReuseConnection
 processRequest settings ii conn app th istatus src req mremainingRef idxhdr nextBodyFlush = do

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -3,6 +3,8 @@
 
 module Network.Wai.Handler.Warp.Header (
     IndexedHeader,
+    IndexedRequestHeader,
+    IndexedResponseHeader,
     (!),
     RequestHeaderIndex (..),
     indexRequestHeader,
@@ -25,6 +27,9 @@ import Network.Wai.Handler.Warp.Types
 
 -- | Array for a set of HTTP headers.
 newtype IndexedHeader a = IxHeader (Array Int (Maybe HeaderValue))
+
+type IndexedRequestHeader = IndexedHeader RequestHeaderIndex
+type IndexedResponseHeader = IndexedHeader ResponseHeaderIndex
 
 -- | Safer way to lookup 'IndexedHeader' values
 (!) :: Enum a => IndexedHeader a -> a -> Maybe HeaderValue

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -1,9 +1,19 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Network.Wai.Handler.Warp.Header where
+module Network.Wai.Handler.Warp.Header (
+    IndexedHeader,
+    (!),
+    RequestHeaderIndex (..),
+    indexRequestHeader,
+    requestMaxIndex,
+    defaultIndexRequestHeader,
+    ResponseHeaderIndex (..),
+    indexResponseHeader,
+) where
 
-import Data.Array
+import Data.Array (Array, array)
+import qualified Data.Array as A ((!))
 import Data.Array.ST
 import qualified Data.ByteString as BS
 import Data.CaseInsensitive (foldedCase)
@@ -14,11 +24,15 @@ import Network.Wai.Handler.Warp.Types
 ----------------------------------------------------------------
 
 -- | Array for a set of HTTP headers.
-type IndexedHeader = Array Int (Maybe HeaderValue)
+newtype IndexedHeader a = IxHeader (Array Int (Maybe HeaderValue))
+
+-- | Safer way to lookup 'IndexedHeader' values
+(!) :: Enum a => IndexedHeader a -> a -> Maybe HeaderValue
+(IxHeader ixHdr) ! ix = ixHdr A.! fromEnum ix
 
 ----------------------------------------------------------------
 
-indexRequestHeader :: RequestHeaders -> IndexedHeader
+indexRequestHeader :: RequestHeaders -> IndexedHeader RequestHeaderIndex
 indexRequestHeader hdr = traverseHeader hdr requestMaxIndex requestKeyIndex
 
 data RequestHeaderIndex
@@ -78,12 +92,14 @@ requestKeyIndex hn = case BS.length bs of
   where
     bs = foldedCase hn
 
-defaultIndexRequestHeader :: IndexedHeader
-defaultIndexRequestHeader = array (0, requestMaxIndex) [(i, Nothing) | i <- [0 .. requestMaxIndex]]
+defaultIndexRequestHeader :: IndexedHeader RequestHeaderIndex
+defaultIndexRequestHeader =
+    IxHeader $
+        array (0, requestMaxIndex) [(i, Nothing) | i <- [0 .. requestMaxIndex]]
 
 ----------------------------------------------------------------
 
-indexResponseHeader :: ResponseHeaders -> IndexedHeader
+indexResponseHeader :: ResponseHeaders -> IndexedHeader ResponseHeaderIndex
 indexResponseHeader hdr = traverseHeader hdr responseMaxIndex responseKeyIndex
 
 data ResponseHeaderIndex
@@ -109,8 +125,8 @@ responseKeyIndex hn = case BS.length bs of
 
 ----------------------------------------------------------------
 
-traverseHeader :: [Header] -> Int -> (HeaderName -> Int) -> IndexedHeader
-traverseHeader hdr maxidx getIndex = runSTArray $ do
+traverseHeader :: [Header] -> Int -> (HeaderName -> Int) -> IndexedHeader a
+traverseHeader hdr maxidx getIndex = IxHeader $ runSTArray $ do
     arr <- newArray (0, maxidx) Nothing
     mapM_ (insert arr) hdr
     return arr

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -61,8 +61,10 @@ module Network.Wai.Handler.Warp.Internal (
     -- * Data types
     InternalInfo (..),
     HeaderValue,
-    IndexedHeader,
-    requestMaxIndex,
+    IndexedRequestHeader,
+    -- I assume 'requestMaxIndex' was used in case anyone wanted to create
+    -- an empty array, so we replace it with 'defaultIndexRequestHeader'.
+    defaultIndexRequestHeader,
 
     -- * Time out manager
 

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -15,7 +15,6 @@ module Network.Wai.Handler.Warp.Request (
 ) where
 
 import qualified Control.Concurrent as Conc (yield)
-import Data.Array ((!))
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Unsafe as SU
 import qualified Data.CaseInsensitive as CI
@@ -68,7 +67,7 @@ recvRequest
     -> IO
         ( Request
         , Maybe (I.IORef Int)
-        , IndexedHeader
+        , IndexedRequestHeader
         , IO ByteString
         )
     -- ^
@@ -81,7 +80,7 @@ recvRequest firstRequest settings conn ii th addr src transport = do
     (method, unparsedPath, path, query, httpversion, hdr) <-
         parseHeaderLines hdrlines
     let idxhdr = indexRequestHeader hdr
-        expect = idxhdr ! fromEnum ReqExpect
+        expect = idxhdr ! ReqExpect
         handle100Continue = handleExpect conn httpversion expect
     (rbody, remainingRef, bodyLength) <- bodyAndSource src idxhdr
     -- body producing function which will produce '100-continue', if needed
@@ -110,10 +109,10 @@ recvRequest firstRequest settings conn ii th addr src transport = do
                 , requestBody = rbody'
                 , vault = vaultValue
                 , requestBodyLength = bodyLength
-                , requestHeaderHost = idxhdr ! fromEnum ReqHost
-                , requestHeaderRange = idxhdr ! fromEnum ReqRange
-                , requestHeaderReferer = idxhdr ! fromEnum ReqReferer
-                , requestHeaderUserAgent = idxhdr ! fromEnum ReqUserAgent
+                , requestHeaderHost = idxhdr ! ReqHost
+                , requestHeaderRange = idxhdr ! ReqRange
+                , requestHeaderReferer = idxhdr ! ReqReferer
+                , requestHeaderUserAgent = idxhdr ! ReqUserAgent
                 }
     return (req, remainingRef, idxhdr, rbodyFlush)
 
@@ -157,7 +156,7 @@ handleExpect _ _ _ = return ()
 
 bodyAndSource
     :: Source
-    -> IndexedHeader
+    -> IndexedRequestHeader
     -> IO
         ( IO ByteString
         , Maybe (I.IORef Int)
@@ -168,12 +167,12 @@ bodyAndSource src idxhdr
         csrc <- mkCSource src
         return (readCSource csrc, Nothing, ChunkedBody)
     | otherwise = do
-        let len = toLength $ idxhdr ! fromEnum ReqContentLength
+        let len = toLength $ idxhdr ! ReqContentLength
             bodyLen = KnownLength $ fromIntegral len
         isrc@(ISource _ remaining) <- mkISource src len
         return (readISource isrc, Just remaining, bodyLen)
   where
-    chunked = isChunked $ idxhdr ! fromEnum ReqTransferEncoding
+    chunked = isChunked $ idxhdr ! ReqTransferEncoding
 
 toLength :: Maybe HeaderValue -> Int
 toLength Nothing = 0

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -16,7 +16,6 @@ module Network.Wai.Handler.Warp.Response (
 ) where
 
 import qualified Control.Exception as E
-import Data.Array ((!))
 import qualified Data.ByteString as S
 import Data.ByteString.Builder (Builder, byteString)
 import Data.ByteString.Builder.Extra (flush)
@@ -111,7 +110,7 @@ sendResponse
     -> T.Handle
     -> Request
     -- ^ HTTP request.
-    -> IndexedHeader
+    -> IndexedRequestHeader
     -- ^ Indexed header of HTTP request.
     -> IO ByteString
     -- ^ source from client, for raw response
@@ -208,7 +207,7 @@ sanitizeHeaderValue v = case C8.lines $ S.filter (/= _cr) v of
 
 data Rsp
     = RspNoBody
-    | RspFile FilePath (Maybe FilePart) IndexedHeader (IO ())
+    | RspFile FilePath (Maybe FilePart) (IndexedRequestHeader) (IO ())
     | RspBuilder Builder Bool
     | RspStream StreamingBody Bool
     | RspRaw (IO ByteString -> (ByteString -> IO ()) -> IO ()) (IO ByteString)
@@ -222,7 +221,7 @@ sendRsp
     -> H.HttpVersion
     -> H.Status
     -> H.ResponseHeaders
-    -> IndexedHeader -- Response
+    -> IndexedResponseHeader
     -> Int -- maxBuilderResponseBufferSize
     -> H.Method
     -> Rsp
@@ -357,7 +356,7 @@ sendRspFile2XX
     -> H.HttpVersion
     -> H.Status
     -> H.ResponseHeaders
-    -> IndexedHeader
+    -> IndexedResponseHeader
     -> Int
     -> H.Method
     -> FilePath
@@ -382,7 +381,7 @@ sendRspFile404
     -> T.Handle
     -> H.HttpVersion
     -> H.ResponseHeaders
-    -> IndexedHeader
+    -> IndexedResponseHeader
     -> Int
     -> H.Method
     -> IO (Maybe H.Status, Maybe Integer)
@@ -422,19 +421,19 @@ sendFragment Connection{connSendAll = send} th bs = do
 
 infoFromRequest
     :: Request
-    -> IndexedHeader
+    -> IndexedRequestHeader
     -> ( Bool -- isPersist
        , Bool -- isChunked
        )
 infoFromRequest req reqidxhdr = (checkPersist req reqidxhdr, checkChunk req)
 
-checkPersist :: Request -> IndexedHeader -> Bool
+checkPersist :: Request -> IndexedRequestHeader -> Bool
 checkPersist req reqidxhdr
     | ver == H.http11 = checkPersist11 conn
     | otherwise = checkPersist10 conn
   where
     ver = httpVersion req
-    conn = reqidxhdr ! fromEnum ReqConnection
+    conn = reqidxhdr ! ReqConnection
     checkPersist11 (Just x)
         | CI.foldCase x == "close" = False
     checkPersist11 _ = True
@@ -454,12 +453,12 @@ checkChunk req = httpVersion req == H.http11
 --
 -- Content-Length is specified by a reverse proxy.
 -- Note that CGI does not specify Content-Length.
-infoFromResponse :: IndexedHeader -> (Bool, Bool) -> (Bool, Bool)
+infoFromResponse :: IndexedResponseHeader -> (Bool, Bool) -> (Bool, Bool)
 infoFromResponse rspidxhdr (isPersist, isChunked) = (isKeepAlive, needsChunked)
   where
     needsChunked = isChunked && not hasLength
     isKeepAlive = isPersist && (isChunked || hasLength)
-    hasLength = isJust $ rspidxhdr ! fromEnum ResContentLength
+    hasLength = isJust $ rspidxhdr ! ResContentLength
 
 ----------------------------------------------------------------
 
@@ -477,8 +476,8 @@ addTransferEncoding :: H.ResponseHeaders -> H.ResponseHeaders
 addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
 
 addDate
-    :: IO D.GMTDate -> IndexedHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
-addDate getdate rspidxhdr hdrs = case rspidxhdr ! fromEnum ResDate of
+    :: IO D.GMTDate -> IndexedResponseHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
+addDate getdate rspidxhdr hdrs = case rspidxhdr ! ResDate of
     Nothing -> do
         gmtdate <- getdate
         return $ (H.hDate, gmtdate) : hdrs
@@ -488,11 +487,11 @@ addDate getdate rspidxhdr hdrs = case rspidxhdr ! fromEnum ResDate of
 
 {-# INLINE addServer #-}
 addServer
-    :: HeaderValue -> IndexedHeader -> H.ResponseHeaders -> H.ResponseHeaders
-addServer "" rspidxhdr hdrs = case rspidxhdr ! fromEnum ResServer of
+    :: HeaderValue -> IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
+addServer "" rspidxhdr hdrs = case rspidxhdr ! ResServer of
     Nothing -> hdrs
     _ -> filter ((/= H.hServer) . fst) hdrs
-addServer serverName rspidxhdr hdrs = case rspidxhdr ! fromEnum ResServer of
+addServer serverName rspidxhdr hdrs = case rspidxhdr ! ResServer of
     Nothing -> (H.hServer, serverName) : hdrs
     _ -> hdrs
 

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.14
+version:            3.4.15
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com


### PR DESCRIPTION
- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Unfortunately, the `IndexedHeader` type is exposed in the `Internal` module, but this is a safer version without any extra overhead.
And this `RequestHeaderIndex` wasn't exposed anyway, the `IndexedHeader` from `recvRequest` can't really be inspected reliably, so the types seem to only be exposed to allow users to use `recvRequest` into `sendResponse`.
This is why I feel this is a safe enough change to make, which _might_ break something, but I don't foresee a large amount of packages using `recvRequest/sendResponse`.

If you know any packages that use that API, do tell.