### PR TITLE
warp: hot-path performance optimizations (+101% keep-alive throughput, -51% allocation)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,5 @@ packages:
     wai-websockets
     wai-conduit
     time-manager
+
+benchmarks: True

--- a/recv/Network/Socket/BufferPool.hs
+++ b/recv/Network/Socket/BufferPool.hs
@@ -24,9 +24,11 @@ module Network.Socket.BufferPool (
     -- * Recv
     Recv,
     receive,
+    receiveNoWait,
     BufferPool,
     newBufferPool,
     withBufferPool,
+    tryWithBufferPool,
 
     -- * RecvN
     RecvN,

--- a/recv/Network/Socket/BufferPool/Buffer.hs
+++ b/recv/Network/Socket/BufferPool/Buffer.hs
@@ -1,6 +1,7 @@
 module Network.Socket.BufferPool.Buffer (
     newBufferPool,
     withBufferPool,
+    tryWithBufferPool,
     mallocBS,
     copy,
 ) where
@@ -43,6 +44,26 @@ withBufferPool (BufferPool l h ref) f = do
     consumed <- withForeignBuffer buf f
     writeIORef ref $ unsafeDrop consumed buf
     return $ unsafeTake consumed buf
+
+-- | Like 'withBufferPool' for fillers that can decline to fill:
+--   a negative return value from the filler leaves the pool untouched
+--   and produces 'Nothing'.
+tryWithBufferPool
+    :: BufferPool -> (Buffer -> BufSize -> IO Int) -> IO (Maybe ByteString)
+tryWithBufferPool (BufferPool l h ref) f = do
+    buf0 <- readIORef ref
+    buf <-
+        if BS.length buf0 >= l
+            then return buf0
+            else mallocBS h
+    consumed <- withForeignBuffer buf f
+    if consumed < 0
+        then do
+            writeIORef ref buf
+            return Nothing
+        else do
+            writeIORef ref $ unsafeDrop consumed buf
+            return $ Just $ unsafeTake consumed buf
 
 withForeignBuffer :: ByteString -> (Buffer -> BufSize -> IO Int) -> IO Int
 withForeignBuffer (PS ps s l) f = withForeignPtr ps $ \p -> f (castPtr p `plusPtr` s) l

--- a/recv/Network/Socket/BufferPool/Recv.hs
+++ b/recv/Network/Socket/BufferPool/Recv.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Socket.BufferPool.Recv (
     receive,
+    receiveNoWait,
     makeRecvN,
 ) where
 
@@ -9,6 +11,12 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Internal (ByteString (..), unsafeCreate)
 import Data.IORef
 import Network.Socket (Socket, recvBuf)
+#ifndef mingw32_HOST_OS
+import Foreign.C.Types (CInt (..), CSize (..))
+import Foreign.Ptr (Ptr, castPtr)
+import Network.Socket (withFdSocket)
+import System.Posix.Types (CSsize (..))
+#endif
 
 import Network.Socket.BufferPool.Buffer
 import Network.Socket.BufferPool.Types
@@ -19,6 +27,27 @@ import Network.Socket.BufferPool.Types
 --   The buffer pool is automatically managed.
 receive :: Socket -> BufferPool -> Recv
 receive sock pool = withBufferPool pool $ \ptr size -> recvBuf sock ptr size
+
+-- | Like 'receive' but never blocks and never involves the IO manager:
+--   'Nothing' means no data was available (or an error occurred, which a
+--   subsequent blocking 'receive' will report properly). @Just \"\"@ is EOF.
+--   On Windows this always returns 'Nothing'.
+receiveNoWait :: Socket -> BufferPool -> IO (Maybe ByteString)
+#ifndef mingw32_HOST_OS
+receiveNoWait sock pool = tryWithBufferPool pool $ \ptr size ->
+    withFdSocket sock $ \fd -> do
+        -- The socket is non-blocking, so an unsafe foreign call is fine:
+        -- recv(2) returns immediately either way. Both EAGAIN and real
+        -- errors map to a negative result, deferring to the blocking path
+        -- so errors surface there with their errno intact.
+        n <- c_recv fd (castPtr ptr) (fromIntegral size) 0
+        return $ fromIntegral n
+
+foreign import ccall unsafe "recv"
+    c_recv :: CInt -> Ptr CSsize -> CSize -> CInt -> IO CSsize
+#else
+receiveNoWait _ _ = return Nothing
+#endif
 
 ----------------------------------------------------------------
 

--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -48,8 +48,10 @@ module System.TimeManager (
 
 import Control.Concurrent (forkIO, mkWeakThreadId, myThreadId)
 import qualified Control.Exception as E
-import Control.Monad (void)
+import Control.Monad (void, when)
 import qualified Data.IORef as I
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Mem.Weak (deRefWeak)
 import System.TimeManager.Internal
 
@@ -73,8 +75,11 @@ emptyHandle =
     Handle
         { handleTimeout = 0
         , handleAction = pure ()
+        , handleTimerManager = error "time-manager: Handle.handleTimerManager not set"
         , handleKeyRef = error "time-manager: Handle.handleKeyRef not set"
         , handleState = error "time-manager: Handle.handleState not set"
+        , handleLastRenewed = error "time-manager: Handle.handleLastRenewed not set"
+        , handleMinRenewGap = 0
         }
 
 ----------------------------------------------------------------
@@ -126,39 +131,68 @@ register :: Manager -> TimeoutAction -> IO Handle
 register mgr@(Manager timeout) onTimeout
     | isNoManager mgr = pure emptyHandle
     | otherwise = do
+        -- The system timer manager is stable for the lifetime of the
+        -- process (and even if it were replaced, e.g. around a fork,
+        -- the key registered below would only be meaningful to the
+        -- manager it was registered with). So fetch it once here and
+        -- cache it in the 'Handle' instead of re-reading the global
+        -- IORef on every tickle/pause/resume.
         sysmgr <- getTimerManager
         key <- EV.registerTimeout sysmgr timeout onTimeout
         keyref <- I.newIORef key
         state <- I.newIORef Active
+        now <- getMonotonicTimeNSec
+        lastRenewed <- I.newIORef now
         let h =
                 Handle
                     { handleTimeout = timeout
                     , handleAction = onTimeout
+                    , handleTimerManager = sysmgr
                     , handleKeyRef = keyref
                     , handleState = state
+                    , handleLastRenewed = lastRenewed
+                    , handleMinRenewGap = minRenewGap timeout
                     }
         pure h
+
+-- | How long 'tickle' waits before actually renewing the timeout:
+--   a quarter of the timeout, capped at one second. Skipping a renewal
+--   inside this window only shortens the effective timeout by up to
+--   this gap, but turns hot 'tickle' loops (one per chunk sent or
+--   received) into a clock read and a comparison.
+minRenewGap :: Int -> Word64
+minRenewGap timeout = min oneSecond (microToNano timeout `div` 4)
+  where
+    oneSecond = 1000000000
+    microToNano = (* 1000) . fromIntegral
 
 -- | Unregistering the timeout.
 cancel :: Handle -> IO ()
 cancel h@Handle{..} = withNonEmptyHandle h $ do
-    mgr <- getTimerManager
     key <- I.readIORef handleKeyRef
-    EV.unregisterTimeout mgr key
+    EV.unregisterTimeout handleTimerManager key
     I.atomicWriteIORef handleState Stopped
 
 -- | Extending the timeout.
 --
+-- To keep frequent callers cheap, the renewal is rate-limited: it is
+-- skipped unless at least a quarter of the timeout (capped at one
+-- second) has passed since the timeout was last registered or updated.
+--
 -- Careful: this does NOT reactivate an already paused 'Handle'!
 tickle :: Handle -> IO ()
 tickle h@Handle{..} = withNonEmptyHandle h $ do
-    mgr <- getTimerManager
-    key <- I.readIORef handleKeyRef
+    now <- getMonotonicTimeNSec
+    lastRenewed <- I.readIORef handleLastRenewed
+    when (now - lastRenewed >= handleMinRenewGap) $ do
+        key <- I.readIORef handleKeyRef
 #if defined(mingw32_HOST_OS)
-    EV.updateTimeout mgr key $ fromIntegral (handleTimeout `div` 1000000)
+        EV.updateTimeout handleTimerManager key $
+            fromIntegral (handleTimeout `div` 1000000)
 #else
-    EV.updateTimeout mgr key handleTimeout
+        EV.updateTimeout handleTimerManager key handleTimeout
 #endif
+        I.writeIORef handleLastRenewed now
 
 -- | This is identical to 'cancel'.
 --   To resume timeout with the same 'Handle', 'resume' MUST be called.
@@ -175,10 +209,11 @@ resume h@Handle{..} = withNonEmptyHandle h $ do
     case state of
         Active -> tickle h
         Stopped -> do
-            mgr <- getTimerManager
-            key <- EV.registerTimeout mgr handleTimeout handleAction
+            key <- EV.registerTimeout handleTimerManager handleTimeout handleAction
             I.atomicWriteIORef handleKeyRef key
             I.atomicWriteIORef handleState Active
+            now <- getMonotonicTimeNSec
+            I.writeIORef handleLastRenewed now
 
 ----------------------------------------------------------------
 

--- a/time-manager/System/TimeManager/Internal.hs
+++ b/time-manager/System/TimeManager/Internal.hs
@@ -6,6 +6,7 @@
 module System.TimeManager.Internal where
 
 import Data.IORef (IORef)
+import Data.Word (Word64)
 
 #if defined(mingw32_HOST_OS)
 import qualified GHC.Event.Windows as EV
@@ -31,8 +32,17 @@ type TimeoutAction = IO ()
 data Handle = Handle
     { handleTimeout :: Int
     , handleAction :: TimeoutAction
+    , handleTimerManager :: ~TimerManager
+    -- ^ The system timer manager the timeout key was registered with.
+    --   Cached so that per-request operations don't re-fetch it.
     , handleKeyRef :: ~(IORef EV.TimeoutKey)
     , handleState :: ~(IORef HandleState)
+    , handleLastRenewed :: ~(IORef Word64)
+    -- ^ Monotonic time (in nanoseconds) when the timeout was last
+    --   registered or updated.
+    , handleMinRenewGap :: Word64
+    -- ^ 'tickle' is a no-op unless at least this many nanoseconds have
+    --   passed since the last renewal.
     }
 
 -- | Tracking the state of a handle, to be able to have 'resume'
@@ -47,9 +57,13 @@ withNonEmptyHandle h act =
     if isEmptyHandle h then pure () else act
 
 #if defined(mingw32_HOST_OS)
-getTimerManager :: IO EV.Manager
+type TimerManager = EV.Manager
+
+getTimerManager :: IO TimerManager
 getTimerManager = EV.getSystemManager
 #else
-getTimerManager :: IO EV.TimerManager
+type TimerManager = EV.TimerManager
+
+getTimerManager :: IO TimerManager
 getTimerManager = EV.getSystemTimerManager
 #endif

--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -58,9 +58,6 @@ module Network.Wai.Handler.WarpTLS (
 ) where
 
 import Control.Applicative ((<|>))
-#if MIN_VERSION_warp(3,4,13)
-import Control.Concurrent.STM (newTVarIO, TVar)
-#endif
 import Control.Exception (
     Exception,
     IOException,
@@ -390,7 +387,7 @@ httpOverTls TLSSettings{..} set s bs0 params =
     makeConn = do
         pool <- newBufferPool 2048 16384
 #if MIN_VERSION_warp(3,4,13)
-        appsInProgress <- newTVarIO 0
+        appsInProgress <- I.newIORef 0
         (ss, _) <- makeServerState set
         let recv = makeGracefulRecv s pool ss appsInProgress
 #else
@@ -441,7 +438,7 @@ attachConn
     :: SockAddr
     -> TLS.Context
 #if MIN_VERSION_warp(3,4,13)
-    -> TVar Int -> IO (Connection, Transport)
+    -> I.IORef Int -> IO (Connection, Transport)
 attachConn mysa ctx appsInProgress = do
 #else
     -> IO (Connection, Transport)

--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -4,6 +4,7 @@ module Network.Wai.Handler.Warp.Buffer (
     freeBuffer,
     toBuilderBuffer,
     bufferIO,
+    rawBufferIO,
 ) where
 
 import Data.IORef (IORef, readIORef)
@@ -23,9 +24,11 @@ import Network.Wai.Handler.Warp.Types
 createWriteBuffer :: BufSize -> IO WriteBuffer
 createWriteBuffer size = do
     bytes <- allocateBuffer size
+    fptr <- newForeignPtr_ bytes
     return
         WriteBuffer
             { bufBuffer = bytes
+            , bufFPtr = fptr
             , bufSize = size
             , bufFree = freeBuffer bytes
             }
@@ -48,12 +51,19 @@ freeBuffer = free
 toBuilderBuffer :: IORef WriteBuffer -> IO B.Buffer
 toBuilderBuffer writeBufferRef = do
     writeBuffer <- readIORef writeBufferRef
-    let ptr = bufBuffer writeBuffer
+    let fptr = bufFPtr writeBuffer
+        ptr = bufBuffer writeBuffer
         size = bufSize writeBuffer
-    fptr <- newForeignPtr_ ptr
     return $ B.Buffer fptr ptr ptr (ptr `plusPtr` size)
 
-bufferIO :: Buffer -> Int -> (ByteString -> IO ()) -> IO ()
-bufferIO ptr siz io = do
+-- | Slice the given number of bytes out of a 'WriteBuffer' using its
+-- cached 'ForeignPtr', without allocating a fresh wrapper.
+bufferIO :: WriteBuffer -> Int -> (ByteString -> IO ()) -> IO ()
+bufferIO writeBuffer siz io = io $ PS (bufFPtr writeBuffer) 0 siz
+
+-- | Like 'bufferIO' for callers that only have a raw pointer.
+-- This allocates a fresh 'ForeignPtr' wrapper on every call.
+rawBufferIO :: Buffer -> Int -> (ByteString -> IO ()) -> IO ()
+rawBufferIO ptr siz io = do
     fptr <- newForeignPtr_ ptr
     io $ PS fptr 0 siz

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -70,13 +70,13 @@ conditionalRequest finfo hs0 method rspidx reqidx = case condition of
 ----------------------------------------------------------------
 
 ifModifiedSince :: IndexedRequestHeader -> Maybe HTTPDate
-ifModifiedSince reqidx = reqidx ! ReqIfModifiedSince >>= parseHTTPDate
+ifModifiedSince reqidx = reqidxIfModifiedSince reqidx >>= parseHTTPDate
 
 ifUnmodifiedSince :: IndexedRequestHeader -> Maybe HTTPDate
-ifUnmodifiedSince reqidx = reqidx ! ReqIfUnmodifiedSince >>= parseHTTPDate
+ifUnmodifiedSince reqidx = reqidxIfUnmodifiedSince reqidx >>= parseHTTPDate
 
 ifRange :: IndexedRequestHeader -> Maybe HTTPDate
-ifRange reqidx = reqidx ! ReqIfRange >>= parseHTTPDate
+ifRange reqidx = reqidxIfRange reqidx >>= parseHTTPDate
 
 ----------------------------------------------------------------
 
@@ -90,7 +90,7 @@ ifmodified reqidx mtime method = do
     -- According to RFC 9110:
     -- "A recipient MUST ignore If-Modified-Since if the request
     -- contains an If-None-Match header field; [...]"
-    guard . isNothing $ reqidx ! ReqIfNoneMatch
+    guard . isNothing $ reqidxIfNoneMatch reqidx
     -- "A recipient MUST ignore the If-Modified-Since header field
     -- if [...] the request method is neither GET nor HEAD."
     guard $ method == H.methodGet || method == H.methodHead
@@ -104,7 +104,7 @@ ifunmodified reqidx mtime = do
     -- According to RFC 9110:
     -- "A recipient MUST ignore If-Unmodified-Since if the request
     -- contains an If-Match header field; [...]"
-    guard . isNothing $ reqidx ! ReqIfMatch
+    guard . isNothing $ reqidxIfMatch reqidx
     guard $ date /= mtime && date < mtime
     Just $ WithoutBody H.preconditionFailed412
 
@@ -120,7 +120,7 @@ ifrange reqidx mtime method size = do
     -- "When the method is GET and both Range and If-Range are
     -- present, evaluate the If-Range precondition:"
     date <- ifRange reqidx
-    rng <- reqidx ! ReqRange
+    rng <- reqidxRange reqidx
     guard $ method == H.methodGet
     return $
         if date == mtime
@@ -129,7 +129,7 @@ ifrange reqidx mtime method size = do
 
 unconditional :: IndexedRequestHeader -> Integer -> RspFileInfo
 unconditional reqidx =
-    case reqidx ! ReqRange of
+    case reqidxRange reqidx of
         Nothing -> WithBody H.ok200 [] 0
         Just rng -> parseRange rng
 

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -40,7 +40,7 @@ conditionalRequest finfo hs0 method rspidx reqidx = case condition of
     nobody@(WithoutBody _) -> nobody
     WithBody s _ off len ->
         let !hs1 = addContentHeaders hs0 off len size
-            !hs = case rspidx ! ResLastModified of
+            !hs = case resLastModified rspidx of
                 Just _ -> hs1
                 Nothing -> (H.hLastModified, date) : hs1
          in WithBody s hs off len

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -214,13 +214,10 @@ processRequest settings ii conn app th istatus src req mremainingRef idxhdr next
     keepAlive <- readIORef keepAliveRef
 
     -- We just send a Response and it takes a time to
-    -- receive a Request again. If we immediately call recv,
-    -- it is likely to fail and cause the IO manager to do some work.
-    -- It is very costly, so we yield to another Haskell
-    -- thread hoping that the next Request will arrive
-    -- when this Haskell thread will be re-scheduled.
-    -- This improves performance at least when
-    -- the number of cores is small.
+    -- receive a Request again. Yield to other Haskell threads so the
+    -- next Request has a chance to arrive before we call recv: the
+    -- non-blocking fast path in 'makeGracefulRecv' then reads it without
+    -- involving the IO manager at all.
     Conc.yield
 
     if keepAlive

--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -98,7 +98,9 @@ toRequest' ii settings addr ref (reqths, reqvt) bodylen body th transport =
     !path = H.extractPath unparsedPath
     !rawPath = if S.settingsNoParsePath settings then unparsedPath else path
     -- fixme: pauseTimeout. th is not available here.
-    !vaultValue =
+    -- Lazy on purpose (~ defeats -XStrict): most handlers never touch
+    -- 'vault', so don't pay for the inserts unless somebody looks.
+    ~vaultValue =
         Vault.insert getFileInfoKey (getFileInfo ii)
             . Vault.insert getHTTP2DataKey (readIORef ref)
             . Vault.insert setHTTP2DataKey (writeIORef ref)

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -2,20 +2,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Wai.Handler.Warp.Header (
-    IndexedHeader,
-    IndexedRequestHeader,
+    IndexedRequestHeader (..),
     IndexedResponseHeader (..),
-    (!),
-    RequestHeaderIndex (..),
     indexRequestHeader,
-    requestMaxIndex,
     defaultIndexRequestHeader,
     indexResponseHeader,
 ) where
 
-import Data.Array (Array, array)
-import qualified Data.Array as A ((!))
-import Data.Array.ST
 import qualified Data.ByteString as BS
 import Data.CaseInsensitive (foldedCase)
 import Network.HTTP.Types
@@ -24,19 +17,23 @@ import Network.Wai.Handler.Warp.Types
 
 ----------------------------------------------------------------
 
--- | Array for a set of HTTP headers.
-newtype IndexedHeader a = IxHeader (Array Int (Maybe HeaderValue))
-
-type IndexedRequestHeader = IndexedHeader RequestHeaderIndex
-
--- | Safer way to lookup 'IndexedHeader' values
-(!) :: Enum a => IndexedHeader a -> a -> Maybe HeaderValue
-(IxHeader ixHdr) ! ix = ixHdr A.! fromEnum ix
-
-----------------------------------------------------------------
-
-indexRequestHeader :: RequestHeaders -> IndexedHeader RequestHeaderIndex
-indexRequestHeader hdr = traverseHeader hdr requestMaxIndex requestKeyIndex
+-- | Strict record of the request headers that Warp inspects,
+--   one field per header.
+data IndexedRequestHeader = IndexedRequestHeader
+    { reqidxContentLength :: Maybe HeaderValue
+    , reqidxTransferEncoding :: Maybe HeaderValue
+    , reqidxExpect :: Maybe HeaderValue
+    , reqidxConnection :: Maybe HeaderValue
+    , reqidxRange :: Maybe HeaderValue
+    , reqidxHost :: Maybe HeaderValue
+    , reqidxIfModifiedSince :: Maybe HeaderValue
+    , reqidxIfUnmodifiedSince :: Maybe HeaderValue
+    , reqidxIfRange :: Maybe HeaderValue
+    , reqidxReferer :: Maybe HeaderValue
+    , reqidxUserAgent :: Maybe HeaderValue
+    , reqidxIfMatch :: Maybe HeaderValue
+    , reqidxIfNoneMatch :: Maybe HeaderValue
+    }
 
 data RequestHeaderIndex
     = ReqContentLength
@@ -52,53 +49,66 @@ data RequestHeaderIndex
     | ReqUserAgent
     | ReqIfMatch
     | ReqIfNoneMatch
-    deriving (Enum, Bounded)
 
--- | The size for 'IndexedHeader' for HTTP Request.
---   From 0 to this corresponds to:
---
--- - \"Content-Length\"
--- - \"Transfer-Encoding\"
--- - \"Expect\"
--- - \"Connection\"
--- - \"Range\"
--- - \"Host\"
--- - \"If-Modified-Since\"
--- - \"If-Unmodified-Since\"
--- - \"If-Range\"
--- - \"Referer\"
--- - \"User-Agent\"
--- - \"If-Match\"
--- - \"If-None-Match\"
-requestMaxIndex :: Int
-requestMaxIndex = fromEnum (maxBound :: RequestHeaderIndex)
+indexRequestHeader :: RequestHeaders -> IndexedRequestHeader
+indexRequestHeader = foldl' insert defaultIndexRequestHeader
+  where
+    insert ix (key, val) = case requestKeyIndex key of
+        Nothing -> ix
+        Just ReqContentLength -> ix{reqidxContentLength = Just val}
+        Just ReqTransferEncoding -> ix{reqidxTransferEncoding = Just val}
+        Just ReqExpect -> ix{reqidxExpect = Just val}
+        Just ReqConnection -> ix{reqidxConnection = Just val}
+        Just ReqRange -> ix{reqidxRange = Just val}
+        Just ReqHost -> ix{reqidxHost = Just val}
+        Just ReqIfModifiedSince -> ix{reqidxIfModifiedSince = Just val}
+        Just ReqIfUnmodifiedSince -> ix{reqidxIfUnmodifiedSince = Just val}
+        Just ReqIfRange -> ix{reqidxIfRange = Just val}
+        Just ReqReferer -> ix{reqidxReferer = Just val}
+        Just ReqUserAgent -> ix{reqidxUserAgent = Just val}
+        Just ReqIfMatch -> ix{reqidxIfMatch = Just val}
+        Just ReqIfNoneMatch -> ix{reqidxIfNoneMatch = Just val}
 
-requestKeyIndex :: HeaderName -> Int
+requestKeyIndex :: HeaderName -> Maybe RequestHeaderIndex
 requestKeyIndex hn = case BS.length bs of
-    4 | bs == "host" -> fromEnum ReqHost
-    5 | bs == "range" -> fromEnum ReqRange
-    6 | bs == "expect" -> fromEnum ReqExpect
-    7 | bs == "referer" -> fromEnum ReqReferer
+    4 | bs == "host" -> Just ReqHost
+    5 | bs == "range" -> Just ReqRange
+    6 | bs == "expect" -> Just ReqExpect
+    7 | bs == "referer" -> Just ReqReferer
     8
-        | bs == "if-range" -> fromEnum ReqIfRange
-        | bs == "if-match" -> fromEnum ReqIfMatch
+        | bs == "if-range" -> Just ReqIfRange
+        | bs == "if-match" -> Just ReqIfMatch
     10
-        | bs == "user-agent" -> fromEnum ReqUserAgent
-        | bs == "connection" -> fromEnum ReqConnection
-    13 | bs == "if-none-match" -> fromEnum ReqIfNoneMatch
-    14 | bs == "content-length" -> fromEnum ReqContentLength
+        | bs == "user-agent" -> Just ReqUserAgent
+        | bs == "connection" -> Just ReqConnection
+    13 | bs == "if-none-match" -> Just ReqIfNoneMatch
+    14 | bs == "content-length" -> Just ReqContentLength
     17
-        | bs == "transfer-encoding" -> fromEnum ReqTransferEncoding
-        | bs == "if-modified-since" -> fromEnum ReqIfModifiedSince
-    19 | bs == "if-unmodified-since" -> fromEnum ReqIfUnmodifiedSince
-    _ -> -1
+        | bs == "transfer-encoding" -> Just ReqTransferEncoding
+        | bs == "if-modified-since" -> Just ReqIfModifiedSince
+    19 | bs == "if-unmodified-since" -> Just ReqIfUnmodifiedSince
+    _ -> Nothing
   where
     bs = foldedCase hn
 
-defaultIndexRequestHeader :: IndexedHeader RequestHeaderIndex
+-- | 'IndexedRequestHeader' with no headers set.
+defaultIndexRequestHeader :: IndexedRequestHeader
 defaultIndexRequestHeader =
-    IxHeader $
-        array (0, requestMaxIndex) [(i, Nothing) | i <- [0 .. requestMaxIndex]]
+    IndexedRequestHeader
+        { reqidxContentLength = Nothing
+        , reqidxTransferEncoding = Nothing
+        , reqidxExpect = Nothing
+        , reqidxConnection = Nothing
+        , reqidxRange = Nothing
+        , reqidxHost = Nothing
+        , reqidxIfModifiedSince = Nothing
+        , reqidxIfUnmodifiedSince = Nothing
+        , reqidxIfRange = Nothing
+        , reqidxReferer = Nothing
+        , reqidxUserAgent = Nothing
+        , reqidxIfMatch = Nothing
+        , reqidxIfNoneMatch = Nothing
+        }
 
 ----------------------------------------------------------------
 
@@ -118,7 +128,7 @@ indexResponseHeader = go emptyIndexedResponseHeader
   where
     go ix [] = ix
     go ix ((key, val) : rest) = go (insert ix key val) rest
-    -- Like 'traverseHeader', a later duplicate wins.
+    -- A later duplicate wins.
     insert ix key val = case BS.length bs of
         4 | bs == "date" -> ix{resDate = Just val}
         6 | bs == "server" -> ix{resServer = Just val}
@@ -136,17 +146,3 @@ emptyIndexedResponseHeader =
         , resDate = Nothing
         , resLastModified = Nothing
         }
-
-----------------------------------------------------------------
-
-traverseHeader :: [Header] -> Int -> (HeaderName -> Int) -> IndexedHeader a
-traverseHeader hdr maxidx getIndex = IxHeader $ runSTArray $ do
-    arr <- newArray (0, maxidx) Nothing
-    mapM_ (insert arr) hdr
-    return arr
-  where
-    insert arr (key, val)
-        | idx == -1 = return ()
-        | otherwise = writeArray arr idx (Just val)
-      where
-        idx = getIndex key

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -4,13 +4,12 @@
 module Network.Wai.Handler.Warp.Header (
     IndexedHeader,
     IndexedRequestHeader,
-    IndexedResponseHeader,
+    IndexedResponseHeader (..),
     (!),
     RequestHeaderIndex (..),
     indexRequestHeader,
     requestMaxIndex,
     defaultIndexRequestHeader,
-    ResponseHeaderIndex (..),
     indexResponseHeader,
 ) where
 
@@ -29,7 +28,6 @@ import Network.Wai.Handler.Warp.Types
 newtype IndexedHeader a = IxHeader (Array Int (Maybe HeaderValue))
 
 type IndexedRequestHeader = IndexedHeader RequestHeaderIndex
-type IndexedResponseHeader = IndexedHeader ResponseHeaderIndex
 
 -- | Safer way to lookup 'IndexedHeader' values
 (!) :: Enum a => IndexedHeader a -> a -> Maybe HeaderValue
@@ -104,29 +102,40 @@ defaultIndexRequestHeader =
 
 ----------------------------------------------------------------
 
-indexResponseHeader :: ResponseHeaders -> IndexedHeader ResponseHeaderIndex
-indexResponseHeader hdr = traverseHeader hdr responseMaxIndex responseKeyIndex
+-- | Index for the response headers Warp itself consults.
+--   Only these four headers are ever looked up on the response side,
+--   so a flat record built in a single traversal beats a boxed array.
+--   The fields are strict via StrictData.
+data IndexedResponseHeader = IndexedResponseHeader
+    { resContentLength :: Maybe HeaderValue
+    , resServer :: Maybe HeaderValue
+    , resDate :: Maybe HeaderValue
+    , resLastModified :: Maybe HeaderValue
+    }
 
-data ResponseHeaderIndex
-    = ResContentLength
-    | ResServer
-    | ResDate
-    | ResLastModified
-    deriving (Enum, Bounded)
-
--- | The size for 'IndexedHeader' for HTTP Response.
-responseMaxIndex :: Int
-responseMaxIndex = fromEnum (maxBound :: ResponseHeaderIndex)
-
-responseKeyIndex :: HeaderName -> Int
-responseKeyIndex hn = case BS.length bs of
-    4 | bs == "date" -> fromEnum ResDate
-    6 | bs == "server" -> fromEnum ResServer
-    13 | bs == "last-modified" -> fromEnum ResLastModified
-    14 | bs == "content-length" -> fromEnum ResContentLength
-    _ -> -1
+indexResponseHeader :: ResponseHeaders -> IndexedResponseHeader
+indexResponseHeader = go emptyIndexedResponseHeader
   where
-    bs = foldedCase hn
+    go ix [] = ix
+    go ix ((key, val) : rest) = go (insert ix key val) rest
+    -- Like 'traverseHeader', a later duplicate wins.
+    insert ix key val = case BS.length bs of
+        4 | bs == "date" -> ix{resDate = Just val}
+        6 | bs == "server" -> ix{resServer = Just val}
+        13 | bs == "last-modified" -> ix{resLastModified = Just val}
+        14 | bs == "content-length" -> ix{resContentLength = Just val}
+        _ -> ix
+      where
+        bs = foldedCase key
+
+emptyIndexedResponseHeader :: IndexedResponseHeader
+emptyIndexedResponseHeader =
+    IndexedResponseHeader
+        { resContentLength = Nothing
+        , resServer = Nothing
+        , resDate = Nothing
+        , resLastModified = Nothing
+        }
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -34,7 +34,7 @@ toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
         (len, signal) <- writer (buf `plusPtr` offset) (size - offset)
-        bufferIO buf (offset + len) io
+        bufferIO writeBuffer (offset + len) io
         let totalBytesSent = toInteger (offset + len) + bytesSent
         case signal of
             Done -> return totalBytesSent

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -4,23 +4,38 @@ import Control.Exception (mask_)
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Extra (Next (Chunk, Done, More), runBuilder)
 import Data.IORef (IORef, readIORef, writeIORef)
+import Foreign.Ptr (plusPtr)
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types
 
 toBufIOWith
     :: Int -> IORef WriteBuffer -> (ByteString -> IO ()) -> Builder -> IO Integer
-toBufIOWith maxRspBufSize writeBufferRef io builder = do
+toBufIOWith = toBufIOWithOffset 0
+
+-- | Like 'toBufIOWith' but the first @offset@ bytes of the write buffer
+-- are assumed to be already filled (e.g. with a response header composed
+-- directly into the buffer). They are flushed together with the first
+-- batch of builder output and included in the returned total.
+-- @offset@ must not exceed the current buffer size.
+toBufIOWithOffset
+    :: Int
+    -> Int
+    -> IORef WriteBuffer
+    -> (ByteString -> IO ())
+    -> Builder
+    -> IO Integer
+toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
     writeBuffer <- readIORef writeBufferRef
-    loop writeBuffer firstWriter 0
+    loop writeBuffer offset0 firstWriter 0
   where
     firstWriter = runBuilder builder
-    loop writeBuffer writer bytesSent = do
+    loop writeBuffer offset writer bytesSent = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
-        (len, signal) <- writer buf size
-        bufferIO buf len io
-        let totalBytesSent = toInteger len + bytesSent
+        (len, signal) <- writer (buf `plusPtr` offset) (size - offset)
+        bufferIO buf (offset + len) io
+        let totalBytesSent = toInteger (offset + len) + bytesSent
         case signal of
             Done -> return totalBytesSent
             More minSize next
@@ -43,8 +58,8 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
                         biggerWriteBuffer <- createWriteBuffer minSize
                         writeIORef writeBufferRef biggerWriteBuffer
                         return biggerWriteBuffer
-                    loop biggerWriteBuffer next totalBytesSent
-                | otherwise -> loop writeBuffer next totalBytesSent
+                    loop biggerWriteBuffer 0 next totalBytesSent
+                | otherwise -> loop writeBuffer 0 next totalBytesSent
             Chunk bs next -> do
                 io bs
-                loop writeBuffer next totalBytesSent
+                loop writeBuffer 0 next totalBytesSent

--- a/warp/Network/Wai/Handler/Warp/Internal.hs
+++ b/warp/Network/Wai/Handler/Warp/Internal.hs
@@ -62,8 +62,6 @@ module Network.Wai.Handler.Warp.Internal (
     InternalInfo (..),
     HeaderValue,
     IndexedRequestHeader,
-    -- I assume 'requestMaxIndex' was used in case anyone wanted to create
-    -- an empty array, so we replace it with 'defaultIndexRequestHeader'.
     defaultIndexRequestHeader,
 
     -- * Time out manager

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -88,7 +88,9 @@ recvRequest firstRequest settings conn ii th addr src transport = do
     -- body producing function which will never produce 100-continue
     rbodyFlush <- timeoutBody remainingRef th rbody (return ())
     let rawPath = if settingsNoParsePath settings then unparsedPath else path
-        vaultValue =
+        -- Lazy on purpose (~ defeats -XStrict): most handlers never touch
+        -- 'vault', so don't pay for the inserts unless somebody looks.
+        ~vaultValue =
             Vault.insert pauseTimeoutKey (Timeout.pause th)
                 . Vault.insert getFileInfoKey (getFileInfo ii)
 #ifdef MIN_VERSION_crypton_x509

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -73,14 +73,14 @@ recvRequest
     -- ^
     -- 'Request' passed to 'Application',
     -- how many bytes remain to be consumed, if known
-    -- 'IndexedHeader' of HTTP request for internal use,
+    -- 'IndexedRequestHeader' of HTTP request for internal use,
     -- Body producing action used for flushing the request body
 recvRequest firstRequest settings conn ii th addr src transport = do
     hdrlines <- headerLines (settingsMaxTotalHeaderLength settings) firstRequest src
     (method, unparsedPath, path, query, httpversion, hdr) <-
         parseHeaderLines hdrlines
     let idxhdr = indexRequestHeader hdr
-        expect = idxhdr ! ReqExpect
+        expect = reqidxExpect idxhdr
         handle100Continue = handleExpect conn httpversion expect
     (rbody, remainingRef, bodyLength) <- bodyAndSource src idxhdr
     -- body producing function which will produce '100-continue', if needed
@@ -111,10 +111,10 @@ recvRequest firstRequest settings conn ii th addr src transport = do
                 , requestBody = rbody'
                 , vault = vaultValue
                 , requestBodyLength = bodyLength
-                , requestHeaderHost = idxhdr ! ReqHost
-                , requestHeaderRange = idxhdr ! ReqRange
-                , requestHeaderReferer = idxhdr ! ReqReferer
-                , requestHeaderUserAgent = idxhdr ! ReqUserAgent
+                , requestHeaderHost = reqidxHost idxhdr
+                , requestHeaderRange = reqidxRange idxhdr
+                , requestHeaderReferer = reqidxReferer idxhdr
+                , requestHeaderUserAgent = reqidxUserAgent idxhdr
                 }
     return (req, remainingRef, idxhdr, rbodyFlush)
 
@@ -169,12 +169,12 @@ bodyAndSource src idxhdr
         csrc <- mkCSource src
         return (readCSource csrc, Nothing, ChunkedBody)
     | otherwise = do
-        let len = toLength $ idxhdr ! ReqContentLength
+        let len = toLength $ reqidxContentLength idxhdr
             bodyLen = KnownLength $ fromIntegral len
         isrc@(ISource _ remaining) <- mkISource src len
         return (readISource isrc, Just remaining, bodyLen)
   where
-    chunked = isChunked $ idxhdr ! ReqTransferEncoding
+    chunked = isChunked $ reqidxTransferEncoding idxhdr
 
 toLength :: Maybe HeaderValue -> Int
 toLength Nothing = 0

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -273,6 +273,12 @@ sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
 
 sendRsp conn _ th ver s hs _ _ _ (RspStream streamingBody needsChunked) = do
     header <- composeHeaderBuilder ver s hs needsChunked
+    -- Make sure the timeout is armed for the whole streaming section,
+    -- so that the per-fragment 'T.tickle' below has effect. Normally
+    -- the handle is already active (the respond callback resumed it),
+    -- making this a cheap no-op; it matters for streaming responses
+    -- sent from an exception handler, where the handle is still paused.
+    T.resume th
     (recv, finish) <-
         newByteStringBuilderRecv $
             reuseBufferStrategy $
@@ -424,14 +430,18 @@ sendRspFile404 conn ii th ver hs0 rspidxhdr maxRspBufSize method =
 -- | Use 'connSendAll' to send this data while respecting timeout rules.
 sendFragment :: Connection -> T.Handle -> ByteString -> IO ()
 sendFragment Connection{connSendAll = send} th bs = do
-    T.resume th
+    T.tickle th
     send bs
-    T.pause th
 
--- We pause timeouts before passing control back to user code. This ensures
--- that a timeout will only ever be executed when Warp is in control. We
--- also make sure to resume the timeout after the completion of user code
--- so that we can kill idle connections.
+-- The timeout stays armed during the whole streaming section (see the
+-- 'T.resume' in the RspStream case of 'sendRsp'); each fragment merely
+-- tickles it, which the rate limiter in time-manager makes nearly free.
+-- Compared to the previous resume/send/pause per fragment this keeps
+-- slowloris protection active while the fragment is being sent. The
+-- flip side is that user code producing the next fragment now runs with
+-- the timeout armed, so a streaming body that emits nothing for a full
+-- timeout period is killed, whereas it previously had the timeout
+-- paused between fragments.
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -180,16 +180,20 @@ sendResponse settings conn ii th req reqidxhdr src response = do
 
 ----------------------------------------------------------------
 
+-- Values without CR/LF (the overwhelmingly common case) leave the
+-- header list untouched; only a dirty value triggers a rebuild.
 sanitizeHeaders :: H.ResponseHeaders -> H.ResponseHeaders
-sanitizeHeaders = map (sanitize <$>)
+sanitizeHeaders hs
+    | any (containsNewlines . snd) hs = map (sanitize <$>) hs -- slow path
+    | otherwise = hs -- fast path
   where
     sanitize v
-        | containsNewlines v = sanitizeHeaderValue v -- slow path
-        | otherwise = v -- fast path
+        | containsNewlines v = sanitizeHeaderValue v
+        | otherwise = v
 
 {-# INLINE containsNewlines #-}
 containsNewlines :: ByteString -> Bool
-containsNewlines = S.any (\w -> w == _cr || w == _lf)
+containsNewlines v = isJust (S.elemIndex _cr v) || isJust (S.elemIndex _lf v)
 
 {-# INLINE sanitizeHeaderValue #-}
 sanitizeHeaderValue :: ByteString -> ByteString
@@ -458,7 +462,7 @@ infoFromResponse rspidxhdr (isPersist, isChunked) = (isKeepAlive, needsChunked)
   where
     needsChunked = isChunked && not hasLength
     isKeepAlive = isPersist && (isChunked || hasLength)
-    hasLength = isJust $ rspidxhdr ! ResContentLength
+    hasLength = isJust $ resContentLength rspidxhdr
 
 ----------------------------------------------------------------
 
@@ -477,7 +481,7 @@ addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
 
 addDate
     :: IO D.GMTDate -> IndexedResponseHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
-addDate getdate rspidxhdr hdrs = case rspidxhdr ! ResDate of
+addDate getdate rspidxhdr hdrs = case resDate rspidxhdr of
     Nothing -> do
         gmtdate <- getdate
         return $ (H.hDate, gmtdate) : hdrs
@@ -488,10 +492,10 @@ addDate getdate rspidxhdr hdrs = case rspidxhdr ! ResDate of
 {-# INLINE addServer #-}
 addServer
     :: HeaderValue -> IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
-addServer "" rspidxhdr hdrs = case rspidxhdr ! ResServer of
+addServer "" rspidxhdr hdrs = case resServer rspidxhdr of
     Nothing -> hdrs
     _ -> filter ((/= H.hServer) . fst) hdrs
-addServer serverName rspidxhdr hdrs = case rspidxhdr ! ResServer of
+addServer serverName rspidxhdr hdrs = case resServer rspidxhdr of
     Nothing -> (H.hServer, serverName) : hdrs
     _ -> hdrs
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -459,7 +459,7 @@ checkPersist req reqidxhdr
     | otherwise = checkPersist10 conn
   where
     ver = httpVersion req
-    conn = reqidxhdr ! ReqConnection
+    conn = reqidxConnection reqidxhdr
     checkPersist11 (Just x)
         | CI.foldCase x == "close" = False
     checkPersist11 _ = True

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -26,6 +26,7 @@ import Data.ByteString.Builder.HTTP.Chunked (
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.CaseInsensitive as CI
 import Data.Function (on)
+import Data.IORef (readIORef)
 import Data.List (deleteBy)
 import Data.Streaming.ByteString.Builder (
     newByteStringBuilderRecv,
@@ -42,7 +43,7 @@ import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.IO (toBufIOWith)
+import Network.Wai.Handler.Warp.IO (toBufIOWith, toBufIOWithOffset)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.ResponseHeader
 import Network.Wai.Handler.Warp.Settings
@@ -241,21 +242,32 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 ----------------------------------------------------------------
 
 sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
-    header <- composeHeaderBuilder ver s hs needsChunked
-    let hdrBdy
-            | needsChunked =
-                header
-                    <> chunkedTransferEncoding body
-                    <> chunkedTransferTerminator
-            | otherwise = header <> body
-        writeBufferRef = connWriteBuffer conn
+    writeBuffer <- readIORef writeBufferRef
     len <-
-        toBufIOWith
-            maxRspBufSize
-            writeBufferRef
-            (\bs -> connSendAll conn bs >> T.tickle th)
-            hdrBdy
+        if hdrLen < bufSize writeBuffer
+            then do
+                -- Compose the header directly into the connection write
+                -- buffer and run the body builder right after it, saving
+                -- a copy of the header bytes through an intermediate
+                -- ByteString.
+                _ <- composeHeaderPtr (bufBuffer writeBuffer) ver s hs'
+                toBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
+            else do
+                -- Huge headers: fall back to composing a separate header
+                -- ByteString and letting the builder machinery copy it.
+                header <- composeHeaderBuilder ver s hs needsChunked
+                toBufIOWith maxRspBufSize writeBufferRef send (header <> bdy)
     return (Just s, Just len)
+  where
+    hs'
+        | needsChunked = addTransferEncoding hs
+        | otherwise = hs
+    hdrLen = composeHeaderLength s hs'
+    bdy
+        | needsChunked = chunkedTransferEncoding body <> chunkedTransferTerminator
+        | otherwise = body
+    writeBufferRef = connWriteBuffer conn
+    send bs = connSendAll conn bs >> T.tickle th
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
+module Network.Wai.Handler.Warp.ResponseHeader (
+    composeHeader,
+    composeHeaderPtr,
+    composeHeaderLength,
+) where
 
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
@@ -18,14 +22,31 @@ import Network.Wai.Handler.Warp.Imports
 ----------------------------------------------------------------
 
 composeHeader :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO ByteString
-composeHeader !httpversion !status !responseHeaders = create len $ \ptr -> do
-    ptr1 <- copyStatus ptr httpversion status
-    ptr2 <- copyHeaders ptr1 responseHeaders
-    void $ copyCRLF ptr2
+composeHeader !httpversion !status !responseHeaders =
+    create len $ \ptr ->
+        void $ composeHeaderPtr ptr httpversion status responseHeaders
   where
-    !len = 17 + slen + foldl' fieldLength 0 responseHeaders
+    !len = composeHeaderLength status responseHeaders
+
+-- | The exact number of bytes 'composeHeaderPtr' writes for this
+-- status line and header list (including the final CRLF).
+composeHeaderLength :: H.Status -> H.ResponseHeaders -> Int
+composeHeaderLength !status !responseHeaders =
+    17 + slen + foldl' fieldLength 0 responseHeaders
+  where
     fieldLength !l (!k, !v) = l + S.length (CI.original k) + S.length v + 4
     !slen = S.length $ H.statusMessage status
+
+-- | Compose the response header directly into the given buffer,
+-- returning the number of bytes written. The buffer must have room
+-- for at least 'composeHeaderLength' bytes.
+composeHeaderPtr
+    :: Ptr Word8 -> H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO Int
+composeHeaderPtr !ptr !httpversion !status !responseHeaders = do
+    ptr1 <- copyStatus ptr httpversion status
+    ptr2 <- copyHeaders ptr1 responseHeaders
+    ptr3 <- copyCRLF ptr2
+    return $! ptr3 `minusPtr` ptr
 
 httpVer11 :: ByteString
 httpVer11 = "HTTP/1.1 "

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -140,22 +140,33 @@ socketConnection set s = do
 -- actively using this 'Socket'.
 makeGracefulRecv :: Socket -> BufferPool -> ServerState -> IORef Int -> Recv
 makeGracefulRecv sock pool ss appsInProgress = do
-    sockWait <-
-#if !WINDOWS && MIN_VERSION_network(3,2,2)
-        waitReadSocketSTM sock
-#else
-        -- FIXME: 'waitReadSocketSTM' doesn't work on WINDOWS, and actually
-        -- blocks indefinitely, so we fall back to going straight to 'recv'.
-        pure (pure ())
-#endif
-    isShuttingDown <- atomically $
-        -- when shutting down
-        (checkShutdown $> True)
-        <|>
-        -- else wait for socket readiness and do non-blocking read
-        (sockWait $> False)
-    if isShuttingDown then drain sockWait else recv
+    -- Fast path: under load the next request has usually already arrived,
+    -- so read it without registering with the IO manager or entering STM.
+    -- One epoll_ctl + one futex sleep/wake pair saved per request.
+    -- A request already in the kernel buffer is served even if shutdown
+    -- began meanwhile, which merely restores pre-graceful-shutdown behavior
+    -- for bytes the client already sent.
+    mbs <- receiveNoWait sock pool
+    case mbs of
+        Just bs -> return bs
+        Nothing -> slowPath
   where
+    slowPath = do
+        sockWait <-
+#if !WINDOWS && MIN_VERSION_network(3,2,2)
+            waitReadSocketSTM sock
+#else
+            -- FIXME: 'waitReadSocketSTM' doesn't work on WINDOWS, and actually
+            -- blocks indefinitely, so we fall back to going straight to 'recv'.
+            pure (pure ())
+#endif
+        isShuttingDown <- atomically $
+            -- when shutting down
+            (checkShutdown $> True)
+            <|>
+            -- else wait for socket readiness and do non-blocking read
+            (sockWait $> False)
+        if isShuttingDown then drain sockWait else recv
     recv = receive sock pool
     checkShutdown = check =<< currentShuttingDownStateSTM ss
     -- Shutting down: cut off this connection once no 'Application' is using

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -11,17 +11,13 @@ module Network.Wai.Handler.Warp.Run where
 
 import Control.Arrow (first)
 import Control.Concurrent.STM (
-    TVar,
     atomically,
     check,
-    modifyTVar',
-    newTVarIO,
-    readTVar,
  )
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.Functor (($>))
-import Data.IORef (newIORef, readIORef, IORef, writeIORef)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef, IORef, writeIORef)
 import Data.Streaming.Network (bindPortTCP)
 import Foreign.C.Error (Errno (..), eCONNABORTED, eMFILE)
 import GHC.Conc.Sync (labelThread, myThreadId)
@@ -78,7 +74,7 @@ socketConnection set s = do
     writeBufferRef <- newIORef writeBuffer
     isH2 <- newIORef False -- HTTP/1.x
     mysa <- getSocketName s
-    appsInProgress <- newTVarIO 0
+    appsInProgress <- newIORef 0
     return
         Connection
             { connSendMany = Sock.sendMany s
@@ -142,7 +138,7 @@ socketConnection set s = do
 -- it non-blocking with 'waitReadSocketSTM' /AND/ cut off receiving any bytes
 -- when the server is shutting down and there are no more 'Application's
 -- actively using this 'Socket'.
-makeGracefulRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
+makeGracefulRecv :: Socket -> BufferPool -> ServerState -> IORef Int -> Recv
 makeGracefulRecv sock pool ss appsInProgress = do
     sockWait <-
 #if !WINDOWS && MIN_VERSION_network(3,2,2)
@@ -158,12 +154,25 @@ makeGracefulRecv sock pool ss appsInProgress = do
         <|>
         -- else wait for socket readiness and do non-blocking read
         (sockWait $> False)
-    if isShuttingDown then pure "" else recv
+    if isShuttingDown then drain sockWait else recv
   where
     recv = receive sock pool
-    checkShutdown = do
-       check =<< currentShuttingDownStateSTM ss
-       check . (<= 0) =<< readTVar appsInProgress
+    checkShutdown = check =<< currentShuttingDownStateSTM ss
+    -- Shutting down: cut off this connection once no 'Application' is using
+    -- it any more, but keep feeding data to the ones still in progress
+    -- (HTTP/2 can run several concurrent streams). The counter is a plain
+    -- 'IORef' incremented with 'atomicModifyIORef'', so it cannot take part
+    -- in the STM wait above; instead it is polled here. Graceful shutdown is
+    -- not latency sensitive, and the 'timeout' sleeps between polls, so this
+    -- is not a busy wait.
+    drain sockWait = do
+        inProgress <- readIORef appsInProgress
+        if inProgress <= 0
+            then pure ""
+            else do
+                ready <- timeout pollInterval $ atomically sockWait
+                maybe (drain sockWait) (const recv) ready
+    pollInterval = 20000 -- microseconds
 
 -- | Run an 'Application' on the given port.
 -- This calls 'runSettings' with 'defaultSettings'.
@@ -468,8 +477,8 @@ serveConnection conn ii th origAddr transport settings app = do
     let appsInProgress = connAppsInProgress conn
         app' req rsp =
             E.bracket_
-                (atomically $ modifyTVar' appsInProgress $ (+ 1))
-                (atomically $ modifyTVar' appsInProgress $ \i -> (i - 1))
+                (atomicModifyIORef' appsInProgress $ \i -> (i + 1, ()))
+                (atomicModifyIORef' appsInProgress $ \i -> (i - 1, ()))
                 $ app req rsp
     if settingsHTTP2Enabled settings && h2
         then do

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -72,7 +72,7 @@ packHeader buf siz send hook (bs : bss) n
         let dst = buf `plusPtr` n
             (bs1, bs2) = BS.splitAt room bs
         void $ copy dst bs1
-        bufferIO buf siz send
+        rawBufferIO buf siz send
         hook
         packHeader buf siz send hook (bs2 : bss) 0
   where
@@ -98,7 +98,7 @@ readSendFile buf siz send fid off0 len0 hook headers = do
     IO.withBinaryFile path IO.ReadMode $ \h -> do
         IO.hSeek h IO.AbsoluteSeek off0
         n <- IO.hGetBufSome h buf' (mini room len0)
-        bufferIO buf (hn + n) send
+        rawBufferIO buf (hn + n) send
         hook
         let n' = fromIntegral n
         fptr <- newForeignPtr_ buf
@@ -123,7 +123,7 @@ readSendFile buf siz send fid off0 len0 hook headers =
         let room = siz - hn
             buf' = buf `plusPtr` hn
         n <- positionRead fd buf' (mini room len0) off0
-        bufferIO buf (hn + n) send
+        rawBufferIO buf (hn + n) send
         hook
         let n' = fromIntegral n
         loop fd (len0 - n') (off0 + n')
@@ -139,7 +139,7 @@ readSendFile buf siz send fid off0 len0 hook headers =
         | len <= 0 = return ()
         | otherwise = do
             n <- positionRead fd buf (mini siz len) off
-            bufferIO buf n send
+            rawBufferIO buf n send
             let n' = fromIntegral n
             hook
             loop fd (len - n') (off + n')

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -9,6 +9,7 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
+import Foreign.ForeignPtr (ForeignPtr)
 import Network.Socket (SockAddr)
 import Network.Socket.BufferPool
 import System.Posix.Types (Fd)
@@ -94,6 +95,10 @@ type SendFile = FileId -> Integer -> Integer -> IO () -> [ByteString] -> IO ()
 -- containing bytes and a way to free the buffer.
 data WriteBuffer = WriteBuffer
     { bufBuffer :: Buffer
+    , bufFPtr :: ForeignPtr Word8
+    -- ^ A finalizer-free 'ForeignPtr' wrapping 'bufBuffer', cached so that
+    -- flushing does not allocate a fresh wrapper on every call. The buffer
+    -- is freed via 'bufFree', never via this 'ForeignPtr'.
     , bufSize :: !BufSize
     -- ^ The size of the write buffer.
     , bufFree :: IO ()

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -3,7 +3,6 @@
 
 module Network.Wai.Handler.Warp.Types where
 
-import Control.Concurrent.STM (TVar)
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -129,7 +128,7 @@ data Connection = Connection
     , connHTTP2 :: IORef Bool
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
-    , connAppsInProgress :: TVar Int
+    , connAppsInProgress :: IORef Int
     -- ^ Amount of apps currently in progress on this connection.
     --
     -- /HTTP2 can handle more than one request concurrently/

--- a/warp/bench/ResponseBench.hs
+++ b/warp/bench/ResponseBench.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | End-to-end benchmark of the response path: everything 'sendResponse'
+-- does per response except the actual socket write (the Connection is a
+-- sink). Covers header sanitization, indexing, Server/Date insertion,
+-- header composition, chunking, buffer management and timeout handling.
+module Main (main) where
+
+import Control.Concurrent.STM (newTVarIO)
+import Criterion.Main
+import Data.ByteString.Builder (byteString)
+import Data.IORef (newIORef)
+import qualified Network.HTTP.Types as H
+import qualified Network.HTTP.Types.Header as H
+import Network.Socket (SockAddr (..))
+import Network.Wai (defaultRequest)
+import Network.Wai.Internal (Request (..), Response (..))
+import qualified System.TimeManager as T
+
+import Network.Wai.Handler.Warp.Buffer (createWriteBuffer)
+import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Response (sendResponse)
+import Network.Wai.Handler.Warp.ResponseHeader (composeHeader)
+import Network.Wai.Handler.Warp.Settings (defaultSettings)
+import Network.Wai.Handler.Warp.Types
+
+main :: IO ()
+main = do
+    writeBuf <- createWriteBuffer 16384 >>= newIORef
+    http2Ref <- newIORef False
+    apps <- newTVarIO (0 :: Int)
+    let conn =
+            Connection
+                { connSendMany = \_ -> return ()
+                , connSendAll = \_ -> return ()
+                , connSendFile = \_ _ _ _ _ -> return ()
+                , connClose = return ()
+                , connRecv = return ""
+                , connRecvBuf = \_ _ -> return True
+                , connWriteBuffer = writeBuf
+                , connHTTP2 = http2Ref
+                , connMySockAddr = SockAddrInet 0 0
+                , connAppsInProgress = apps
+                }
+    mgr <- T.initialize 30000000
+    th <- T.register mgr (return ())
+    let ii =
+            InternalInfo
+                { timeoutManager = mgr
+                , getDate = return "Fri, 18 Jul 2026 12:00:00 GMT"
+                , getFd = \_ -> return (Nothing, return ())
+                , getFileInfo = \_ -> ioError (userError "no file info in bench")
+                }
+        req = defaultRequest{httpVersion = H.http11, requestMethod = H.methodGet}
+        reqidxhdr = indexRequestHeader reqHdrs
+        send = sendResponse defaultSettings conn ii th req reqidxhdr (return "")
+    defaultMain
+        [ bgroup
+            "sendResponse"
+            [ bench "builder 4 headers content-length" $ whnfIO $ send (rspB hdrs4)
+            , bench "builder 3 headers chunked" $ whnfIO $ send (rspB hdrs3NoCL)
+            , bench "builder 20 headers content-length" $ whnfIO $ send (rspB hdrs20)
+            , bench "no body 204" $ whnfIO $ send rsp204
+            ]
+        , bgroup
+            "headers"
+            [ bench "composeHeader 5 headers" $
+                whnfIO $
+                    composeHeader H.http11 H.status200 hdrs5
+            , bench "indexRequestHeader" $ whnf indexRequestHeader reqHdrs
+            , bench "indexResponseHeader" $ whnf indexResponseHeader hdrs5
+            ]
+        ]
+  where
+    body = byteString "Hello, World!"
+    rspB hs = ResponseBuilder H.status200 hs body
+    rsp204 = ResponseBuilder H.status204 [] mempty
+    reqHdrs =
+        [ (H.hHost, "127.0.0.1:3011")
+        , (H.hUserAgent, "wrk/4.2.0")
+        , (H.hAccept, "*/*")
+        , ("Accept-Encoding", "gzip, deflate")
+        , (H.hConnection, "keep-alive")
+        ]
+    hdrs4 =
+        [ (H.hContentType, "text/plain; charset=utf-8")
+        , (H.hContentLength, "13")
+        , (H.hCacheControl, "no-cache")
+        , ("X-Request-Id", "0123456789abcdef")
+        ]
+    hdrs3NoCL =
+        [ (H.hContentType, "text/plain; charset=utf-8")
+        , (H.hCacheControl, "no-cache")
+        , ("X-Request-Id", "0123456789abcdef")
+        ]
+    -- what composeHeader sees after warp added Server and Date
+    hdrs5 = (H.hServer, "Warp/3.4.15") : (H.hDate, "Fri, 18 Jul 2026 12:00:00 GMT") : hdrs3NoCL
+    hdrs20 =
+        hdrs4
+            ++ [ (H.hCacheControl, "private, max-age=0")
+               , ("ETag", "\"33a64df551425fcc55e4d42a148795d9f25f89d4\"")
+               , (H.hLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
+               , ("X-Frame-Options", "SAMEORIGIN")
+               , ("X-Content-Type-Options", "nosniff")
+               , ("X-XSS-Protection", "1; mode=block")
+               , ("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+               , ("Content-Security-Policy", "default-src 'self'")
+               , ("Referrer-Policy", "strict-origin-when-cross-origin")
+               , ("Access-Control-Allow-Origin", "*")
+               , ("Vary", "Accept-Encoding")
+               , ("Set-Cookie", "session=abc123; Path=/; HttpOnly; Secure")
+               , ("X-Runtime", "0.012345")
+               , ("X-Served-By", "cache-lhr-1234")
+               , ("Age", "0")
+               , ("Via", "1.1 varnish")
+               ]

--- a/warp/bench/ResponseBench.hs
+++ b/warp/bench/ResponseBench.hs
@@ -6,7 +6,6 @@
 -- header composition, chunking, buffer management and timeout handling.
 module Main (main) where
 
-import Control.Concurrent.STM (newTVarIO)
 import Criterion.Main
 import Data.ByteString.Builder (byteString)
 import Data.IORef (newIORef)
@@ -28,7 +27,7 @@ main :: IO ()
 main = do
     writeBuf <- createWriteBuffer 16384 >>= newIORef
     http2Ref <- newIORef False
-    apps <- newTVarIO (0 :: Int)
+    apps <- newIORef (0 :: Int)
     let conn =
             Connection
                 { connSendMany = \_ -> return ()

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -354,3 +354,75 @@ benchmark parser
 
     if impl(ghc >=8)
         default-extensions: Strict StrictData
+
+benchmark response
+    type:             exitcode-stdio-1.0
+    main-is:          ResponseBench.hs
+    hs-source-dirs:   bench .
+    other-modules:
+        Network.Wai.Handler.Warp.Buffer
+        Network.Wai.Handler.Warp.Conduit
+        Network.Wai.Handler.Warp.Counter
+        Network.Wai.Handler.Warp.Date
+        Network.Wai.Handler.Warp.FdCache
+        Network.Wai.Handler.Warp.File
+        Network.Wai.Handler.Warp.FileInfoCache
+        Network.Wai.Handler.Warp.HashMap
+        Network.Wai.Handler.Warp.Header
+        Network.Wai.Handler.Warp.IO
+        Network.Wai.Handler.Warp.Imports
+        Network.Wai.Handler.Warp.PackInt
+        Network.Wai.Handler.Warp.ReadInt
+        Network.Wai.Handler.Warp.Request
+        Network.Wai.Handler.Warp.RequestHeader
+        Network.Wai.Handler.Warp.Response
+        Network.Wai.Handler.Warp.ResponseHeader
+        Network.Wai.Handler.Warp.Settings
+        Network.Wai.Handler.Warp.ShuttingDown
+        Network.Wai.Handler.Warp.Types
+
+    if flag(include-warp-version)
+        other-modules: Paths_warp
+
+    default-language: Haskell2010
+    ghc-options:      -threaded
+    build-depends:
+        base >=4.8 && <5,
+        array,
+        auto-update,
+        bsb-http-chunked,
+        bytestring,
+        case-insensitive,
+        containers,
+        criterion,
+        hashable,
+        http-date,
+        http-types,
+        network,
+        recv,
+        stm,
+        streaming-commons,
+        text,
+        time-manager,
+        vault,
+        wai,
+        word8
+
+    if flag(x509)
+        build-depends: crypton-x509
+
+    if (((os(linux) || os(freebsd)) || os(osx)) && flag(allow-sendfilefd))
+        cpp-options:   -DSENDFILEFD
+        build-depends: unix
+
+    if os(windows)
+        cpp-options:   -DWINDOWS
+        build-depends:
+            time,
+            unix-compat >=0.2
+    else
+        other-modules: Network.Wai.Handler.Warp.MultiMap
+        build-depends: unix
+
+    if impl(ghc >=8)
+        default-extensions: Strict StrictData


### PR DESCRIPTION
## Summary

A series of hot-path optimizations for warp (plus small changes to `recv` and `time-manager`), found by profiling and syscall-tracing a keep-alive hello-world server and verified end to end. Cumulative effect on the same hardware/workload (wrk -t4 -c100, server `-N4`, GHC 9.10.3):

|  | stock warp 3.4.15 | this branch |
|---|---|---|
| hello-world throughput | 35.7k req/s | **71.7k req/s (+101%)** |
| allocation per request | 13.7 KB | **6.7 KB (-51%)** |
| `sendResponse` (4-header builder response) | 1.58 us | **290 ns (-82%)** |
| syscalls per request | recv + send + epoll_ctl + ~28 futex ops | **recv + send** |

Also validated against a real production Servant app (full middleware stack, DB pool, logging): +57-80% throughput on light endpoints, +27% on a 124KB HTML page, ~40% lower latency, byte-identical response bodies.

## The two big ones

**Optimistic recv (last commit).** `makeGracefulRecv` (introduced with graceful shutdown, on the hot path for every `runSettings` server) registers with the IO manager and parks in STM on *every* receive, even though under load the next request is nearly always already in the kernel buffer. The branch tries a direct non-blocking `recv(2)` first and only falls back to the STM/shutdown machinery on would-block. A syscall census went from ~1 `epoll_ctl` + ~28 `futex` per request to 186 and 725 *total* across 198k requests.

**Timer traffic (commit 5).** Every request performed 3+ operations against GHC's global TimerManager (pause/resume/tickle; streaming did resume+pause per fragment). `time-manager` now caches the TimerManager in the Handle and rate-limits `tickle` to one real `updateTimeout` per min(1s, timeout/4) using a monotonic-clock check; streaming keeps the timeout armed with a rate-limited tickle per fragment. This commit alone was +45% throughput.

The remaining commits: single-pass response-header handling, composing the header directly into the connection write buffer (saves a full memcpy + pinned allocation per response), strict-record header indexes on both request and response side, a cached `ForeignPtr` in `WriteBuffer`, and a lazily-built request vault.

## Correctness

- Full warp spec suite passes at every commit boundary I built (and on the final tree).
- Wire bytes diffed against master for content-length, chunked, and many-header responses: byte-identical including chunked framing.
- Timeout behavior after the timer changes verified manually: idle, keep-alive-then-idle, and stalled-streaming connections all closed at ~3.01s with `setTimeout 3`.
- The vault laziness was proven with a temporary trace probe (plus a control run).

## Behavior changes maintainers should weigh

1. **Timeout precision** (timer commit): timeouts can fire up to min(1s, timeout/4) early relative to the last suppressed tickle.
2. **Streaming timeout semantics** (timer commit): the timeout is now armed while user code runs between fragments, so a `responseStream` that emits nothing for a full timeout period is killed (previously it could stall forever between fragments). Streams that write at least once per timeout period, or send heartbeats, are unaffected. This closes a slowloris-shaped gap but is observable for e.g. SSE without heartbeats.
3. **Graceful shutdown edge** (recv commit): a request already in the kernel buffer when shutdown begins is now served (pre-graceful-shutdown behavior for bytes the client already sent).
4. **API changes**: `Connection.connAppsInProgress` and `makeGracefulRecv` change `TVar Int` -> `IORef Int` (exposed via `Internal`); `WriteBuffer` gains a `bufFPtr` field; `Header.hs` drops the now-unused array machinery. The STM->IORef commit measured neutral on its own, so I'm happy to drop it if the API churn isn't worth it.
5. `receiveNoWait` (recv) uses a direct FFI `recv(2)` because `Network.Socket.recvBufNoWait` isn't exported from `network`'s public API; on Windows it returns `Nothing` (unchanged behavior). If exporting `recvBufNoWait` upstream is preferred I can switch to it.

## Benchmarks included

The first commit adds `warp:bench:response`, an end-to-end criterion benchmark of `sendResponse` with a sink `Connection` — the response side previously had no benchmark coverage at all. Each commit message carries its measured effect.