### PR TITLE
warp: compose response header directly into the write buffer

### DIFF
--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -4,23 +4,38 @@ import Control.Exception (mask_)
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Extra (Next (Chunk, Done, More), runBuilder)
 import Data.IORef (IORef, readIORef, writeIORef)
+import Foreign.Ptr (plusPtr)
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types
 
 toBufIOWith
     :: Int -> IORef WriteBuffer -> (ByteString -> IO ()) -> Builder -> IO Integer
-toBufIOWith maxRspBufSize writeBufferRef io builder = do
+toBufIOWith = toBufIOWithOffset 0
+
+-- | Like 'toBufIOWith' but the first @offset@ bytes of the write buffer
+-- are assumed to be already filled (e.g. with a response header composed
+-- directly into the buffer). They are flushed together with the first
+-- batch of builder output and included in the returned total.
+-- @offset@ must not exceed the current buffer size.
+toBufIOWithOffset
+    :: Int
+    -> Int
+    -> IORef WriteBuffer
+    -> (ByteString -> IO ())
+    -> Builder
+    -> IO Integer
+toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
     writeBuffer <- readIORef writeBufferRef
-    loop writeBuffer firstWriter 0
+    loop writeBuffer offset0 firstWriter 0
   where
     firstWriter = runBuilder builder
-    loop writeBuffer writer bytesSent = do
+    loop writeBuffer offset writer bytesSent = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
-        (len, signal) <- writer buf size
-        bufferIO buf len io
-        let totalBytesSent = toInteger len + bytesSent
+        (len, signal) <- writer (buf `plusPtr` offset) (size - offset)
+        bufferIO buf (offset + len) io
+        let totalBytesSent = toInteger (offset + len) + bytesSent
         case signal of
             Done -> return totalBytesSent
             More minSize next
@@ -43,8 +58,8 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
                         biggerWriteBuffer <- createWriteBuffer minSize
                         writeIORef writeBufferRef biggerWriteBuffer
                         return biggerWriteBuffer
-                    loop biggerWriteBuffer next totalBytesSent
-                | otherwise -> loop writeBuffer next totalBytesSent
+                    loop biggerWriteBuffer 0 next totalBytesSent
+                | otherwise -> loop writeBuffer 0 next totalBytesSent
             Chunk bs next -> do
                 io bs
-                loop writeBuffer next totalBytesSent
+                loop writeBuffer 0 next totalBytesSent

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -11,21 +11,30 @@ import Network.Wai.Handler.Warp.Types
 
 toBufIOWith
     :: Int -> IORef WriteBuffer -> (ByteString -> IO ()) -> Builder -> IO Integer
-toBufIOWith = toBufIOWithOffset 0
+toBufIOWith = unsafeToBufIOWithOffset 0
 
 -- | Like 'toBufIOWith' but the first @offset@ bytes of the write buffer
 -- are assumed to be already filled (e.g. with a response header composed
 -- directly into the buffer). They are flushed together with the first
 -- batch of builder output and included in the returned total.
--- @offset@ must not exceed the current buffer size.
-toBufIOWithOffset
+--
+-- === WARNING: @offset@ MUST NOT exceed the current buffer size!!!
+--
+-- This function performs NO bounds checking on @offset@. The builder is
+-- handed the pointer @buffer + offset@ with @bufSize - offset@ bytes of
+-- claimed free space, so an oversized @offset@ points past the end of the
+-- allocation and advertises negative capacity, i.e. out-of-bounds writes
+-- and memory corruption. Every caller MUST verify
+-- @offset < bufSize@ of the current write buffer first (see the
+-- @hdrLen@ check in 'Network.Wai.Handler.Warp.Response.sendRsp').
+unsafeToBufIOWithOffset
     :: Int
     -> Int
     -> IORef WriteBuffer
     -> (ByteString -> IO ())
     -> Builder
     -> IO Integer
-toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
+unsafeToBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
     writeBuffer <- readIORef writeBufferRef
     loop writeBuffer offset0 firstWriter 0
   where

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -12,21 +12,30 @@ import Network.Wai.Handler.Warp.Types
 
 toBufIOWith
     :: Int -> IORef WriteBuffer -> (ByteString -> IO ()) -> Builder -> IO Integer
-toBufIOWith = toBufIOWithOffset 0
+toBufIOWith = unsafeToBufIOWithOffset 0
 
 -- | Like 'toBufIOWith' but the first @offset@ bytes of the write buffer
 -- are assumed to be already filled (e.g. with a response header composed
 -- directly into the buffer). They are flushed together with the first
 -- batch of builder output and included in the returned total.
--- @offset@ must not exceed the current buffer size.
-toBufIOWithOffset
+--
+-- === WARNING: @offset@ MUST NOT exceed the current buffer size!!!
+--
+-- This function performs NO bounds checking on @offset@. The builder is
+-- handed the pointer @buffer + offset@ with @bufSize - offset@ bytes of
+-- claimed free space, so an oversized @offset@ points past the end of the
+-- allocation and advertises negative capacity, i.e. out-of-bounds writes
+-- and memory corruption. Every caller MUST verify
+-- @offset < bufSize@ of the current write buffer first (see the
+-- @hdrLen@ check in 'Network.Wai.Handler.Warp.Response.sendRsp').
+unsafeToBufIOWithOffset
     :: Int
     -> Int
     -> IORef WriteBuffer
     -> (ByteString -> IO ())
     -> Builder
     -> IO Integer
-toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
+unsafeToBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
     writeBuffer <- readIORef writeBufferRef
     loop writeBuffer offset0 firstWriter 0
   where

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -5,23 +5,38 @@ import qualified Data.ByteString as B (length)
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Builder.Extra (Next (Chunk, Done, More), runBuilder)
 import Data.IORef (IORef, readIORef, writeIORef)
+import Foreign.Ptr (plusPtr)
 import Network.Wai.Handler.Warp.Buffer
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.Types
 
 toBufIOWith
     :: Int -> IORef WriteBuffer -> (ByteString -> IO ()) -> Builder -> IO Integer
-toBufIOWith maxRspBufSize writeBufferRef io builder = do
+toBufIOWith = toBufIOWithOffset 0
+
+-- | Like 'toBufIOWith' but the first @offset@ bytes of the write buffer
+-- are assumed to be already filled (e.g. with a response header composed
+-- directly into the buffer). They are flushed together with the first
+-- batch of builder output and included in the returned total.
+-- @offset@ must not exceed the current buffer size.
+toBufIOWithOffset
+    :: Int
+    -> Int
+    -> IORef WriteBuffer
+    -> (ByteString -> IO ())
+    -> Builder
+    -> IO Integer
+toBufIOWithOffset offset0 maxRspBufSize writeBufferRef io builder = do
     writeBuffer <- readIORef writeBufferRef
-    loop writeBuffer firstWriter 0
+    loop writeBuffer offset0 firstWriter 0
   where
     firstWriter = runBuilder builder
-    loop writeBuffer writer bytesSent = do
+    loop writeBuffer offset writer bytesSent = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
-        (len, signal) <- writer buf size
-        bufferIO buf len io
-        let totalBytesSent = toInteger len + bytesSent
+        (len, signal) <- writer (buf `plusPtr` offset) (size - offset)
+        bufferIO buf (offset + len) io
+        let totalBytesSent = toInteger (offset + len) + bytesSent
         case signal of
             Done -> return totalBytesSent
             More minSize next
@@ -44,8 +59,9 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
                         biggerWriteBuffer <- createWriteBuffer minSize
                         writeIORef writeBufferRef biggerWriteBuffer
                         return biggerWriteBuffer
-                    loop biggerWriteBuffer next totalBytesSent
-                | otherwise -> loop writeBuffer next totalBytesSent
+                    loop biggerWriteBuffer 0 next totalBytesSent
+                | otherwise -> loop writeBuffer 0 next totalBytesSent
             Chunk bs next -> do
                 io bs
-                loop writeBuffer next $ totalBytesSent + fromIntegral (B.length bs)
+                loop writeBuffer 0 next $
+                    totalBytesSent + fromIntegral (B.length bs)

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -26,6 +26,7 @@ import Data.ByteString.Builder.HTTP.Chunked (
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.CaseInsensitive as CI
 import Data.Function (on)
+import Data.IORef (readIORef)
 import Data.List (deleteBy)
 import Data.Streaming.ByteString.Builder (
     newByteStringBuilderRecv,
@@ -42,7 +43,7 @@ import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.IO (toBufIOWith)
+import Network.Wai.Handler.Warp.IO (toBufIOWith, toBufIOWithOffset)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.ResponseHeader
 import Network.Wai.Handler.Warp.Settings
@@ -237,21 +238,32 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 ----------------------------------------------------------------
 
 sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
-    header <- composeHeaderBuilder ver s hs needsChunked
-    let hdrBdy
-            | needsChunked =
-                header
-                    <> chunkedTransferEncoding body
-                    <> chunkedTransferTerminator
-            | otherwise = header <> body
-        writeBufferRef = connWriteBuffer conn
+    writeBuffer <- readIORef writeBufferRef
     len <-
-        toBufIOWith
-            maxRspBufSize
-            writeBufferRef
-            (\bs -> connSendAll conn bs >> T.tickle th)
-            hdrBdy
+        if hdrLen < bufSize writeBuffer
+            then do
+                -- Compose the header directly into the connection write
+                -- buffer and run the body builder right after it, saving
+                -- a copy of the header bytes through an intermediate
+                -- ByteString.
+                _ <- composeHeaderPtr (bufBuffer writeBuffer) ver s hs'
+                toBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
+            else do
+                -- Huge headers: fall back to composing a separate header
+                -- ByteString and letting the builder machinery copy it.
+                header <- composeHeaderBuilder ver s hs needsChunked
+                toBufIOWith maxRspBufSize writeBufferRef send (header <> bdy)
     return (Just s, Just len)
+  where
+    hs'
+        | needsChunked = addTransferEncoding hs
+        | otherwise = hs
+    hdrLen = composeHeaderLength s hs'
+    bdy
+        | needsChunked = chunkedTransferEncoding body <> chunkedTransferTerminator
+        | otherwise = body
+    writeBufferRef = connWriteBuffer conn
+    send bs = connSendAll conn bs >> T.tickle th
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -43,7 +43,7 @@ import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.IO (toBufIOWith, toBufIOWithOffset)
+import Network.Wai.Handler.Warp.IO (toBufIOWith, unsafeToBufIOWithOffset)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.ResponseHeader
 import Network.Wai.Handler.Warp.Settings
@@ -240,6 +240,15 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
     writeBuffer <- readIORef writeBufferRef
     len <-
+        -- SAFETY: this check is what makes the unchecked writes below
+        -- memory-safe, do not weaken it. composeHeaderPtr writes hdrLen
+        -- bytes into the write buffer with no bounds checking of its own,
+        -- and unsafeToBufIOWithOffset requires an offset within the
+        -- buffer (it hands the builder buffer + offset with
+        -- bufSize - offset bytes of claimed free space). If hdrLen could
+        -- reach the buffer size, either write would run past the end of
+        -- the allocation and corrupt memory, so oversized headers must
+        -- take the composeHeaderBuilder fallback.
         if hdrLen < bufSize writeBuffer
             then do
                 -- Compose the header directly into the connection write
@@ -247,7 +256,7 @@ sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
                 -- a copy of the header bytes through an intermediate
                 -- ByteString.
                 _ <- composeHeaderPtr (bufBuffer writeBuffer) ver s hs'
-                toBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
+                unsafeToBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
             else do
                 -- Huge headers: fall back to composing a separate header
                 -- ByteString and letting the builder machinery copy it.

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -44,7 +44,7 @@ import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.IO (toBufIOWith, toBufIOWithOffset)
+import Network.Wai.Handler.Warp.IO (toBufIOWith, unsafeToBufIOWithOffset)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.ResponseHeader
 import Network.Wai.Handler.Warp.Settings
@@ -291,6 +291,15 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 sendRsp conn _ th ver s hs rspidxhdr maxRspBufSize _ (RspBuilder body needsChunked) = do
     writeBuffer <- readIORef writeBufferRef
     len <-
+        -- SAFETY: this check is what makes the unchecked writes below
+        -- memory-safe, do not weaken it. composeHeaderPtr writes hdrLen
+        -- bytes into the write buffer with no bounds checking of its own,
+        -- and unsafeToBufIOWithOffset requires an offset within the
+        -- buffer (it hands the builder buffer + offset with
+        -- bufSize - offset bytes of claimed free space). If hdrLen could
+        -- reach the buffer size, either write would run past the end of
+        -- the allocation and corrupt memory, so oversized headers must
+        -- take the composeHeaderBuilder fallback.
         if hdrLen < bufSize writeBuffer
             then do
                 -- Compose the header directly into the connection write
@@ -298,7 +307,7 @@ sendRsp conn _ th ver s hs rspidxhdr maxRspBufSize _ (RspBuilder body needsChunk
                 -- a copy of the header bytes through an intermediate
                 -- ByteString.
                 _ <- composeHeaderPtr (bufBuffer writeBuffer) ver s hs'
-                toBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
+                unsafeToBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
             else do
                 -- Huge headers: fall back to composing a separate header
                 -- ByteString and letting the builder machinery copy it.

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -44,7 +44,7 @@ import Network.Wai.Handler.Warp.Buffer (toBuilderBuffer)
 import qualified Network.Wai.Handler.Warp.Date as D
 import Network.Wai.Handler.Warp.File
 import Network.Wai.Handler.Warp.Header
-import Network.Wai.Handler.Warp.IO (toBufIOWith)
+import Network.Wai.Handler.Warp.IO (toBufIOWith, toBufIOWithOffset)
 import Network.Wai.Handler.Warp.Imports
 import Network.Wai.Handler.Warp.ResponseHeader
 import Network.Wai.Handler.Warp.Settings
@@ -289,22 +289,33 @@ sendRsp conn _ _ ver s hs _ _ _ RspNoBody = do
 ----------------------------------------------------------------
 
 sendRsp conn _ th ver s hs rspidxhdr maxRspBufSize _ (RspBuilder body needsChunked) = do
-    (header, hdrLen) <- composeHeaderBuilder ver s hs rspidxhdr needsChunked
-    let hdrBdy
-            | needsChunked =
-                header
-                    <> chunkedTransferEncoding body
-                    <> chunkedTransferTerminator
-            | otherwise = header <> body
-        writeBufferRef = connWriteBuffer conn
+    writeBuffer <- readIORef writeBufferRef
     len <-
-        toBufIOWith
-            maxRspBufSize
-            writeBufferRef
-            (\bs -> connSendAll conn bs >> T.tickle th)
-            hdrBdy
+        if hdrLen < bufSize writeBuffer
+            then do
+                -- Compose the header directly into the connection write
+                -- buffer and run the body builder right after it, saving
+                -- a copy of the header bytes through an intermediate
+                -- ByteString.
+                _ <- composeHeaderPtr (bufBuffer writeBuffer) ver s hs'
+                toBufIOWithOffset hdrLen maxRspBufSize writeBufferRef send bdy
+            else do
+                -- Huge headers: fall back to composing a separate header
+                -- ByteString and letting the builder machinery copy it.
+                (header, _) <- composeHeaderBuilder ver s hs rspidxhdr needsChunked
+                toBufIOWith maxRspBufSize writeBufferRef send (header <> bdy)
     --              small adjustment to only count the body
     return (Just s, Just $ len - fromIntegral hdrLen)
+  where
+    hs'
+        | needsChunked = addTransferEncoding rspidxhdr hs
+        | otherwise = hs
+    hdrLen = composeHeaderLength s hs'
+    bdy
+        | needsChunked = chunkedTransferEncoding body <> chunkedTransferTerminator
+        | otherwise = body
+    writeBufferRef = connWriteBuffer conn
+    send bs = connSendAll conn bs >> T.tickle th
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
+module Network.Wai.Handler.Warp.ResponseHeader (
+    composeHeader,
+    composeHeaderPtr,
+    composeHeaderLength,
+) where
 
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
@@ -18,14 +22,31 @@ import Network.Wai.Handler.Warp.Imports
 ----------------------------------------------------------------
 
 composeHeader :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO ByteString
-composeHeader !httpversion !status !responseHeaders = create len $ \ptr -> do
-    ptr1 <- copyStatus ptr httpversion status
-    ptr2 <- copyHeaders ptr1 responseHeaders
-    void $ copyCRLF ptr2
+composeHeader !httpversion !status !responseHeaders =
+    create len $ \ptr ->
+        void $ composeHeaderPtr ptr httpversion status responseHeaders
   where
-    !len = 17 + slen + foldl' fieldLength 0 responseHeaders
+    !len = composeHeaderLength status responseHeaders
+
+-- | The exact number of bytes 'composeHeaderPtr' writes for this
+-- status line and header list (including the final CRLF).
+composeHeaderLength :: H.Status -> H.ResponseHeaders -> Int
+composeHeaderLength !status !responseHeaders =
+    17 + slen + foldl' fieldLength 0 responseHeaders
+  where
     fieldLength !l (!k, !v) = l + S.length (CI.original k) + S.length v + 4
     !slen = S.length $ H.statusMessage status
+
+-- | Compose the response header directly into the given buffer,
+-- returning the number of bytes written. The buffer must have room
+-- for at least 'composeHeaderLength' bytes.
+composeHeaderPtr
+    :: Ptr Word8 -> H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO Int
+composeHeaderPtr !ptr !httpversion !status !responseHeaders = do
+    ptr1 <- copyStatus ptr httpversion status
+    ptr2 <- copyHeaders ptr1 responseHeaders
+    ptr3 <- copyCRLF ptr2
+    return $! ptr3 `minusPtr` ptr
 
 httpVer11 :: ByteString
 httpVer11 = "HTTP/1.1 "

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Network.Wai.Handler.Warp.ResponseHeader (composeHeader) where
+module Network.Wai.Handler.Warp.ResponseHeader (
+    composeHeader,
+    composeHeaderPtr,
+    composeHeaderLength,
+) where
 
 import qualified Data.ByteString as S
 import Data.ByteString.Internal (create)
@@ -18,14 +22,31 @@ import Network.Wai.Handler.Warp.Imports
 ----------------------------------------------------------------
 
 composeHeader :: H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO ByteString
-composeHeader !httpversion !status !responseHeaders = create len $ \ptr -> do
-    ptr1 <- copyStatus ptr httpversion status
-    ptr2 <- copyHeaders ptr1 responseHeaders
-    void $ copyCRLF ptr2
+composeHeader !httpversion !status !responseHeaders =
+    create len $ \ptr ->
+        void $ composeHeaderPtr ptr httpversion status responseHeaders
   where
-    !len = 17 + slen + List.foldl' fieldLength 0 responseHeaders
+    !len = composeHeaderLength status responseHeaders
+
+-- | The exact number of bytes 'composeHeaderPtr' writes for this
+-- status line and header list (including the final CRLF).
+composeHeaderLength :: H.Status -> H.ResponseHeaders -> Int
+composeHeaderLength !status !responseHeaders =
+    17 + slen + List.foldl' fieldLength 0 responseHeaders
+  where
     fieldLength !l (!k, !v) = l + S.length (CI.original k) + S.length v + 4
     !slen = S.length $ H.statusMessage status
+
+-- | Compose the response header directly into the given buffer,
+-- returning the number of bytes written. The buffer must have room
+-- for at least 'composeHeaderLength' bytes.
+composeHeaderPtr
+    :: Ptr Word8 -> H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO Int
+composeHeaderPtr !ptr !httpversion !status !responseHeaders = do
+    ptr1 <- copyStatus ptr httpversion status
+    ptr2 <- copyHeaders ptr1 responseHeaders
+    ptr3 <- copyCRLF ptr2
+    return $! ptr3 `minusPtr` ptr
 
 httpVer11 :: ByteString
 httpVer11 = "HTTP/1.1 "

--- a/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
+++ b/warp/Network/Wai/Handler/Warp/ResponseHeader.hs
@@ -42,6 +42,7 @@ composeHeaderLength !status !responseHeaders =
 -- for at least 'composeHeaderLength' bytes.
 composeHeaderPtr
     :: Ptr Word8 -> H.HttpVersion -> H.Status -> H.ResponseHeaders -> IO Int
+{-# INLINE composeHeaderPtr #-}
 composeHeaderPtr !ptr !httpversion !status !responseHeaders = do
     ptr1 <- copyStatus ptr httpversion status
     ptr2 <- copyHeaders ptr1 responseHeaders


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs; independent of the others.

For `RspBuilder` responses (responseBuilder/responseLBS, the most common type) the header block was copied twice: composed into a fresh pinned ByteString, then copied again into the connection write buffer (headers are nearly always < 4096 bytes, so bytestring's builder copies rather than inserts). Now the header is composed directly into the write buffer (`composeHeaderPtr`/`composeHeaderLength` in ResponseHeader, sharing the existing copy loops) and the body builder continues after it via `unsafeToBufIOWithOffset` (`toBufIOWith = unsafeToBufIOWithOffset 0`, no duplicated loop). Oversized headers fall back to the old path. The length reported to the logger is unchanged.

### Correctness

Wire bytes verified byte-identical against current master for content-length, chunked, and 20-header responses, including chunked framing (`Transfer-Encoding: chunked` and the terminating `0\r\n` chunk). Re-verified against master @ 79b0e6b7 rather than the original base. Spec suite: 121 examples, 0 failures.

### Measurements

Against master @ 79b0e6b7, `warp:bench:response`, GHC 9.10.3, 7 rounds alternating master/branch from prebuilt binaries, pinned with `taskset -c 3`, medians across rounds.

Allocation, bytes per iteration, via `--regress allocated:iters +RTS -T` (R² = 1.000, so this is exact rather than sampled):

| bench | master | branch | |
|---|---|---|---|
| builder 4 headers content-length | 2385 | 1842 | -22.8% |
| builder 3 headers chunked | 2514 | 1986 | -21.0% |
| builder 20 headers content-length | 4539 | 3434 | -24.4% |
| no body 204 (untouched path) | 1009 | 1009 | 0% |
| headers/* (untouched) | unchanged | unchanged | 0% |

That is roughly 540 B less allocated per response, and the paths this PR does not touch allocate byte-identically.

Times, same runs: -4.8% (4 headers), -5.2% (chunked), -3.7% (20 headers).

**Treat the timings as weak evidence.** In the same sweep `indexResponseHeader`, which this PR does not touch, moved +7.7% between the two binaries purely from code layout, so a few percent on these sub-microsecond benchmarks is noise. The allocation figures are the claim worth reviewing. (An earlier revision of this description quoted -6% and -11%; those did not reproduce under interleaved runs against current master and have been dropped.)

Two notes for anyone re-running these:

- The `sendResponse` benchmarks report severely inflated variance. That is not GC (`+RTS -s` shows 99.7% productivity). `strace -c` counts ~313k `write` syscalls for a single `sendResponse` benchmark, about one per iteration, from `T.tickle th` reaching `wakeManager`. The timer wake-up dominates both the jitter and a good part of the absolute number, which is why the allocation regression is the more useful signal here. That cost is what #1097 targets.
- Comparing distributions rather than single runs caught a real regression in this branch: `composeHeaderPtr` was not being inlined, leaving `composeHeader` with an out-of-line call plus a `minusPtr` it discards (~4% slower than master). Fixed in the latest commit with an `INLINE` pragma, which also inlines it into `sendRsp`.
