### PR TITLE
warp: add end-to-end response-path benchmark

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,5 @@ packages:
     wai-websockets
     wai-conduit
     time-manager
+
+benchmarks: True

--- a/warp/bench/ResponseBench.hs
+++ b/warp/bench/ResponseBench.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | End-to-end benchmark of the response path: everything 'sendResponse'
+-- does per response except the actual socket write (the Connection is a
+-- sink). Covers header sanitization, indexing, Server/Date insertion,
+-- header composition, chunking, buffer management and timeout handling.
+module Main (main) where
+
+import Control.Concurrent.STM (newTVarIO)
+import Criterion.Main
+import Data.ByteString.Builder (byteString)
+import Data.IORef (newIORef)
+import qualified Network.HTTP.Types as H
+import qualified Network.HTTP.Types.Header as H
+import Network.Socket (SockAddr (..))
+import Network.Wai (defaultRequest)
+import Network.Wai.Internal (Request (..), Response (..))
+import qualified System.TimeManager as T
+
+import Network.Wai.Handler.Warp.Buffer (createWriteBuffer)
+import Network.Wai.Handler.Warp.Header
+import Network.Wai.Handler.Warp.Response (sendResponse)
+import Network.Wai.Handler.Warp.ResponseHeader (composeHeader)
+import Network.Wai.Handler.Warp.Settings (defaultSettings)
+import Network.Wai.Handler.Warp.Types
+
+main :: IO ()
+main = do
+    writeBuf <- createWriteBuffer 16384 >>= newIORef
+    http2Ref <- newIORef False
+    apps <- newTVarIO (0 :: Int)
+    let conn =
+            Connection
+                { connSendMany = \_ -> return ()
+                , connSendAll = \_ -> return ()
+                , connSendFile = \_ _ _ _ _ -> return ()
+                , connClose = return ()
+                , connRecv = return ""
+                , connRecvBuf = \_ _ -> return True
+                , connWriteBuffer = writeBuf
+                , connHTTP2 = http2Ref
+                , connMySockAddr = SockAddrInet 0 0
+                , connAppsInProgress = apps
+                }
+    mgr <- T.initialize 30000000
+    th <- T.register mgr (return ())
+    let ii =
+            InternalInfo
+                { timeoutManager = mgr
+                , getDate = return "Fri, 18 Jul 2026 12:00:00 GMT"
+                , getFd = \_ -> return (Nothing, return ())
+                , getFileInfo = \_ -> ioError (userError "no file info in bench")
+                }
+        req = defaultRequest{httpVersion = H.http11, requestMethod = H.methodGet}
+        reqidxhdr = indexRequestHeader reqHdrs
+        send = sendResponse defaultSettings conn ii th req reqidxhdr (return "")
+    defaultMain
+        [ bgroup
+            "sendResponse"
+            [ bench "builder 4 headers content-length" $ whnfIO $ send (rspB hdrs4)
+            , bench "builder 3 headers chunked" $ whnfIO $ send (rspB hdrs3NoCL)
+            , bench "builder 20 headers content-length" $ whnfIO $ send (rspB hdrs20)
+            , bench "no body 204" $ whnfIO $ send rsp204
+            ]
+        , bgroup
+            "headers"
+            [ bench "composeHeader 5 headers" $
+                whnfIO $
+                    composeHeader H.http11 H.status200 hdrs5
+            , bench "indexRequestHeader" $ whnf indexRequestHeader reqHdrs
+            , bench "indexResponseHeader" $ whnf indexResponseHeader hdrs5
+            ]
+        ]
+  where
+    body = byteString "Hello, World!"
+    rspB hs = ResponseBuilder H.status200 hs body
+    rsp204 = ResponseBuilder H.status204 [] mempty
+    reqHdrs =
+        [ (H.hHost, "127.0.0.1:3011")
+        , (H.hUserAgent, "wrk/4.2.0")
+        , (H.hAccept, "*/*")
+        , ("Accept-Encoding", "gzip, deflate")
+        , (H.hConnection, "keep-alive")
+        ]
+    hdrs4 =
+        [ (H.hContentType, "text/plain; charset=utf-8")
+        , (H.hContentLength, "13")
+        , (H.hCacheControl, "no-cache")
+        , ("X-Request-Id", "0123456789abcdef")
+        ]
+    hdrs3NoCL =
+        [ (H.hContentType, "text/plain; charset=utf-8")
+        , (H.hCacheControl, "no-cache")
+        , ("X-Request-Id", "0123456789abcdef")
+        ]
+    -- what composeHeader sees after warp added Server and Date
+    hdrs5 = (H.hServer, "Warp/3.4.15") : (H.hDate, "Fri, 18 Jul 2026 12:00:00 GMT") : hdrs3NoCL
+    hdrs20 =
+        hdrs4
+            ++ [ (H.hCacheControl, "private, max-age=0")
+               , ("ETag", "\"33a64df551425fcc55e4d42a148795d9f25f89d4\"")
+               , (H.hLastModified, "Wed, 21 Oct 2015 07:28:00 GMT")
+               , ("X-Frame-Options", "SAMEORIGIN")
+               , ("X-Content-Type-Options", "nosniff")
+               , ("X-XSS-Protection", "1; mode=block")
+               , ("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+               , ("Content-Security-Policy", "default-src 'self'")
+               , ("Referrer-Policy", "strict-origin-when-cross-origin")
+               , ("Access-Control-Allow-Origin", "*")
+               , ("Vary", "Accept-Encoding")
+               , ("Set-Cookie", "session=abc123; Path=/; HttpOnly; Secure")
+               , ("X-Runtime", "0.012345")
+               , ("X-Served-By", "cache-lhr-1234")
+               , ("Age", "0")
+               , ("Via", "1.1 varnish")
+               ]

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -354,3 +354,75 @@ benchmark parser
 
     if impl(ghc >=8)
         default-extensions: Strict StrictData
+
+benchmark response
+    type:             exitcode-stdio-1.0
+    main-is:          ResponseBench.hs
+    hs-source-dirs:   bench .
+    other-modules:
+        Network.Wai.Handler.Warp.Buffer
+        Network.Wai.Handler.Warp.Conduit
+        Network.Wai.Handler.Warp.Counter
+        Network.Wai.Handler.Warp.Date
+        Network.Wai.Handler.Warp.FdCache
+        Network.Wai.Handler.Warp.File
+        Network.Wai.Handler.Warp.FileInfoCache
+        Network.Wai.Handler.Warp.HashMap
+        Network.Wai.Handler.Warp.Header
+        Network.Wai.Handler.Warp.IO
+        Network.Wai.Handler.Warp.Imports
+        Network.Wai.Handler.Warp.PackInt
+        Network.Wai.Handler.Warp.ReadInt
+        Network.Wai.Handler.Warp.Request
+        Network.Wai.Handler.Warp.RequestHeader
+        Network.Wai.Handler.Warp.Response
+        Network.Wai.Handler.Warp.ResponseHeader
+        Network.Wai.Handler.Warp.Settings
+        Network.Wai.Handler.Warp.ShuttingDown
+        Network.Wai.Handler.Warp.Types
+
+    if flag(include-warp-version)
+        other-modules: Paths_warp
+
+    default-language: Haskell2010
+    ghc-options:      -threaded
+    build-depends:
+        base >=4.8 && <5,
+        array,
+        auto-update,
+        bsb-http-chunked,
+        bytestring,
+        case-insensitive,
+        containers,
+        criterion,
+        hashable,
+        http-date,
+        http-types,
+        network,
+        recv,
+        stm,
+        streaming-commons,
+        text,
+        time-manager,
+        vault,
+        wai,
+        word8
+
+    if flag(x509)
+        build-depends: crypton-x509
+
+    if (((os(linux) || os(freebsd)) || os(osx)) && flag(allow-sendfilefd))
+        cpp-options:   -DSENDFILEFD
+        build-depends: unix
+
+    if os(windows)
+        cpp-options:   -DWINDOWS
+        build-depends:
+            time,
+            unix-compat >=0.2
+    else
+        other-modules: Network.Wai.Handler.Warp.MultiMap
+        build-depends: unix
+
+    if impl(ghc >=8)
+        default-extensions: Strict StrictData


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs.

The existing bench suite covers only request-line parsing and header splitting; the response side had no benchmark at all. This adds `warp:bench:response`, a criterion benchmark driving the real `sendResponse` end to end with a sink `Connection`, a real time-manager `Handle`, and a realistic indexed request header, plus isolated benches for `composeHeader` and the header indexers. Compiled `-threaded` with the library's `Strict`/`StrictData` to match production semantics. Also sets `benchmarks: True` in `cabal.project`.

Baseline it establishes (GHC 9.10.3): builder response with 4 headers 1.58µs, 20 headers 2.80µs, 204-no-body 727ns. The other PRs in the series quote measurements from this benchmark.


