### PR TITLE
warp: track in-flight apps with an IORef instead of STM (optional)

### DIFF
--- a/warp-tls/Network/Wai/Handler/WarpTLS.hs
+++ b/warp-tls/Network/Wai/Handler/WarpTLS.hs
@@ -58,9 +58,6 @@ module Network.Wai.Handler.WarpTLS (
 ) where
 
 import Control.Applicative ((<|>))
-#if MIN_VERSION_warp(3,4,13)
-import Control.Concurrent.STM (newTVarIO, TVar)
-#endif
 import Control.Exception (
     Exception,
     IOException,
@@ -390,7 +387,7 @@ httpOverTls TLSSettings{..} set s bs0 params =
     makeConn = do
         pool <- newBufferPool 2048 16384
 #if MIN_VERSION_warp(3,4,13)
-        appsInProgress <- newTVarIO 0
+        appsInProgress <- I.newIORef 0
         (ss, _) <- makeServerState set
         let recv = makeGracefulRecv s pool ss appsInProgress
 #else
@@ -441,7 +438,7 @@ attachConn
     :: SockAddr
     -> TLS.Context
 #if MIN_VERSION_warp(3,4,13)
-    -> TVar Int -> IO (Connection, Transport)
+    -> I.IORef Int -> IO (Connection, Transport)
 attachConn mysa ctx appsInProgress = do
 #else
     -> IO (Connection, Transport)

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -11,17 +11,13 @@ module Network.Wai.Handler.Warp.Run where
 
 import Control.Arrow (first)
 import Control.Concurrent.STM (
-    TVar,
     atomically,
     check,
-    modifyTVar',
-    newTVarIO,
-    readTVar,
  )
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.Functor (($>))
-import Data.IORef (newIORef, readIORef, IORef, writeIORef)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef, IORef, writeIORef)
 import Data.Streaming.Network (bindPortTCP)
 import Foreign.C.Error (Errno (..), eCONNABORTED, eMFILE)
 import GHC.Conc.Sync (labelThread, myThreadId)
@@ -78,7 +74,7 @@ socketConnection set s = do
     writeBufferRef <- newIORef writeBuffer
     isH2 <- newIORef False -- HTTP/1.x
     mysa <- getSocketName s
-    appsInProgress <- newTVarIO 0
+    appsInProgress <- newIORef 0
     return
         Connection
             { connSendMany = Sock.sendMany s
@@ -142,7 +138,7 @@ socketConnection set s = do
 -- it non-blocking with 'waitReadSocketSTM' /AND/ cut off receiving any bytes
 -- when the server is shutting down and there are no more 'Application's
 -- actively using this 'Socket'.
-makeGracefulRecv :: Socket -> BufferPool -> ServerState -> TVar Int -> Recv
+makeGracefulRecv :: Socket -> BufferPool -> ServerState -> IORef Int -> Recv
 makeGracefulRecv sock pool ss appsInProgress = do
     sockWait <-
 #if !WINDOWS && MIN_VERSION_network(3,2,2)
@@ -158,12 +154,25 @@ makeGracefulRecv sock pool ss appsInProgress = do
         <|>
         -- else wait for socket readiness and do non-blocking read
         (sockWait $> False)
-    if isShuttingDown then pure "" else recv
+    if isShuttingDown then drain sockWait else recv
   where
     recv = receive sock pool
-    checkShutdown = do
-       check =<< currentShuttingDownStateSTM ss
-       check . (<= 0) =<< readTVar appsInProgress
+    checkShutdown = check =<< currentShuttingDownStateSTM ss
+    -- Shutting down: cut off this connection once no 'Application' is using
+    -- it any more, but keep feeding data to the ones still in progress
+    -- (HTTP/2 can run several concurrent streams). The counter is a plain
+    -- 'IORef' incremented with 'atomicModifyIORef'', so it cannot take part
+    -- in the STM wait above; instead it is polled here. Graceful shutdown is
+    -- not latency sensitive, and the 'timeout' sleeps between polls, so this
+    -- is not a busy wait.
+    drain sockWait = do
+        inProgress <- readIORef appsInProgress
+        if inProgress <= 0
+            then pure ""
+            else do
+                ready <- timeout pollInterval $ atomically sockWait
+                maybe (drain sockWait) (const recv) ready
+    pollInterval = 20000 -- microseconds
 
 -- | Run an 'Application' on the given port.
 -- This calls 'runSettings' with 'defaultSettings'.
@@ -468,8 +477,8 @@ serveConnection conn ii th origAddr transport settings app = do
     let appsInProgress = connAppsInProgress conn
         app' req rsp =
             E.bracket_
-                (atomically $ modifyTVar' appsInProgress $ (+ 1))
-                (atomically $ modifyTVar' appsInProgress $ \i -> (i - 1))
+                (atomicModifyIORef' appsInProgress $ \i -> (i + 1, ()))
+                (atomicModifyIORef' appsInProgress $ \i -> (i - 1, ()))
                 $ app req rsp
     if settingsHTTP2Enabled settings && h2
         then do

--- a/warp/Network/Wai/Handler/Warp/Types.hs
+++ b/warp/Network/Wai/Handler/Warp/Types.hs
@@ -3,7 +3,6 @@
 
 module Network.Wai.Handler.Warp.Types where
 
-import Control.Concurrent.STM (TVar)
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -129,7 +128,7 @@ data Connection = Connection
     , connHTTP2 :: IORef Bool
     -- ^ Is this connection HTTP/2?
     , connMySockAddr :: SockAddr
-    , connAppsInProgress :: TVar Int
+    , connAppsInProgress :: IORef Int
     -- ^ Amount of apps currently in progress on this connection.
     --
     -- /HTTP2 can handle more than one request concurrently/


### PR DESCRIPTION
Part of a series splitting #1090 into independently reviewable PRs. **Offered as optional** — measured performance-neutral on its own; take it or leave it.

Every request pays two STM transactions to bump the graceful-shutdown in-flight counter, even when no shutdown ever happens. This makes `connAppsInProgress` an `IORef Int` (atomicModifyIORef', exact); the shutdown-side wait polls at 20ms (sleeping inside `timeout` around the socket-readiness STM wait, no busy loop) while still feeding in-progress streams. Not-shutting-down path unchanged; warp-tls updated in lockstep.

Honest numbers: no measurable throughput or allocation change on a keep-alive hello-world load test — the value is a simpler hot path, at the cost of an `Internal` API change (`TVar Int` → `IORef Int` on `Connection.connAppsInProgress` and `makeGracefulRecv`). If the API churn isn't worth it, closing this PR affects nothing else in the series.

Interaction note: if the benchmark PR merges first, this needs a one-line rebase in the bench's `Connection` construction. GracefulShutdown spec passes; full spec suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HBrMGfWRxTpYeEB4UT8Kf
