### PR TITLE
warp: stop rebuilding clean response headers, index in one pass

### DIFF
--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -40,7 +40,7 @@ conditionalRequest finfo hs0 method rspidx reqidx = case condition of
     nobody@(WithoutBody _) -> nobody
     WithBody s _ off len ->
         let !hs1 = addContentHeaders hs0 off len size
-            !hs = case rspidx ! ResLastModified of
+            !hs = case resLastModified rspidx of
                 Just _ -> hs1
                 Nothing -> (H.hLastModified, date) : hs1
          in WithBody s hs off len

--- a/warp/Network/Wai/Handler/Warp/File.hs
+++ b/warp/Network/Wai/Handler/Warp/File.hs
@@ -33,16 +33,16 @@ conditionalRequest
     :: I.FileInfo
     -> H.ResponseHeaders
     -> H.Method
-    -> IndexedResponseHeader
+    -> ResponseHeaderPresence
     -> IndexedRequestHeader
     -> RspFileInfo
 conditionalRequest finfo hs0 method rspidx reqidx = case condition of
     nobody@(WithoutBody _) -> nobody
     WithBody s _ off len ->
         let !hs1 = addContentHeaders hs0 off len size
-            !hs = case resLastModified rspidx of
-                Just _ -> hs1
-                Nothing -> (H.hLastModified, date) : hs1
+            !hs
+                | hasLastModified rspidx = hs1
+                | otherwise = (H.hLastModified, date) : hs1
          in WithBody s hs off len
   where
     !mtime = I.fileInfoTime finfo

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -4,13 +4,12 @@
 module Network.Wai.Handler.Warp.Header (
     IndexedHeader,
     IndexedRequestHeader,
-    IndexedResponseHeader,
+    IndexedResponseHeader (..),
     (!),
     RequestHeaderIndex (..),
     indexRequestHeader,
     requestMaxIndex,
     defaultIndexRequestHeader,
-    ResponseHeaderIndex (..),
     indexResponseHeader,
 ) where
 
@@ -29,7 +28,6 @@ import Network.Wai.Handler.Warp.Types
 newtype IndexedHeader a = IxHeader (Array Int (Maybe HeaderValue))
 
 type IndexedRequestHeader = IndexedHeader RequestHeaderIndex
-type IndexedResponseHeader = IndexedHeader ResponseHeaderIndex
 
 -- | Safer way to lookup 'IndexedHeader' values
 (!) :: Enum a => IndexedHeader a -> a -> Maybe HeaderValue
@@ -104,29 +102,40 @@ defaultIndexRequestHeader =
 
 ----------------------------------------------------------------
 
-indexResponseHeader :: ResponseHeaders -> IndexedHeader ResponseHeaderIndex
-indexResponseHeader hdr = traverseHeader hdr responseMaxIndex responseKeyIndex
+-- | Index for the response headers Warp itself consults.
+--   Only these four headers are ever looked up on the response side,
+--   so a flat record built in a single traversal beats a boxed array.
+--   The fields are strict via StrictData.
+data IndexedResponseHeader = IndexedResponseHeader
+    { resContentLength :: Maybe HeaderValue
+    , resServer :: Maybe HeaderValue
+    , resDate :: Maybe HeaderValue
+    , resLastModified :: Maybe HeaderValue
+    }
 
-data ResponseHeaderIndex
-    = ResContentLength
-    | ResServer
-    | ResDate
-    | ResLastModified
-    deriving (Enum, Bounded)
-
--- | The size for 'IndexedHeader' for HTTP Response.
-responseMaxIndex :: Int
-responseMaxIndex = fromEnum (maxBound :: ResponseHeaderIndex)
-
-responseKeyIndex :: HeaderName -> Int
-responseKeyIndex hn = case BS.length bs of
-    4 | bs == "date" -> fromEnum ResDate
-    6 | bs == "server" -> fromEnum ResServer
-    13 | bs == "last-modified" -> fromEnum ResLastModified
-    14 | bs == "content-length" -> fromEnum ResContentLength
-    _ -> -1
+indexResponseHeader :: ResponseHeaders -> IndexedResponseHeader
+indexResponseHeader = go emptyIndexedResponseHeader
   where
-    bs = foldedCase hn
+    go ix [] = ix
+    go ix ((key, val) : rest) = go (insert ix key val) rest
+    -- Like 'traverseHeader', a later duplicate wins.
+    insert ix key val = case BS.length bs of
+        4 | bs == "date" -> ix{resDate = Just val}
+        6 | bs == "server" -> ix{resServer = Just val}
+        13 | bs == "last-modified" -> ix{resLastModified = Just val}
+        14 | bs == "content-length" -> ix{resContentLength = Just val}
+        _ -> ix
+      where
+        bs = foldedCase key
+
+emptyIndexedResponseHeader :: IndexedResponseHeader
+emptyIndexedResponseHeader =
+    IndexedResponseHeader
+        { resContentLength = Nothing
+        , resServer = Nothing
+        , resDate = Nothing
+        , resLastModified = Nothing
+        }
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Header.hs
+++ b/warp/Network/Wai/Handler/Warp/Header.hs
@@ -4,7 +4,7 @@
 module Network.Wai.Handler.Warp.Header (
     IndexedHeader,
     IndexedRequestHeader,
-    IndexedResponseHeader (..),
+    ResponseHeaderPresence (..),
     (!),
     RequestHeaderIndex (..),
     indexRequestHeader,
@@ -102,39 +102,38 @@ defaultIndexRequestHeader =
 
 ----------------------------------------------------------------
 
--- | Index for the response headers Warp itself consults.
---   Only these four headers are ever looked up on the response side,
---   so a flat record built in a single traversal beats a boxed array.
---   The fields are strict via StrictData.
-data IndexedResponseHeader = IndexedResponseHeader
-    { resContentLength :: Maybe HeaderValue
-    , resServer :: Maybe HeaderValue
-    , resDate :: Maybe HeaderValue
-    , resLastModified :: Maybe HeaderValue
+-- | Presence of the response headers Warp itself consults.
+--   Only these four headers are ever looked up on the response side, and
+--   only their presence, never their value, so a flat record of strict
+--   'Bool's built in a single traversal beats a boxed array.
+data ResponseHeaderPresence = ResponseHeaderPresence
+    { hasContentLength :: Bool
+    , hasServer :: Bool
+    , hasDate :: Bool
+    , hasLastModified :: Bool
     }
 
-indexResponseHeader :: ResponseHeaders -> IndexedResponseHeader
-indexResponseHeader = go emptyIndexedResponseHeader
+indexResponseHeader :: ResponseHeaders -> ResponseHeaderPresence
+indexResponseHeader = go emptyResponseHeaderPresence
   where
     go ix [] = ix
-    go ix ((key, val) : rest) = go (insert ix key val) rest
-    -- Like 'traverseHeader', a later duplicate wins.
-    insert ix key val = case BS.length bs of
-        4 | bs == "date" -> ix{resDate = Just val}
-        6 | bs == "server" -> ix{resServer = Just val}
-        13 | bs == "last-modified" -> ix{resLastModified = Just val}
-        14 | bs == "content-length" -> ix{resContentLength = Just val}
+    go ix ((key, _) : rest) = go (insert ix key) rest
+    insert ix key = case BS.length bs of
+        4 | bs == "date" -> ix{hasDate = True}
+        6 | bs == "server" -> ix{hasServer = True}
+        13 | bs == "last-modified" -> ix{hasLastModified = True}
+        14 | bs == "content-length" -> ix{hasContentLength = True}
         _ -> ix
       where
         bs = foldedCase key
 
-emptyIndexedResponseHeader :: IndexedResponseHeader
-emptyIndexedResponseHeader =
-    IndexedResponseHeader
-        { resContentLength = Nothing
-        , resServer = Nothing
-        , resDate = Nothing
-        , resLastModified = Nothing
+emptyResponseHeaderPresence :: ResponseHeaderPresence
+emptyResponseHeaderPresence =
+    ResponseHeaderPresence
+        { hasContentLength = False
+        , hasServer = False
+        , hasDate = False
+        , hasLastModified = False
         }
 
 ----------------------------------------------------------------

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -180,16 +180,20 @@ sendResponse settings conn ii th req reqidxhdr src response = do
 
 ----------------------------------------------------------------
 
+-- Values without CR/LF (the overwhelmingly common case) leave the
+-- header list untouched; only a dirty value triggers a rebuild.
 sanitizeHeaders :: H.ResponseHeaders -> H.ResponseHeaders
-sanitizeHeaders = map (sanitize <$>)
+sanitizeHeaders hs
+    | any (containsNewlines . snd) hs = map (sanitize <$>) hs -- slow path
+    | otherwise = hs -- fast path
   where
     sanitize v
-        | containsNewlines v = sanitizeHeaderValue v -- slow path
-        | otherwise = v -- fast path
+        | containsNewlines v = sanitizeHeaderValue v
+        | otherwise = v
 
 {-# INLINE containsNewlines #-}
 containsNewlines :: ByteString -> Bool
-containsNewlines = S.any (\w -> w == _cr || w == _lf)
+containsNewlines v = isJust (S.elemIndex _cr v) || isJust (S.elemIndex _lf v)
 
 {-# INLINE sanitizeHeaderValue #-}
 sanitizeHeaderValue :: ByteString -> ByteString
@@ -458,7 +462,7 @@ infoFromResponse rspidxhdr (isPersist, isChunked) = (isKeepAlive, needsChunked)
   where
     needsChunked = isChunked && not hasLength
     isKeepAlive = isPersist && (isChunked || hasLength)
-    hasLength = isJust $ rspidxhdr ! ResContentLength
+    hasLength = isJust $ resContentLength rspidxhdr
 
 ----------------------------------------------------------------
 
@@ -477,7 +481,7 @@ addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
 
 addDate
     :: IO D.GMTDate -> IndexedResponseHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
-addDate getdate rspidxhdr hdrs = case rspidxhdr ! ResDate of
+addDate getdate rspidxhdr hdrs = case resDate rspidxhdr of
     Nothing -> do
         gmtdate <- getdate
         return $ (H.hDate, gmtdate) : hdrs
@@ -488,10 +492,10 @@ addDate getdate rspidxhdr hdrs = case rspidxhdr ! ResDate of
 {-# INLINE addServer #-}
 addServer
     :: HeaderValue -> IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
-addServer "" rspidxhdr hdrs = case rspidxhdr ! ResServer of
+addServer "" rspidxhdr hdrs = case resServer rspidxhdr of
     Nothing -> hdrs
     _ -> filter ((/= H.hServer) . fst) hdrs
-addServer serverName rspidxhdr hdrs = case rspidxhdr ! ResServer of
+addServer serverName rspidxhdr hdrs = case resServer rspidxhdr of
     Nothing -> (H.hServer, serverName) : hdrs
     _ -> hdrs
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -7,6 +7,7 @@
 module Network.Wai.Handler.Warp.Response (
     sendResponse,
     sanitizeHeaderValue, -- for testing
+    containsNewlines, -- for benchmarking
     --  Provided here for backwards compatibility.
     warpVersion,
     hasBody,

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -193,7 +193,8 @@ sanitizeHeaders hs
 
 {-# INLINE containsNewlines #-}
 containsNewlines :: ByteString -> Bool
-containsNewlines v = isJust (S.elemIndex _cr v) || isJust (S.elemIndex _lf v)
+-- Each 'S.any (w ==)' is rewritten to a memchr via bytestring's 'anyByte' rule.
+containsNewlines v = S.any (_lf ==) v || S.any (_cr ==) v
 
 {-# INLINE sanitizeHeaderValue #-}
 sanitizeHeaderValue :: ByteString -> ByteString
@@ -225,7 +226,7 @@ sendRsp
     -> H.HttpVersion
     -> H.Status
     -> H.ResponseHeaders
-    -> IndexedResponseHeader
+    -> ResponseHeaderPresence
     -> Int -- maxBuilderResponseBufferSize
     -> H.Method
     -> Rsp
@@ -360,7 +361,7 @@ sendRspFile2XX
     -> H.HttpVersion
     -> H.Status
     -> H.ResponseHeaders
-    -> IndexedResponseHeader
+    -> ResponseHeaderPresence
     -> Int
     -> H.Method
     -> FilePath
@@ -385,7 +386,7 @@ sendRspFile404
     -> T.Handle
     -> H.HttpVersion
     -> H.ResponseHeaders
-    -> IndexedResponseHeader
+    -> ResponseHeaderPresence
     -> Int
     -> H.Method
     -> IO (Maybe H.Status, Maybe Integer)
@@ -457,12 +458,12 @@ checkChunk req = httpVersion req == H.http11
 --
 -- Content-Length is specified by a reverse proxy.
 -- Note that CGI does not specify Content-Length.
-infoFromResponse :: IndexedResponseHeader -> (Bool, Bool) -> (Bool, Bool)
+infoFromResponse :: ResponseHeaderPresence -> (Bool, Bool) -> (Bool, Bool)
 infoFromResponse rspidxhdr (isPersist, isChunked) = (isKeepAlive, needsChunked)
   where
     needsChunked = isChunked && not hasLength
     isKeepAlive = isPersist && (isChunked || hasLength)
-    hasLength = isJust $ resContentLength rspidxhdr
+    hasLength = hasContentLength rspidxhdr
 
 ----------------------------------------------------------------
 
@@ -480,24 +481,24 @@ addTransferEncoding :: H.ResponseHeaders -> H.ResponseHeaders
 addTransferEncoding hdrs = (H.hTransferEncoding, "chunked") : hdrs
 
 addDate
-    :: IO D.GMTDate -> IndexedResponseHeader -> H.ResponseHeaders -> IO H.ResponseHeaders
-addDate getdate rspidxhdr hdrs = case resDate rspidxhdr of
-    Nothing -> do
+    :: IO D.GMTDate -> ResponseHeaderPresence -> H.ResponseHeaders -> IO H.ResponseHeaders
+addDate getdate rspidxhdr hdrs
+    | hasDate rspidxhdr = return hdrs
+    | otherwise = do
         gmtdate <- getdate
         return $ (H.hDate, gmtdate) : hdrs
-    Just _ -> return hdrs
 
 ----------------------------------------------------------------
 
 {-# INLINE addServer #-}
 addServer
-    :: HeaderValue -> IndexedResponseHeader -> H.ResponseHeaders -> H.ResponseHeaders
-addServer "" rspidxhdr hdrs = case resServer rspidxhdr of
-    Nothing -> hdrs
-    _ -> filter ((/= H.hServer) . fst) hdrs
-addServer serverName rspidxhdr hdrs = case resServer rspidxhdr of
-    Nothing -> (H.hServer, serverName) : hdrs
-    _ -> hdrs
+    :: HeaderValue -> ResponseHeaderPresence -> H.ResponseHeaders -> H.ResponseHeaders
+addServer "" rspidxhdr hdrs
+    | hasServer rspidxhdr = filter ((/= H.hServer) . fst) hdrs
+    | otherwise = hdrs
+addServer serverName rspidxhdr hdrs
+    | hasServer rspidxhdr = hdrs
+    | otherwise = (H.hServer, serverName) : hdrs
 
 addAltSvc :: Settings -> H.ResponseHeaders -> H.ResponseHeaders
 addAltSvc settings hs = case settingsAltSvc settings of

--- a/warp/bench/Parser.hs
+++ b/warp/bench/Parser.hs
@@ -19,6 +19,7 @@ import qualified Network.HTTP.Types as H
 import Prelude hiding (lines)
 
 import Network.Wai.Handler.Warp.Request (FirstRequest (..), headerLines)
+import Network.Wai.Handler.Warp.Response (containsNewlines)
 import Network.Wai.Handler.Warp.Types
 
 import Criterion.Main
@@ -53,6 +54,15 @@ main = do
             , bench "new parsing 10" $ whnfAppIO testIt (chunkRequest 10)
             , bench "new parsing 25" $ whnfAppIO testIt (chunkRequest 25)
             , bench "new parsing 100" $ whnfAppIO testIt (chunkRequest 100)
+            ]
+        , bgroup
+            "containsNewlines"
+            -- Clean values (no CR/LF) are the overwhelmingly common case and
+            -- the one the fast path must stay cheap for; the dirty case is
+            -- what forces a rebuild in 'sanitizeHeaders'.
+            [ bench "clean short" $ whnf containsNewlines "Mighttpd/2.5.8"
+            , bench "clean long" $ whnf containsNewlines cleanLong
+            , bench "dirty" $ whnf containsNewlines "text/html\r\nInjected: header"
             ]
         ]
   where
@@ -241,6 +251,11 @@ parseRequestLine0 s =
                      in return $! (method, rpath, qstring, hv)
                 else throwIO NonHttp
         _ -> throwIO $ BadFirstLine $ B.unpack s
+
+-- A long, clean header value (no CR/LF): forces the memchr scan to walk the
+-- whole value before deciding it is clean.
+cleanLong :: S.ByteString
+cleanLong = S.replicate 512 _A
 
 producer :: [ByteString] -> IO Source
 producer a = do

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -295,19 +295,26 @@ benchmark parser
     main-is:          Parser.hs
     hs-source-dirs:   bench .
     other-modules:
+        Network.Wai.Handler.Warp.Buffer
         Network.Wai.Handler.Warp.Conduit
         Network.Wai.Handler.Warp.Counter
         Network.Wai.Handler.Warp.Date
         Network.Wai.Handler.Warp.FdCache
+        Network.Wai.Handler.Warp.File
         Network.Wai.Handler.Warp.FileInfoCache
         Network.Wai.Handler.Warp.HashMap
         Network.Wai.Handler.Warp.Header
+        Network.Wai.Handler.Warp.IO
         Network.Wai.Handler.Warp.Imports
         Network.Wai.Handler.Warp.MultiMap
+        Network.Wai.Handler.Warp.PackInt
         Network.Wai.Handler.Warp.ReadInt
         Network.Wai.Handler.Warp.Request
         Network.Wai.Handler.Warp.RequestHeader
+        Network.Wai.Handler.Warp.Response
+        Network.Wai.Handler.Warp.ResponseHeader
         Network.Wai.Handler.Warp.Settings
+        Network.Wai.Handler.Warp.ShuttingDown
         Network.Wai.Handler.Warp.Types
 
     if flag(include-warp-version)
@@ -317,7 +324,9 @@ benchmark parser
     build-depends:
         base >=4.8 && <5,
         array,
+        async,
         auto-update,
+        bsb-http-chunked,
         bytestring,
         case-insensitive,
         containers,
@@ -325,9 +334,11 @@ benchmark parser
         hashable,
         http-date,
         http-types,
-        network,
+        http2,
+        iproute,
         network,
         recv,
+        simple-sendfile,
         stm,
         streaming-commons,
         text,


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs; independent of the others (touches only the response side of `Header.hs`, `Response.hs`, `File.hs`).

`sendResponse` rebuilt the response header list even when nothing needed sanitizing (the overwhelmingly common case) and byte-scanned every value with `S.any`; `indexResponseHeader` built a boxed `Data.Array` although only four slots are ever consulted. Now: a memchr-based (`S.elemIndex`) dirty check returns the input list untouched when clean, and the response index is a four-field strict record filled in one traversal. Dirty-value sanitization output is unchanged.

Measured (bench from #1091): `sendResponse` 4 headers 1.58µs → 1.39µs (−12%), 20 headers 2.80µs → 2.08µs (−26%); ≈ −425 B allocated per request under keep-alive load. Spec suite passes.

Rebase note: this and the request-side index PR both touch `Header.hs`; whichever merges second has a trivial conflict (they modify disjoint halves; together they make the shared array machinery fully dead, and the second PR deletes it).
