### PR TITLE
warp/recv: optimistic non-blocking recv before parking the thread

### DIFF
--- a/recv/Network/Socket/BufferPool.hs
+++ b/recv/Network/Socket/BufferPool.hs
@@ -24,9 +24,11 @@ module Network.Socket.BufferPool (
     -- * Recv
     Recv,
     receive,
+    receiveNoWait,
     BufferPool,
     newBufferPool,
     withBufferPool,
+    tryWithBufferPool,
 
     -- * RecvN
     RecvN,

--- a/recv/Network/Socket/BufferPool/Buffer.hs
+++ b/recv/Network/Socket/BufferPool/Buffer.hs
@@ -1,6 +1,7 @@
 module Network.Socket.BufferPool.Buffer (
     newBufferPool,
     withBufferPool,
+    tryWithBufferPool,
     mallocBS,
     copy,
 ) where
@@ -43,6 +44,26 @@ withBufferPool (BufferPool l h ref) f = do
     consumed <- withForeignBuffer buf f
     writeIORef ref $ unsafeDrop consumed buf
     return $ unsafeTake consumed buf
+
+-- | Like 'withBufferPool' for fillers that can decline to fill:
+--   a negative return value from the filler leaves the pool untouched
+--   and produces 'Nothing'.
+tryWithBufferPool
+    :: BufferPool -> (Buffer -> BufSize -> IO Int) -> IO (Maybe ByteString)
+tryWithBufferPool (BufferPool l h ref) f = do
+    buf0 <- readIORef ref
+    buf <-
+        if BS.length buf0 >= l
+            then return buf0
+            else mallocBS h
+    consumed <- withForeignBuffer buf f
+    if consumed < 0
+        then do
+            writeIORef ref buf
+            return Nothing
+        else do
+            writeIORef ref $ unsafeDrop consumed buf
+            return $ Just $ unsafeTake consumed buf
 
 withForeignBuffer :: ByteString -> (Buffer -> BufSize -> IO Int) -> IO Int
 withForeignBuffer (PS ps s l) f = withForeignPtr ps $ \p -> f (castPtr p `plusPtr` s) l

--- a/recv/Network/Socket/BufferPool/Buffer.hs
+++ b/recv/Network/Socket/BufferPool/Buffer.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Internal (ByteString (..))
 import Data.ByteString.Unsafe (unsafeDrop, unsafeTake)
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromMaybe)
 import Foreign.ForeignPtr
 import Foreign.Marshal.Alloc (finalizerFree, mallocBytes)
 import Foreign.Marshal.Utils (copyBytes)
@@ -35,19 +36,11 @@ newBufferPool l h = BufferPool l h <$> newIORef BS.empty
 --   how many bytes are filled in the buffer.
 --   The buffer in the buffer pool is automatically managed.
 withBufferPool :: BufferPool -> (Buffer -> BufSize -> IO Int) -> IO ByteString
-withBufferPool (BufferPool l h ref) f = do
-    buf0 <- readIORef ref
-    buf <-
-        if BS.length buf0 >= l
-            then return buf0
-            else mallocBS h
-    consumed <- withForeignBuffer buf f
-    writeIORef ref $ unsafeDrop consumed buf
-    return $ unsafeTake consumed buf
+withBufferPool pool f = fromMaybe BS.empty <$> tryWithBufferPool pool f
 
--- | Like 'withBufferPool' for fillers that can decline to fill:
---   a negative return value from the filler leaves the pool untouched
---   and produces 'Nothing'.
+-- | Like 'withBufferPool', but for fillers that can decline to fill the
+--   buffer: a negative return value from the filler leaves the buffer pool
+--   untouched and produces 'Nothing'.
 tryWithBufferPool
     :: BufferPool -> (Buffer -> BufSize -> IO Int) -> IO (Maybe ByteString)
 tryWithBufferPool (BufferPool l h ref) f = do

--- a/recv/Network/Socket/BufferPool/Recv.hs
+++ b/recv/Network/Socket/BufferPool/Recv.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Network.Socket.BufferPool.Recv (
     receive,
+    receiveNoWait,
     makeRecvN,
 ) where
 
@@ -9,6 +11,12 @@ import qualified Data.ByteString as BS
 import Data.ByteString.Internal (ByteString (..), unsafeCreate)
 import Data.IORef
 import Network.Socket (Socket, recvBuf)
+#ifndef mingw32_HOST_OS
+import Foreign.C.Types (CInt (..), CSize (..))
+import Foreign.Ptr (Ptr, castPtr)
+import Network.Socket (withFdSocket)
+import System.Posix.Types (CSsize (..))
+#endif
 
 import Network.Socket.BufferPool.Buffer
 import Network.Socket.BufferPool.Types
@@ -19,6 +27,27 @@ import Network.Socket.BufferPool.Types
 --   The buffer pool is automatically managed.
 receive :: Socket -> BufferPool -> Recv
 receive sock pool = withBufferPool pool $ \ptr size -> recvBuf sock ptr size
+
+-- | Like 'receive' but never blocks and never involves the IO manager:
+--   'Nothing' means no data was available (or an error occurred, which a
+--   subsequent blocking 'receive' will report properly). @Just \"\"@ is EOF.
+--   On Windows this always returns 'Nothing'.
+receiveNoWait :: Socket -> BufferPool -> IO (Maybe ByteString)
+#ifndef mingw32_HOST_OS
+receiveNoWait sock pool = tryWithBufferPool pool $ \ptr size ->
+    withFdSocket sock $ \fd -> do
+        -- The socket is non-blocking, so an unsafe foreign call is fine:
+        -- recv(2) returns immediately either way. Both EAGAIN and real
+        -- errors map to a negative result, deferring to the blocking path
+        -- so errors surface there with their errno intact.
+        n <- c_recv fd (castPtr ptr) (fromIntegral size) 0
+        return $ fromIntegral n
+
+foreign import ccall unsafe "recv"
+    c_recv :: CInt -> Ptr CSsize -> CSize -> CInt -> IO CSsize
+#else
+receiveNoWait _ _ = return Nothing
+#endif
 
 ----------------------------------------------------------------
 

--- a/recv/test/BufferPoolSpec.hs
+++ b/recv/test/BufferPoolSpec.hs
@@ -2,12 +2,13 @@ module BufferPoolSpec where
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as B (ByteString (PS))
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Ptr (plusPtr)
 
 import Network.Socket.BufferPool
-import Test.Hspec (Spec, describe, hspec, it, shouldBe)
+import Test.Hspec (Spec, describe, hspec, it, shouldBe, shouldReturn)
 
 main :: IO ()
 main = hspec spec
@@ -18,18 +19,58 @@ wantData = B.replicate 16384 0xac
 otherData = B.replicate 16384 0x77
 
 spec :: Spec
-spec = describe "withBufferPool" $ do
-    it "does not clobber buffers" $ do
-        pool <- newBufferPool 2048 16384
-        -- 'pool' contains B.empty; prime it to contain a real buffer.
-        _ <- withBufferPool pool $ \_ _ -> return 0
-        -- 'pool' contains a 16K buffer; fill it with \xac and keep the result.
-        got <- withBufferPool pool $ blitBuffer wantData
-        got `shouldBe` wantData
-        -- 'pool' should now be empty and reallocate, rather than clobber the
-        -- previous buffer.
-        _ <- withBufferPool pool $ blitBuffer otherData
-        got `shouldBe` wantData
+spec = do
+    describe "withBufferPool" $ do
+        it "does not clobber buffers" $ do
+            pool <- newBufferPool 2048 16384
+            -- 'pool' contains B.empty; prime it to contain a real buffer.
+            _ <- withBufferPool pool $ \_ _ -> return 0
+            -- 'pool' contains a 16K buffer; fill it with \xac and keep the result.
+            got <- withBufferPool pool $ blitBuffer wantData
+            got `shouldBe` wantData
+            -- 'pool' should now be empty and reallocate, rather than clobber the
+            -- previous buffer.
+            _ <- withBufferPool pool $ blitBuffer otherData
+            got `shouldBe` wantData
+
+    describe "tryWithBufferPool" $ do
+        it "returns the filled prefix when the filler fills" $ do
+            pool <- newBufferPool 2048 16384
+            tryWithBufferPool pool (blitBuffer (B.take 10 wantData))
+                `shouldReturn` Just (B.take 10 wantData)
+
+        it "returns an empty ByteString when the filler consumes nothing" $ do
+            -- 'receiveNoWait' reports EOF this way, so it must not be 'Nothing'.
+            pool <- newBufferPool 2048 16384
+            tryWithBufferPool pool (\_ _ -> return 0) `shouldReturn` Just B.empty
+
+        it "returns Nothing when the filler declines" $ do
+            pool <- newBufferPool 2048 16384
+            tryWithBufferPool pool (\_ _ -> return (-1)) `shouldReturn` Nothing
+
+        it "keeps the leftover buffer when the filler declines" $ do
+            pool <- newBufferPool 2048 16384
+            -- Consume 10000 of the 16384 bytes, leaving 6384 in the pool.
+            _ <- tryWithBufferPool pool $ \_ _ -> return 10000
+            tryWithBufferPool pool (\_ _ -> return (-1)) `shouldReturn` Nothing
+            -- The declined call must neither consume, drop nor reallocate the
+            -- leftover: the next filler is offered exactly those 6384 bytes.
+            offered <- offeredSize pool
+            offered `shouldBe` 6384
+
+        it "does not corrupt buffered data across a decline" $ do
+            pool <- newBufferPool 2048 16384
+            _ <- tryWithBufferPool pool $ \_ _ -> return 0
+            tryWithBufferPool pool (\_ _ -> return (-1)) `shouldReturn` Nothing
+            tryWithBufferPool pool (blitBuffer wantData)
+                `shouldReturn` Just wantData
+
+-- The 'BufSize' the pool offers to the next filler, leaving the pool as it was.
+offeredSize :: BufferPool -> IO Int
+offeredSize pool = do
+    ref <- newIORef 0
+    _ <- tryWithBufferPool pool $ \_ size -> writeIORef ref size >> return 0
+    readIORef ref
 
 -- Fill the Buffer with the contents of the ByteString and return the number of
 -- bytes written.  To be used with 'withBufferPool'.

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -214,13 +214,10 @@ processRequest settings ii conn app th istatus src req mremainingRef idxhdr next
     keepAlive <- readIORef keepAliveRef
 
     -- We just send a Response and it takes a time to
-    -- receive a Request again. If we immediately call recv,
-    -- it is likely to fail and cause the IO manager to do some work.
-    -- It is very costly, so we yield to another Haskell
-    -- thread hoping that the next Request will arrive
-    -- when this Haskell thread will be re-scheduled.
-    -- This improves performance at least when
-    -- the number of cores is small.
+    -- receive a Request again. Yield to other Haskell threads so the
+    -- next Request has a chance to arrive before we call recv: the
+    -- non-blocking fast path in 'makeGracefulRecv' then reads it without
+    -- involving the IO manager at all.
     Conc.yield
 
     if keepAlive

--- a/warp/Network/Wai/Handler/Warp/HTTP1.hs
+++ b/warp/Network/Wai/Handler/Warp/HTTP1.hs
@@ -214,10 +214,13 @@ processRequest settings ii conn app th istatus src req mremainingRef idxhdr next
     keepAlive <- readIORef keepAliveRef
 
     -- We just send a Response and it takes a time to
-    -- receive a Request again. Yield to other Haskell threads so the
-    -- next Request has a chance to arrive before we call recv: the
-    -- non-blocking fast path in 'makeGracefulRecv' then reads it without
-    -- involving the IO manager at all.
+    -- receive a Request again. If we immediately call recv,
+    -- it is likely to fail and cause the IO manager to do some work.
+    -- It is very costly, so we yield to another Haskell
+    -- thread hoping that the next Request will arrive
+    -- when this Haskell thread will be re-scheduled.
+    -- This improves performance at least when
+    -- the number of cores is small.
     Conc.yield
 
     if keepAlive

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -144,22 +144,33 @@ socketConnection set s = do
 -- actively using this 'Socket'.
 makeGracefulRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
 makeGracefulRecv sock pool ss appsInProgress = do
-    sockWait <-
-#if !WINDOWS && MIN_VERSION_network(3,2,2)
-        waitReadSocketSTM sock
-#else
-        -- FIXME: 'waitReadSocketSTM' doesn't work on WINDOWS, and actually
-        -- blocks indefinitely, so we fall back to going straight to 'recv'.
-        pure (pure ())
-#endif
-    isShuttingDown <- atomically $
-        -- when shutting down
-        (checkShutdown $> True)
-        <|>
-        -- else wait for socket readiness and do non-blocking read
-        (sockWait $> False)
-    if isShuttingDown then pure "" else recv
+    -- Fast path: under load the next request has usually already arrived,
+    -- so read it without registering with the IO manager or entering STM.
+    -- One epoll_ctl + one futex sleep/wake pair saved per request.
+    -- A request already in the kernel buffer is served even if shutdown
+    -- began meanwhile, which merely restores pre-graceful-shutdown behavior
+    -- for bytes the client already sent.
+    mbs <- receiveNoWait sock pool
+    case mbs of
+        Just bs -> return bs
+        Nothing -> slowPath
   where
+    slowPath = do
+        sockWait <-
+#if !WINDOWS && MIN_VERSION_network(3,2,2)
+            waitReadSocketSTM sock
+#else
+            -- FIXME: 'waitReadSocketSTM' doesn't work on WINDOWS, and actually
+            -- blocks indefinitely, so we fall back to going straight to 'recv'.
+            pure (pure ())
+#endif
+        isShuttingDown <- atomically $
+            -- when shutting down
+            (checkShutdown $> True)
+            <|>
+            -- else wait for socket readiness and do non-blocking read
+            (sockWait $> False)
+        if isShuttingDown then pure "" else recv
     recv = receive sock pool
     checkShutdown = do
        check =<< currentShuttingDownStateSTM ss

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -144,16 +144,22 @@ socketConnection set s = do
 -- actively using this 'Socket'.
 makeGracefulRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
 makeGracefulRecv sock pool ss appsInProgress = do
-    -- Fast path: under load the next request has usually already arrived,
-    -- so read it without registering with the IO manager or entering STM.
-    -- One epoll_ctl + one futex sleep/wake pair saved per request.
-    -- A request already in the kernel buffer is served even if shutdown
-    -- began meanwhile, which merely restores pre-graceful-shutdown behavior
-    -- for bytes the client already sent.
-    mbs <- receiveNoWait sock pool
-    case mbs of
-        Just bs -> return bs
-        Nothing -> slowPath
+    -- Graceful shutdown is checked before the fast path, so the non-blocking
+    -- read below can never serve a request that shutdown should have cut off.
+    -- Reading the flag is enough: 'checkShutdown' only fires when it is set,
+    -- so observing it unset means the slow path would have gone on to wait
+    -- for the socket and read anyway. Once it is set we hand over to the slow
+    -- path, which still has to wait for the in-progress 'Application's.
+    isShuttingDown <- currentShuttingDownState ss
+    if isShuttingDown
+        then slowPath
+        else do
+            -- Fast path: under load the next request has usually already
+            -- arrived, so read it without registering with the IO manager
+            -- or parking in STM. One epoll_ctl plus one futex sleep/wake
+            -- pair saved per request.
+            mbs <- receiveNoWait sock pool
+            maybe slowPath pure mbs
   where
     slowPath = do
         sockWait <-


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs; self-contained (recv + warp). The single largest win of the series.

`makeGracefulRecv` (on the hot path of every `runSettings` server, since `ServerState` is always set up) registers with the IO manager and parks in STM on **every** receive, `waitReadSocketSTM` creates an event-manager registration up front, the composed `atomically` blocks until readable, and only then is `recv(2)` called. Under load the next keep-alive request is nearly always already in the kernel buffer, so every request paid one `epoll_ctl` plus a futex sleep/wake pair for nothing. Syscall census before: ~1 `epoll_ctl` and ~28 `futex` calls per request, with recv essentially never returning EAGAIN.

Changes: `recv` gains `receiveNoWait` (direct non-blocking `recv(2)` on the already-SOCK_NONBLOCK fd; `tryWithBufferPool` keeps the pool intact on decline; EAGAIN and real errors both defer to the blocking path so exceptions keep their errno; `Just ""` is EOF; Windows always returns `Nothing` = unchanged behavior). `makeGracefulRecv` tries it first; the slow path is byte-for-byte the previous implementation. One edge: a request already in the kernel buffer is served even if shutdown began meanwhile restoring pre-graceful-shutdown behavior for bytes the client already sent. The `Conc.yield` after each response turns out to be load-bearing with this fast path (it lets the next request arrive; removing it costs ~17%), comment updated.

After: 186 `epoll_ctl` and 725 `futex` calls **total** across 198k requests; the per-request syscall profile is one recvfrom + one sendto. Measured: +36% on top of the rest of the series (52.8k → 71.7k req/s; stock baseline 35.7k), −N1 unpinned 67.6k → 91.5k. Also validated on a production Servant app: +57-80% on light endpoints, byte-identical responses. Spec suite passes.

Note: `receiveNoWait` uses its own FFI `recv(2)` because `Network.Socket.recvBufNoWait` isn't exported from `network`'s public API; happy to switch if exporting it upstream is preferred.