### PR TITLE
warp: fewer timer operations around streaming response bodies

### DIFF
--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -257,6 +257,12 @@ sendRsp conn _ th ver s hs _ maxRspBufSize _ (RspBuilder body needsChunked) = do
 
 sendRsp conn _ th ver s hs _ _ _ (RspStream streamingBody needsChunked) = do
     header <- composeHeaderBuilder ver s hs needsChunked
+    -- Make sure the timeout is armed for the whole streaming section,
+    -- so that the per-fragment 'T.tickle' below has effect. Normally
+    -- the handle is already active (the respond callback resumed it),
+    -- making this a cheap no-op; it matters for streaming responses
+    -- sent from an exception handler, where the handle is still paused.
+    T.resume th
     (recv, finish) <-
         newByteStringBuilderRecv $
             reuseBufferStrategy $
@@ -408,14 +414,18 @@ sendRspFile404 conn ii th ver hs0 rspidxhdr maxRspBufSize method =
 -- | Use 'connSendAll' to send this data while respecting timeout rules.
 sendFragment :: Connection -> T.Handle -> ByteString -> IO ()
 sendFragment Connection{connSendAll = send} th bs = do
-    T.resume th
+    T.tickle th
     send bs
-    T.pause th
 
--- We pause timeouts before passing control back to user code. This ensures
--- that a timeout will only ever be executed when Warp is in control. We
--- also make sure to resume the timeout after the completion of user code
--- so that we can kill idle connections.
+-- The timeout stays armed during the whole streaming section (see the
+-- 'T.resume' in the RspStream case of 'sendRsp'); each fragment merely
+-- tickles it, which the rate limiter in time-manager makes nearly free.
+-- Compared to the previous resume/send/pause per fragment this keeps
+-- slowloris protection active while the fragment is being sent. The
+-- flip side is that user code producing the next fragment now runs with
+-- the timeout armed, so a streaming body that emits nothing for a full
+-- timeout period is killed, whereas it previously had the timeout
+-- paused between fragments.
 
 ----------------------------------------------------------------
 

--- a/warp/Network/Wai/Handler/Warp/Response.hs
+++ b/warp/Network/Wai/Handler/Warp/Response.hs
@@ -310,6 +310,12 @@ sendRsp conn _ th ver s hs rspidxhdr maxRspBufSize _ (RspBuilder body needsChunk
 
 sendRsp conn _ th ver s hs rspidxhdr _ _ (RspStream streamingBody needsChunked) = do
     (header, hdrLen) <- composeHeaderBuilder ver s hs rspidxhdr needsChunked
+    -- Make sure the timeout is armed for the whole streaming section,
+    -- so that the per-fragment 'T.tickle' below has effect. Normally
+    -- the handle is already active (the respond callback resumed it),
+    -- making this a cheap no-op; it matters for streaming responses
+    -- sent from an exception handler, where the handle is still paused.
+    T.resume th
     (recv, finish) <-
         newByteStringBuilderRecv $
             reuseBufferStrategy $
@@ -476,14 +482,18 @@ sendRspFile404 conn ii th ver hs0 rspidxhdr maxRspBufSize method =
 -- | Use 'connSendAll' to send this data while respecting timeout rules.
 sendFragment :: Connection -> T.Handle -> ByteString -> IO ()
 sendFragment Connection{connSendAll = send} th bs = do
-    T.resume th
+    T.tickle th
     send bs
-    T.pause th
 
--- We pause timeouts before passing control back to user code. This ensures
--- that a timeout will only ever be executed when Warp is in control. We
--- also make sure to resume the timeout after the completion of user code
--- so that we can kill idle connections.
+-- The timeout stays armed during the whole streaming section (see the
+-- 'T.resume' in the RspStream case of 'sendRsp'); each fragment merely
+-- tickles it, which the rate limiter in time-manager makes nearly free.
+-- Compared to the previous resume/send/pause per fragment this keeps
+-- slowloris protection active while the fragment is being sent. The
+-- flip side is that user code producing the next fragment now runs with
+-- the timeout armed, so a streaming body that emits nothing for a full
+-- timeout period is killed, whereas it previously had the timeout
+-- paused between fragments.
 
 ----------------------------------------------------------------
 

--- a/warp/bench/ResponseBench.hs
+++ b/warp/bench/ResponseBench.hs
@@ -7,6 +7,7 @@
 module Main (main) where
 
 import Control.Concurrent.STM (newTVarIO)
+import Control.Monad (replicateM_)
 import Criterion.Main
 import Data.ByteString.Builder (byteString)
 import Data.IORef (newIORef)
@@ -61,6 +62,7 @@ main = do
             , bench "builder 3 headers chunked" $ whnfIO $ send (rspB hdrs3NoCL)
             , bench "builder 20 headers content-length" $ whnfIO $ send (rspB hdrs20)
             , bench "no body 204" $ whnfIO $ send rsp204
+            , bench "stream 64 fragments" $ whnfIO $ send (rspS 64)
             ]
         , bgroup
             "headers"
@@ -74,6 +76,9 @@ main = do
   where
     body = byteString "Hello, World!"
     rspB hs = ResponseBuilder H.status200 hs body
+    -- One fragment per write/flush pair, the shape an SSE-style body has.
+    rspS n = ResponseStream H.status200 hdrs3NoCL $ \write flush ->
+        replicateM_ n (write body >> flush)
     rsp204 = ResponseBuilder H.status204 [] mempty
     reqHdrs =
         [ (H.hHost, "127.0.0.1:3011")


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs. Works standalone (halves per-fragment timer ops); compounds with the time-manager tickle rate-limiting PR, which makes the per-fragment tickle nearly free.

`sendFragment` wrapped every streamed fragment in `T.resume`/`T.pause`: two timer-queue operations per fragment. Streaming now resumes once before the body, tickles per fragment, and pauses once after.

Deliberate semantics change for maintainers to weigh: The timeout is armed while user code computes between fragments, so a `responseStream` that produces nothing for a full timeout period is killed, previously it could stall forever between fragments, since the timeout was only armed during warp's own sends. Streams writing at least once per timeout period (or sending heartbeats) are unaffected, and the sends themselves are now covered, closing a slowloris-shaped gap. Observable for e.g. SSE without heartbeats. Verified manually that a stalled stream closes at the configured timeout.