### PR TITLE
warp: build the request vault lazily

### DIFF
--- a/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP2/Request.hs
@@ -98,7 +98,9 @@ toRequest' ii settings addr ref (reqths, reqvt) bodylen body th transport =
     !path = H.extractPath unparsedPath
     !rawPath = if S.settingsNoParsePath settings then unparsedPath else path
     -- fixme: pauseTimeout. th is not available here.
-    !vaultValue =
+    -- Lazy on purpose (~ defeats -XStrict): most handlers never touch
+    -- 'vault', so don't pay for the inserts unless somebody looks.
+    ~vaultValue =
         Vault.insert getFileInfoKey (getFileInfo ii)
             . Vault.insert getHTTP2DataKey (readIORef ref)
             . Vault.insert setHTTP2DataKey (writeIORef ref)

--- a/warp/Network/Wai/Handler/Warp/Request.hs
+++ b/warp/Network/Wai/Handler/Warp/Request.hs
@@ -88,7 +88,9 @@ recvRequest firstRequest settings conn ii th addr src transport = do
     -- body producing function which will never produce 100-continue
     rbodyFlush <- timeoutBody remainingRef th rbody (return ())
     let rawPath = if settingsNoParsePath settings then unparsedPath else path
-        vaultValue =
+        -- Lazy on purpose (~ defeats -XStrict): most handlers never touch
+        -- 'vault', so don't pay for the inserts unless somebody looks.
+        ~vaultValue =
             Vault.insert pauseTimeoutKey (Timeout.pause th)
                 . Vault.insert getFileInfoKey (getFileInfo ii)
 #ifdef MIN_VERSION_crypton_x509


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs; independent of the others.

Every HTTP/1 request eagerly built a Vault with 2-3 inserts (5-6 for HTTP/2), each allocating map spine + a Locker, though most applications never read the vault. warp is compiled with `-XStrict`, so a lazy pattern (`~`) on the vault binding keeps the insert chain a thunk that only materializes if a handler forces `vault req` (the field is lazy in wai's `Request`).

Laziness proven with a temporary trace probe: handlers ignoring the vault never build it; a handler forcing it builds it exactly once; a control run with the `~` removed fired on every request. Contents when read are identical. ≈ −200 B/request. Spec suite passes.
