### PR TITLE
warp: cache a ForeignPtr in WriteBuffer, drop per-flush allocation

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -485,8 +485,7 @@ attachConn mysa ctx = do
         sendfile fid offset len hook headers = do
             writeBuffer <- I.readIORef writeBufferRef
             readSendFile
-                (bufBuffer writeBuffer)
-                (bufSize writeBuffer)
+                writeBuffer
                 sendall
                 fid
                 offset

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -27,6 +27,11 @@
 * Rework internal indexed headers to records for performance and to remove
   dependencies on `array`.
   [#1092](https://github.com/yesodweb/wai/pull/1092) [#1093](https://github.com/yesodweb/wai/pull/1093)
+* `WriteBuffer` now carries a cached `ForeignPtr` of its buffer, so flushing a
+  response no longer allocates a fresh wrapper. `sendFile` and `readSendFile`
+  now take the `WriteBuffer` instead of a `Buffer` and a `BufSize`, which
+  changes the API of `Network.Wai.Handler.Warp.Internal`.
+  [#1095](https://github.com/yesodweb/wai/pull/1095)
 
 ## 3.4.14
 

--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -4,6 +4,7 @@ module Network.Wai.Handler.Warp.Buffer (
     freeBuffer,
     toBuilderBuffer,
     bufferIO,
+    rawBufferIO,
 ) where
 
 import Data.IORef (IORef, readIORef)
@@ -23,9 +24,11 @@ import Network.Wai.Handler.Warp.Types
 createWriteBuffer :: BufSize -> IO WriteBuffer
 createWriteBuffer size = do
     bytes <- allocateBuffer size
+    fptr <- newForeignPtr_ bytes
     return
         WriteBuffer
             { bufBuffer = bytes
+            , bufFPtr = fptr
             , bufSize = size
             , bufFree = freeBuffer bytes
             }
@@ -48,12 +51,19 @@ freeBuffer = free
 toBuilderBuffer :: IORef WriteBuffer -> IO B.Buffer
 toBuilderBuffer writeBufferRef = do
     writeBuffer <- readIORef writeBufferRef
-    let ptr = bufBuffer writeBuffer
+    let fptr = bufFPtr writeBuffer
+        ptr = bufBuffer writeBuffer
         size = bufSize writeBuffer
-    fptr <- newForeignPtr_ ptr
     return $ B.Buffer fptr ptr ptr (ptr `plusPtr` size)
 
-bufferIO :: Buffer -> Int -> (ByteString -> IO ()) -> IO ()
-bufferIO ptr siz io = do
+-- | Slice the given number of bytes out of a 'WriteBuffer' using its
+-- cached 'ForeignPtr', without allocating a fresh wrapper.
+bufferIO :: WriteBuffer -> Int -> (ByteString -> IO ()) -> IO ()
+bufferIO writeBuffer siz io = io $ PS (bufFPtr writeBuffer) 0 siz
+
+-- | Like 'bufferIO' for callers that only have a raw pointer.
+-- This allocates a fresh 'ForeignPtr' wrapper on every call.
+rawBufferIO :: Buffer -> Int -> (ByteString -> IO ()) -> IO ()
+rawBufferIO ptr siz io = do
     fptr <- newForeignPtr_ ptr
     io $ PS fptr 0 siz

--- a/warp/Network/Wai/Handler/Warp/Buffer.hs
+++ b/warp/Network/Wai/Handler/Warp/Buffer.hs
@@ -4,7 +4,6 @@ module Network.Wai.Handler.Warp.Buffer (
     freeBuffer,
     toBuilderBuffer,
     bufferIO,
-    rawBufferIO,
 ) where
 
 import Data.IORef (IORef, readIORef)
@@ -60,10 +59,3 @@ toBuilderBuffer writeBufferRef = do
 -- cached 'ForeignPtr', without allocating a fresh wrapper.
 bufferIO :: WriteBuffer -> Int -> (ByteString -> IO ()) -> IO ()
 bufferIO writeBuffer siz io = io $ PS (bufFPtr writeBuffer) 0 siz
-
--- | Like 'bufferIO' for callers that only have a raw pointer.
--- This allocates a fresh 'ForeignPtr' wrapper on every call.
-rawBufferIO :: Buffer -> Int -> (ByteString -> IO ()) -> IO ()
-rawBufferIO ptr siz io = do
-    fptr <- newForeignPtr_ ptr
-    io $ PS fptr 0 siz

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -19,7 +19,7 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
         (len, signal) <- writer buf size
-        bufferIO buf len io
+        bufferIO writeBuffer len io
         let totalBytesSent = toInteger len + bytesSent
         case signal of
             Done -> return totalBytesSent

--- a/warp/Network/Wai/Handler/Warp/IO.hs
+++ b/warp/Network/Wai/Handler/Warp/IO.hs
@@ -20,7 +20,7 @@ toBufIOWith maxRspBufSize writeBufferRef io builder = do
         let buf = bufBuffer writeBuffer
             size = bufSize writeBuffer
         (len, signal) <- writer buf size
-        bufferIO buf len io
+        bufferIO writeBuffer len io
         let totalBytesSent = toInteger len + bytesSent
         case signal of
             Done -> return totalBytesSent

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -117,8 +117,7 @@ socketConnection set s = do
         writeBuffer <- readIORef writeBufferRef
         sendFile
             s
-            (bufBuffer writeBuffer)
-            (bufSize writeBuffer)
+            writeBuffer
             sendall
             fid
             offset

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -72,7 +72,7 @@ packHeader buf siz send hook (bs : bss) n
         let dst = buf `plusPtr` n
             (bs1, bs2) = BS.splitAt room bs
         void $ copy dst bs1
-        bufferIO buf siz send
+        rawBufferIO buf siz send
         hook
         packHeader buf siz send hook (bs2 : bss) 0
   where
@@ -98,7 +98,7 @@ readSendFile buf siz send fid off0 len0 hook headers = do
     IO.withBinaryFile path IO.ReadMode $ \h -> do
         IO.hSeek h IO.AbsoluteSeek off0
         n <- IO.hGetBufSome h buf' (mini room len0)
-        bufferIO buf (hn + n) send
+        rawBufferIO buf (hn + n) send
         hook
         let n' = fromIntegral n
         fptr <- newForeignPtr_ buf
@@ -123,7 +123,7 @@ readSendFile buf siz send fid off0 len0 hook headers =
         let room = siz - hn
             buf' = buf `plusPtr` hn
         n <- positionRead fd buf' (mini room len0) off0
-        bufferIO buf (hn + n) send
+        rawBufferIO buf (hn + n) send
         hook
         let n' = fromIntegral n
         loop fd (len0 - n') (off0 + n')
@@ -139,7 +139,7 @@ readSendFile buf siz send fid off0 len0 hook headers =
         | len <= 0 = return ()
         | otherwise = do
             n <- positionRead fd buf (mini siz len) off
-            bufferIO buf n send
+            rawBufferIO buf n send
             let n' = fromIntegral n
             hook
             loop fd (len - n') (off + n')

--- a/warp/Network/Wai/Handler/Warp/SendFile.hs
+++ b/warp/Network/Wai/Handler/Warp/SendFile.hs
@@ -15,7 +15,6 @@ import Network.Socket (Socket)
 import Network.Socket.BufferPool
 
 #ifdef WINDOWS
-import Foreign.ForeignPtr (newForeignPtr_)
 import Foreign.Ptr (plusPtr)
 import qualified System.IO as IO
 #else
@@ -39,9 +38,9 @@ import Network.Wai.Handler.Warp.Types
 --   For other OSes, this is identical to 'readSendFile'.
 --
 -- Since: 3.1.0
-sendFile :: Socket -> Buffer -> BufSize -> (ByteString -> IO ()) -> SendFile
+sendFile :: Socket -> WriteBuffer -> (ByteString -> IO ()) -> SendFile
 #ifdef SENDFILEFD
-sendFile s _ _ _ fid off len act hdr = case mfid of
+sendFile s _ _ fid off len act hdr = case mfid of
     -- settingsFdCacheDuration is 0
     Nothing -> sendfileWithHeader s path (PartOfFile off len) act hdr
     Just fd -> sendfileFdWithHeader s fd (PartOfFile off len) act hdr
@@ -55,29 +54,28 @@ sendFile _ = readSendFile
 ----------------------------------------------------------------
 
 packHeader
-    :: Buffer
-    -> BufSize
+    :: WriteBuffer
     -> (ByteString -> IO ())
     -> IO ()
     -> [ByteString]
     -> Int
     -> IO Int
-packHeader _ _ _ _ [] n = return n
-packHeader buf siz send hook (bs : bss) n
+packHeader _ _ _ [] n = return n
+packHeader wbuf send hook (bs : bss) n
     | len < room = do
-        let dst = buf `plusPtr` n
+        let dst = bufBuffer wbuf `plusPtr` n
         void $ copy dst bs
-        packHeader buf siz send hook bss (n + len)
+        packHeader wbuf send hook bss (n + len)
     | otherwise = do
-        let dst = buf `plusPtr` n
+        let dst = bufBuffer wbuf `plusPtr` n
             (bs1, bs2) = BS.splitAt room bs
         void $ copy dst bs1
-        rawBufferIO buf siz send
+        bufferIO wbuf (bufSize wbuf) send
         hook
-        packHeader buf siz send hook (bs2 : bss) 0
+        packHeader wbuf send hook (bs2 : bss) 0
   where
     len = BS.length bs
-    room = siz - n
+    room = bufSize wbuf - n
 
 mini :: Int -> Integer -> Int
 mini i n
@@ -90,44 +88,45 @@ mini i n
 --
 -- Since: 3.1.0
 #ifdef WINDOWS
-readSendFile :: Buffer -> BufSize -> (ByteString -> IO ()) -> SendFile
-readSendFile buf siz send fid off0 len0 hook headers = do
-    hn <- packHeader buf siz send hook headers 0
+readSendFile :: WriteBuffer -> (ByteString -> IO ()) -> SendFile
+readSendFile wbuf send fid off0 len0 hook headers = do
+    hn <- packHeader wbuf send hook headers 0
     let room = siz - hn
         buf' = buf `plusPtr` hn
     IO.withBinaryFile path IO.ReadMode $ \h -> do
         IO.hSeek h IO.AbsoluteSeek off0
         n <- IO.hGetBufSome h buf' (mini room len0)
-        rawBufferIO buf (hn + n) send
+        bufferIO wbuf (hn + n) send
         hook
         let n' = fromIntegral n
-        fptr <- newForeignPtr_ buf
-        loop h fptr (len0 - n')
+        loop h (len0 - n')
   where
+    buf = bufBuffer wbuf
+    siz = bufSize wbuf
     path = fileIdPath fid
-    loop h fptr len
+    loop h len
         | len <= 0 = return ()
         | otherwise = do
             n <- IO.hGetBufSome h buf (mini siz len)
             when (n /= 0) $ do
-                let bs = PS fptr 0 n
-                    n' = fromIntegral n
-                send bs
+                bufferIO wbuf n send
                 hook
-                loop h fptr (len - n')
+                loop h (len - fromIntegral n)
 #else
-readSendFile :: Buffer -> BufSize -> (ByteString -> IO ()) -> SendFile
-readSendFile buf siz send fid off0 len0 hook headers =
+readSendFile :: WriteBuffer -> (ByteString -> IO ()) -> SendFile
+readSendFile wbuf send fid off0 len0 hook headers =
     E.bracket setup teardown $ \fd -> do
-        hn <- packHeader buf siz send hook headers 0
+        hn <- packHeader wbuf send hook headers 0
         let room = siz - hn
             buf' = buf `plusPtr` hn
         n <- positionRead fd buf' (mini room len0) off0
-        rawBufferIO buf (hn + n) send
+        bufferIO wbuf (hn + n) send
         hook
         let n' = fromIntegral n
         loop fd (len0 - n') (off0 + n')
   where
+    buf = bufBuffer wbuf
+    siz = bufSize wbuf
     path = fileIdPath fid
     setup = case fileIdFd fid of
         Just fd -> return fd
@@ -139,7 +138,7 @@ readSendFile buf siz send fid off0 len0 hook headers =
         | len <= 0 = return ()
         | otherwise = do
             n <- positionRead fd buf (mini siz len) off
-            rawBufferIO buf n send
+            bufferIO wbuf n send
             let n' = fromIntegral n
             hook
             loop fd (len - n') (off + n')

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -10,6 +10,7 @@ import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 #ifdef MIN_VERSION_crypton_x509
 import Data.X509
 #endif
+import Foreign.ForeignPtr (ForeignPtr)
 import Network.Socket (SockAddr)
 import Network.Socket.BufferPool
 import System.Posix.Types (Fd)
@@ -95,6 +96,10 @@ type SendFile = FileId -> Integer -> Integer -> IO () -> [ByteString] -> IO ()
 -- containing bytes and a way to free the buffer.
 data WriteBuffer = WriteBuffer
     { bufBuffer :: Buffer
+    , bufFPtr :: ForeignPtr Word8
+    -- ^ A finalizer-free 'ForeignPtr' wrapping 'bufBuffer', cached so that
+    -- flushing does not allocate a fresh wrapper on every call. The buffer
+    -- is freed via 'bufFree', never via this 'ForeignPtr'.
     , bufSize :: !BufSize
     -- ^ The size of the write buffer.
     , bufFree :: IO ()

--- a/warp/test/SendFileSpec.hs
+++ b/warp/test/SendFileSpec.hs
@@ -60,34 +60,34 @@ spec = do
             tryReadSendFile 10 20 100 ["012345678", "901234"] `shouldReturn` ExitSuccess
 
 tryPackHeader :: Int -> [ByteString] -> IO Int
-tryPackHeader siz hdrs = bracket (allocateBuffer siz) freeBuffer $ \buf ->
-    packHeader buf siz send hook hdrs 0
+tryPackHeader siz hdrs = bracket (createWriteBuffer siz) bufFree $ \wbuf ->
+    packHeader wbuf send hook hdrs 0
   where
     send _ = return ()
     hook = return ()
 
 tryPackHeader2 :: Int -> [ByteString] -> ByteString -> IO Bool
-tryPackHeader2 siz hdrs ans = bracket setup teardown $ \buf -> do
-    _ <- packHeader buf siz send hook hdrs 0
+tryPackHeader2 siz hdrs ans = bracket setup teardown $ \wbuf -> do
+    _ <- packHeader wbuf send hook hdrs 0
     checkFile outputFile ans
   where
-    setup = allocateBuffer siz
-    teardown buf = freeBuffer buf >> removeFileIfExists outputFile
+    setup = createWriteBuffer siz
+    teardown wbuf = bufFree wbuf >> removeFileIfExists outputFile
     outputFile = "tempfile"
     send = BS.appendFile outputFile
     hook = return ()
 
 tryReadSendFile :: Int -> Integer -> Integer -> [ByteString] -> IO ExitCode
-tryReadSendFile siz off len hdrs = bracket setup teardown $ \buf -> do
+tryReadSendFile siz off len hdrs = bracket setup teardown $ \wbuf -> do
     mapM_ (BS.appendFile expectedFile) hdrs
     copyfile inputFile expectedFile off len
-    readSendFile buf siz send fid off len hook hdrs
+    readSendFile wbuf send fid off len hook hdrs
     compareFiles expectedFile outputFile
   where
     hook = return ()
-    setup = allocateBuffer siz
-    teardown buf = do
-        freeBuffer buf
+    setup = createWriteBuffer siz
+    teardown wbuf = do
+        bufFree wbuf
         removeFileIfExists outputFile
         removeFileIfExists expectedFile
     inputFile = "test/inputFile"


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs; independent of the others.

`bufferIO` called `newForeignPtr_` + `PS` on every write-buffer flush (at least once per response) and `toBuilderBuffer` once per streaming response, allocating a fresh wrapper for a pointer that is stable for the `WriteBuffer`'s lifetime. `WriteBuffer` now carries a `bufFPtr` minted once in `createWriteBuffer` (finalizer-free; `bufFree` remains the only free path). The one site that replaces a `WriteBuffer` (growth in `toBufIOWith`) goes through `createWriteBuffer`, so pointer and ForeignPtr cannot drift.

Following review, `sendFile`, `readSendFile` and `packHeader` now take the `WriteBuffer` itself instead of a `Buffer` plus a `BufSize`, so the file-sending paths reach the cached ForeignPtr too and `rawBufferIO` is gone entirely. Both call sites (`Run.socketConnection` and warp-tls `attachConn`) already had the `WriteBuffer` in hand and took it apart, so they get shorter.

API note: this changes the API of `Network.Wai.Handler.Warp.Internal` (the new `WriteBuffer` field, and the `sendFile`/`readSendFile` signatures), so there is a ChangeLog entry under the unreleased 3.4.15 section. `createWriteBuffer` remains the sanctioned constructor. warp-tls is updated in the same commit. Spec suite passes (including large-response buffer growth).
