### PR TITLE
time-manager: cache the TimerManager and rate-limit tickle

### DIFF
--- a/time-manager/ChangeLog.md
+++ b/time-manager/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for time-manager
 
+## 0.3.3
+
+* `Handle` now caches the system `TimerManager` instead of re-reading the
+  global `IORef` on every operation, and `tickle` is rate-limited: the
+  renewal is skipped unless a quarter of the timeout (capped at one second)
+  has passed since the timeout was last registered or updated.
+  [#1097](https://github.com/yesodweb/wai/pull/1097)
+
 ## 0.3.2
 
 * Add `stopAfterWithResult`. [#1069](https://github.com/yesodweb/wai/pull/1069)

--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -48,8 +48,10 @@ module System.TimeManager (
 
 import Control.Concurrent (forkIO, mkWeakThreadId, myThreadId)
 import qualified Control.Exception as E
-import Control.Monad (void)
+import Control.Monad (void, when)
 import qualified Data.IORef as I
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.Mem.Weak (deRefWeak)
 import System.TimeManager.Internal
 
@@ -73,8 +75,11 @@ emptyHandle =
     Handle
         { handleTimeout = 0
         , handleAction = pure ()
+        , handleTimerManager = error "time-manager: Handle.handleTimerManager not set"
         , handleKeyRef = error "time-manager: Handle.handleKeyRef not set"
         , handleState = error "time-manager: Handle.handleState not set"
+        , handleLastRenewed = error "time-manager: Handle.handleLastRenewed not set"
+        , handleMinRenewGap = 0
         }
 
 ----------------------------------------------------------------
@@ -126,39 +131,68 @@ register :: Manager -> TimeoutAction -> IO Handle
 register mgr@(Manager timeout) onTimeout
     | isNoManager mgr = pure emptyHandle
     | otherwise = do
+        -- The system timer manager is stable for the lifetime of the
+        -- process (and even if it were replaced, e.g. around a fork,
+        -- the key registered below would only be meaningful to the
+        -- manager it was registered with). So fetch it once here and
+        -- cache it in the 'Handle' instead of re-reading the global
+        -- IORef on every tickle/pause/resume.
         sysmgr <- getTimerManager
         key <- EV.registerTimeout sysmgr timeout onTimeout
         keyref <- I.newIORef key
         state <- I.newIORef Active
+        now <- getMonotonicTimeNSec
+        lastRenewed <- I.newIORef now
         let h =
                 Handle
                     { handleTimeout = timeout
                     , handleAction = onTimeout
+                    , handleTimerManager = sysmgr
                     , handleKeyRef = keyref
                     , handleState = state
+                    , handleLastRenewed = lastRenewed
+                    , handleMinRenewGap = minRenewGap timeout
                     }
         pure h
+
+-- | How long 'tickle' waits before actually renewing the timeout:
+--   a quarter of the timeout, capped at one second. Skipping a renewal
+--   inside this window only shortens the effective timeout by up to
+--   this gap, but turns hot 'tickle' loops (one per chunk sent or
+--   received) into a clock read and a comparison.
+minRenewGap :: Int -> Word64
+minRenewGap timeout = min oneSecond (microToNano timeout `div` 4)
+  where
+    oneSecond = 1000000000
+    microToNano = (* 1000) . fromIntegral
 
 -- | Unregistering the timeout.
 cancel :: Handle -> IO ()
 cancel h@Handle{..} = withNonEmptyHandle h $ do
-    mgr <- getTimerManager
     key <- I.readIORef handleKeyRef
-    EV.unregisterTimeout mgr key
+    EV.unregisterTimeout handleTimerManager key
     I.atomicWriteIORef handleState Stopped
 
 -- | Extending the timeout.
 --
+-- To keep frequent callers cheap, the renewal is rate-limited: it is
+-- skipped unless at least a quarter of the timeout (capped at one
+-- second) has passed since the timeout was last registered or updated.
+--
 -- Careful: this does NOT reactivate an already paused 'Handle'!
 tickle :: Handle -> IO ()
 tickle h@Handle{..} = withNonEmptyHandle h $ do
-    mgr <- getTimerManager
-    key <- I.readIORef handleKeyRef
+    now <- getMonotonicTimeNSec
+    lastRenewed <- I.readIORef handleLastRenewed
+    when (now - lastRenewed >= handleMinRenewGap) $ do
+        key <- I.readIORef handleKeyRef
 #if defined(mingw32_HOST_OS)
-    EV.updateTimeout mgr key $ fromIntegral (handleTimeout `div` 1000000)
+        EV.updateTimeout handleTimerManager key $
+            fromIntegral (handleTimeout `div` 1000000)
 #else
-    EV.updateTimeout mgr key handleTimeout
+        EV.updateTimeout handleTimerManager key handleTimeout
 #endif
+        I.writeIORef handleLastRenewed now
 
 -- | This is identical to 'cancel'.
 --   To resume timeout with the same 'Handle', 'resume' MUST be called.
@@ -175,10 +209,11 @@ resume h@Handle{..} = withNonEmptyHandle h $ do
     case state of
         Active -> tickle h
         Stopped -> do
-            mgr <- getTimerManager
-            key <- EV.registerTimeout mgr handleTimeout handleAction
+            key <- EV.registerTimeout handleTimerManager handleTimeout handleAction
             I.atomicWriteIORef handleKeyRef key
             I.atomicWriteIORef handleState Active
+            now <- getMonotonicTimeNSec
+            I.writeIORef handleLastRenewed now
 
 ----------------------------------------------------------------
 

--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Timeout manager. Since @v0.3.0@, timeout manager is a wrapper of
@@ -140,9 +141,9 @@ register mgr@(Manager timeout) onTimeout
         -- IORef on every tickle/pause/resume.
         sysmgr <- getTimerManager
         key <- EV.registerTimeout sysmgr timeout onTimeout
+        now <- getMonotonicTimeNSec
         keyref <- I.newIORef key
         state <- I.newIORef Active
-        now <- getMonotonicTimeNSec
         lastRenewed <- I.newIORef now
         let h =
                 Handle
@@ -164,8 +165,8 @@ register mgr@(Manager timeout) onTimeout
 minRenewGap :: Int -> Word64
 minRenewGap timeout = min oneSecond (microToNano timeout `shiftR` 2)
   where
-    oneSecond = 1000000000
-    microToNano = (* 1000) . fromIntegral
+    oneSecond = 1_000_000_000
+    microToNano = (* 1_000) . fromIntegral
 
 -- | Unregistering the timeout.
 cancel :: Handle -> IO ()
@@ -187,13 +188,13 @@ tickle h@Handle{..} = withNonEmptyHandle h $ do
     lastRenewed <- I.readIORef handleLastRenewed
     when (now - lastRenewed >= handleMinRenewGap) $ do
         key <- I.readIORef handleKeyRef
+        I.writeIORef handleLastRenewed now
 #if defined(mingw32_HOST_OS)
         EV.updateTimeout handleTimerManager key $
-            fromIntegral (handleTimeout `div` 1000000)
+            fromIntegral (handleTimeout `div` 1_000_000)
 #else
         EV.updateTimeout handleTimerManager key handleTimeout
 #endif
-        I.writeIORef handleLastRenewed now
 
 -- | This is identical to 'cancel'.
 --   To resume timeout with the same 'Handle', 'resume' MUST be called.

--- a/time-manager/System/TimeManager.hs
+++ b/time-manager/System/TimeManager.hs
@@ -49,6 +49,7 @@ module System.TimeManager (
 import Control.Concurrent (forkIO, mkWeakThreadId, myThreadId)
 import qualified Control.Exception as E
 import Control.Monad (void, when)
+import Data.Bits (shiftR)
 import qualified Data.IORef as I
 import Data.Word (Word64)
 import GHC.Clock (getMonotonicTimeNSec)
@@ -161,7 +162,7 @@ register mgr@(Manager timeout) onTimeout
 --   this gap, but turns hot 'tickle' loops (one per chunk sent or
 --   received) into a clock read and a comparison.
 minRenewGap :: Int -> Word64
-minRenewGap timeout = min oneSecond (microToNano timeout `div` 4)
+minRenewGap timeout = min oneSecond (microToNano timeout `shiftR` 2)
   where
     oneSecond = 1000000000
     microToNano = (* 1000) . fromIntegral

--- a/time-manager/System/TimeManager/Internal.hs
+++ b/time-manager/System/TimeManager/Internal.hs
@@ -6,6 +6,7 @@
 module System.TimeManager.Internal where
 
 import Data.IORef (IORef)
+import Data.Word (Word64)
 
 #if defined(mingw32_HOST_OS)
 import qualified GHC.Event.Windows as EV
@@ -31,8 +32,17 @@ type TimeoutAction = IO ()
 data Handle = Handle
     { handleTimeout :: Int
     , handleAction :: TimeoutAction
+    , handleTimerManager :: ~TimerManager
+    -- ^ The system timer manager the timeout key was registered with.
+    --   Cached so that per-request operations don't re-fetch it.
     , handleKeyRef :: ~(IORef EV.TimeoutKey)
     , handleState :: ~(IORef HandleState)
+    , handleLastRenewed :: ~(IORef Word64)
+    -- ^ Monotonic time (in nanoseconds) when the timeout was last
+    --   registered or updated.
+    , handleMinRenewGap :: Word64
+    -- ^ 'tickle' is a no-op unless at least this many nanoseconds have
+    --   passed since the last renewal.
     }
 
 -- | Tracking the state of a handle, to be able to have 'resume'
@@ -47,9 +57,13 @@ withNonEmptyHandle h act =
     if isEmptyHandle h then pure () else act
 
 #if defined(mingw32_HOST_OS)
-getTimerManager :: IO EV.Manager
+type TimerManager = EV.Manager
+
+getTimerManager :: IO TimerManager
 getTimerManager = EV.getSystemManager
 #else
-getTimerManager :: IO EV.TimerManager
+type TimerManager = EV.TimerManager
+
+getTimerManager :: IO TimerManager
 getTimerManager = EV.getSystemTimerManager
 #endif

--- a/time-manager/time-manager.cabal
+++ b/time-manager/time-manager.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               time-manager
-version:            0.3.2
+version:            0.3.3
 license:            MIT
 license-file:       LICENSE
 maintainer:         kazu@iij.ad.jp


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs. Standalone: benefits current warp releases as-is (warp already tickles on every request); compounds with the companion warp streaming PR.

Every tickle/pause/resume/cancel re-fetched the global TimerManager (a global IORef read), and every tickle did a real `updateTimeout` against the process-wide timer queue (warp tickles per request and per recv/send chunk). The `Handle` now caches the TimerManager at registration (stable for the process lifetime; per-Handle caching also keeps `TimeoutKey`s paired with their issuing manager), records the monotonic time of the last registration/update, and rate-limits tickle to one real update per min(1s, timeout/4). The common-case tickle is one VDSO clock read + one IORef read + compare, zero timer-queue traffic. The timeout/4 floor caps the precision loss at 25% of short timeouts.

Semantics: timeouts can fire up to min(1s, timeout/4) early relative to the last suppressed tickle (documented on `tickle`). Verified manually with `setTimeout 3`: idle, keep-alive-then-idle, and stalled-streaming connections all closed at ~3.01s. time-manager and warp test suites pass.

Measured together with the warp streaming PR on a keep-alive hello-world server: +45% throughput (35.7k → 51.9k req/s), `sendResponse` 1.58µs → 436ns, −3.5KB allocation/request. The largest single win in the series.

