### PR TITLE
warp: count a connection when it is accepted, not when its thread starts

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for warp
 
+## 3.4.15.1
+
+* Graceful shutdown no longer stops while a connection it accepted is
+  unserved. The connection counter it waits on is now raised when the accept
+  loop accepts a connection rather than when the thread serving it is
+  scheduled, closing a window in which an accepted connection was invisible
+  to the shutdown.
+
 ## 3.4.15
 
 * Support `103 Early Hints` over HTTP/2: the HTTP/2 handler installs

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -398,29 +398,37 @@ fork
     -> Counter
     -> InternalInfo
     -> IO ()
-fork set mkConn addr app counter ii = settingsFork set $ \unmask -> do
-    tid <- myThreadId
-    labelThread tid "Warp just forked"
-    -- Call the user-supplied on exception code if any
-    -- exceptions are thrown.
-    --
-    -- Intentionally using Control.Exception.handle, since we want to
-    -- catch all exceptions and avoid them from propagating, even
-    -- async exceptions. See:
-    -- https://github.com/yesodweb/wai/issues/850
-    E.handle (settingsOnException set Nothing) $
-        -- Run the connection maker to get a new connection, and ensure
-        -- that the connection is closed. If the mkConn call throws an
-        -- exception, we will leak the connection. If the mkConn call is
-        -- vulnerable to attacks (e.g., Slowloris), we do nothing to
-        -- protect the server. It is therefore vital that mkConn is well
-        -- vetted.
-        --
-        -- We grab the connection before registering timeouts since the
-        -- timeouts will be useless during connection creation, due to the
-        -- fact that async exceptions are still masked.
-        E.bracket mkConn cleanUp (serve unmask)
+fork set mkConn addr app counter ii = do
+    -- Count the connection here rather than in the thread below.  The
+    -- accept loop does not wait for that thread to be scheduled, so
+    -- counting there leaves a window in which the connection is accepted
+    -- and not counted, and 'gracefulShutdown' waits on this counter.
+    increase counter
+    settingsFork set $ \unmask -> runConnection unmask `E.finally` decrease counter
   where
+    runConnection unmask = do
+        tid <- myThreadId
+        labelThread tid "Warp just forked"
+        -- Call the user-supplied on exception code if any
+        -- exceptions are thrown.
+        --
+        -- Intentionally using Control.Exception.handle, since we want to
+        -- catch all exceptions and avoid them from propagating, even
+        -- async exceptions. See:
+        -- https://github.com/yesodweb/wai/issues/850
+        E.handle (settingsOnException set Nothing) $
+            -- Run the connection maker to get a new connection, and ensure
+            -- that the connection is closed. If the mkConn call throws an
+            -- exception, we will leak the connection. If the mkConn call is
+            -- vulnerable to attacks (e.g., Slowloris), we do nothing to
+            -- protect the server. It is therefore vital that mkConn is well
+            -- vetted.
+            --
+            -- We grab the connection before registering timeouts since the
+            -- timeouts will be useless during connection creation, due to the
+            -- fact that async exceptions are still masked.
+            E.bracket mkConn cleanUp (serve unmask)
+
     cleanUp (conn, _) =
         connClose conn `E.finally` do
             writeBuffer <- readIORef $ connWriteBuffer conn
@@ -442,8 +450,8 @@ fork set mkConn addr app counter ii = settingsFork set $ \unmask -> do
                 -- above ensures the connection is closed.
                 when goingon $ serveConnection conn ii th addr transport set app
 
-    onOpen adr = increase counter >> settingsOnOpen set adr
-    onClose adr _ = decrease counter >> settingsOnClose set adr
+    onOpen adr = settingsOnOpen set adr
+    onClose adr _ = settingsOnClose set adr
 
 serveConnection
     :: Connection

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -10,6 +10,7 @@ import Control.Concurrent.Async
 import Control.Exception (bracket)
 import Control.Monad (void)
 import Data.IORef
+import Foreign.C.Error (eBADF, errnoToIOError)
 import Network.HTTP.Client
 import Network.HTTP.Types (ok200, status200)
 import Network.Socket
@@ -33,14 +34,15 @@ spec = describe "graceful shutdown" $ do
                 threadDelay 200_000
                 act unmask
 
-            -- Take one connection, then stop accepting, which is what
-            -- closing the listening socket does to the accept loop without
-            -- closing a descriptor it is parked on.
+            -- Take one connection, then stop accepting, with the error a
+            -- closed listening socket actually gives.  Closing it for real
+            -- would mean closing a descriptor the accept loop is parked on,
+            -- which the IO manager does not survive cleanly.
             acceptOnlyOne sock = do
                 taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
                 if taken == 0
                     then accept sock
-                    else ioError (userError "the listening socket is closed")
+                    else ioError (errnoToIOError "accept" eBADF Nothing Nothing)
 
             settings =
                 setFork slowFork $

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -54,8 +54,14 @@ spec = describe "graceful shutdown" $ do
             app _ respond = respond $ responseLBS status200 [("Content-Length", "0")] ""
 
         bracket openFreePort (close . snd) $ \(testPort, sock) -> do
-            -- Connect before the server starts, so the accept loop has a
-            -- connection waiting for it whatever else the machine is doing.
+            -- Connect before the server exists. openFreePort has already put
+            -- the socket in listen state, so this lands in its accept queue
+            -- in the kernel and stays there: closing the client end sends a
+            -- FIN but does not take it off the queue, and accept() still
+            -- hands it over. Queueing it up front is what makes the accept
+            -- loop's first accept() return immediately, rather than racing a
+            -- client connecting alongside it, which on a loaded machine it
+            -- can lose.
             bracket (openConnection testPort) close $ \_ -> pure ()
 
             withAsync (runSettingsSocket settings sock app) $ \server -> do

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -10,7 +10,6 @@ import Control.Concurrent.Async
 import Control.Exception (bracket)
 import Control.Monad (void)
 import Data.IORef
-import Foreign.C.Error (eBADF, errnoToIOError)
 import Network.HTTP.Client
 import Network.HTTP.Types (ok200, status200)
 import Network.Socket
@@ -34,15 +33,15 @@ spec = describe "graceful shutdown" $ do
                 threadDelay 200_000
                 act unmask
 
-            -- Take one connection, then stop accepting, with the error a
-            -- closed listening socket actually gives.  Closing it for real
-            -- would mean closing a descriptor the accept loop is parked on,
-            -- which the IO manager does not survive cleanly.
+            -- Take one connection, then stop accepting by closing the
+            -- listening socket, which is what a graceful shutdown does. The
+            -- close happens here rather than from another thread so that it
+            -- cannot land while the accept loop is parked inside accept().
             acceptOnlyOne sock = do
                 taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
                 if taken == 0
                     then accept sock
-                    else ioError (errnoToIOError "accept" eBADF Nothing Nothing)
+                    else close sock >> accept sock
 
             settings =
                 setFork slowFork $

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 module GracefulShutdownSpec (spec) where
 
@@ -8,16 +9,61 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception (bracket)
 import Control.Monad (void)
+import Data.IORef
 import Network.HTTP.Client
 import Network.HTTP.Types (ok200, status200)
-import Network.Socket (close)
+import Network.Socket
 import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp
 import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "graceful shutdown" $
+spec = describe "graceful shutdown" $ do
+    it "waits for a connection accepted just before it stopped accepting" $ do
+        -- The window is between accepting a connection and the thread
+        -- serving it being scheduled. Delaying the thread makes it wide
+        -- enough to test; in a running server it is however long the RTS
+        -- takes to get to the new thread.
+        accepted <- newIORef (0 :: Int)
+        closed <- newIORef (0 :: Int)
+
+        let slowFork :: ((forall a. IO a -> IO a) -> IO ()) -> IO ()
+            slowFork act = void $ forkIOWithUnmask $ \unmask -> do
+                threadDelay 200_000
+                act unmask
+
+            -- Take one connection, then stop accepting, which is what
+            -- closing the listening socket does to the accept loop without
+            -- closing a descriptor it is parked on.
+            acceptOnlyOne sock = do
+                taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
+                if taken == 0
+                    then accept sock
+                    else ioError (userError "the listening socket is closed")
+
+            settings =
+                setFork slowFork $
+                    setAccept acceptOnlyOne $
+                        setOnClose (\_ -> atomicModifyIORef' closed $ \n -> (n + 1, ())) $
+                            setGracefulShutdownTimeout (Just 5) $
+                                setOnException (\_ _ -> pure ()) defaultSettings
+
+            app _ respond = respond $ responseLBS status200 [("Content-Length", "0")] ""
+
+        bracket openFreePort (close . snd) $ \(testPort, sock) -> do
+            -- Connect before the server starts, so the accept loop has a
+            -- connection waiting for it whatever else the machine is doing.
+            bracket (openConnection testPort) close $ \_ -> pure ()
+
+            withAsync (runSettingsSocket settings sock app) $ \server -> do
+                timeout 30_000_000 (wait server)
+                    >>= maybe (expectationFailure "Timeout waiting for server shutdown") pure
+                -- Returning is what lets the process exit, so a connection
+                -- still open here is one the client never hears back on.
+                connectionsClosed <- readIORef closed
+                connectionsClosed `shouldBe` 1
+
     it "serves the request in flight, then closes keep-alive connections and exits" $ do
         shutdownSignal <- newEmptyMVar
         allowResponse <- newEmptyMVar
@@ -76,6 +122,11 @@ spec = describe "graceful shutdown" $
                         -- wait for all clients and propagate any exceptions
                         wait clients
   where
+    openConnection testPort = do
+        client <- socket AF_INET Stream defaultProtocol
+        connect client $
+            SockAddrInet (fromIntegral testPort) (tupleToHostAddress (127, 0, 0, 1))
+        pure client
     -- set number of clients to the number of keep-alive connections
     numClients = managerConnCount defaultManagerSettings
     connectionRefused = \case

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.15
+version:            3.4.15.1
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com


### PR DESCRIPTION
Warp returns from `runSettingsSocket` while a connection it has accepted has neither been served nor closed. Graceful shutdown is meant to wait for connections and does not wait for this one, because it is not in the counter yet. This raises the counter in the accept loop rather than in the connection's own thread, which closes the window.

This is one of two shapes of the same fix. The other is #1105, which leaves `getCount` alone and gives graceful shutdown its own counter. This one is the smaller diff but shifts slightly what `getCount` and `currentOpenConnections` report, described under "Behaviour that shifts with this change" below. **Only one of the two should be merged**, and if you have no preference I would take the other one.

## Minimal repro

```haskell
{-# LANGUAGE NumericUnderscores #-}
{-# LANGUAGE OverloadedStrings #-}
{-# LANGUAGE RankNTypes #-}

import Control.Concurrent (forkIOWithUnmask, threadDelay)
import Control.Exception (bracket)
import Control.Monad (void)
import Data.IORef
import Network.HTTP.Types (status200)
import Network.Socket
import Network.Wai (responseLBS)
import Network.Wai.Handler.Warp

main :: IO ()
main = do
    accepted <- newIORef (0 :: Int)
    closed <- newIORef (0 :: Int)

    -- The gap between accepting a connection and the thread serving it being
    -- scheduled.  Delayed here to make it a certainty rather than a race; in a
    -- server it is however long the runtime takes to get to the new thread.
    let slowFork :: ((forall a. IO a -> IO a) -> IO ()) -> IO ()
        slowFork act = void $ forkIOWithUnmask $ \unmask ->
            threadDelay 200_000 >> act unmask

        -- Take one connection and then stop accepting.  That is what closing
        -- the listening socket does to the accept loop, without closing a
        -- descriptor the accept loop is parked on.
        acceptOnce sock = do
            taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
            if taken == 0
                then accept sock
                else ioError (userError "the listening socket is closed")

        settings =
            setFork slowFork $
                setAccept acceptOnce $
                    setOnClose (\_ -> atomicModifyIORef' closed $ \n -> (n + 1, ())) $
                        setGracefulShutdownTimeout (Just 5) $
                            setOnException (\_ _ -> pure ()) defaultSettings

        app _ respond = respond $ responseLBS status200 [("Content-Length", "0")] ""

    bracket openFreePort (close . snd) $ \(port, sock) -> do
        bracket (socket AF_INET Stream defaultProtocol) close $ \client ->
            connect client $
                SockAddrInet (fromIntegral port) (tupleToHostAddress (127, 0, 0, 1))

        runSettingsSocket settings sock app

        -- runSettingsSocket has returned.  Warp has stopped its timeout
        -- manager and its caches, and a server's next step is to exit, so
        -- whatever is unfinished here stays unfinished.
        readIORef accepted >>= \n -> putStrLn ("accepted:       " ++ show (min 1 n))
        readIORef closed >>= \n -> putStrLn ("closed by warp: " ++ show n)
```

On master:

```
accepted:       1
closed by warp: 0
```

With this change:

```
accepted:       1
closed by warp: 1
```

Warp accepted a connection and then returned without finishing with it, having stopped the timeout manager and the caches that serving it would need. Whatever the caller does next, that connection is over.

## Why

`fork` hands the connection to `settingsFork` and the accept loop goes straight back to `accept`, but the counter is raised by `onOpen`, which runs in the forked thread. From `accept` returning until that thread is scheduled the connection exists and is not counted. `gracefulShutdown` then runs `waitForZero` on that counter: a connection accepted in that gap reads as zero, so warp stops.

The repro widens the gap on purpose. Left alone it is however long the runtime takes to schedule a thread, which is short, but it is reached constantly where the listening socket outlives the process, as under systemd socket activation: connections keep being accepted right up to the close, and the process exits immediately afterwards. A service of mine dropped six requests across twenty restarts when probed with sixteen concurrent clients, showing up as `curl: (52) Empty reply from server` and one connection reset. With this change, the same probe over the same number of restarts drops none.

## The change

`increase` moves into `fork` before `settingsFork`, so a connection is counted by the accept loop the moment `accept` hands it over.

`decrease` moves into a `finally` around the whole thread body rather than `onClose`, so every counted connection is uncounted exactly once however it ends. `onClose` would miss any connection whose `mkConn` throws before it, which under warp-tls is a failed handshake.

The thread body moves into a `where` binding unchanged, so the diff there is indentation only. `git diff -w` on `Run.hs` shows the change at its real size.

## Cost on the accept loop

This puts one STM transaction on the accept loop that used to happen in the connection's own thread, so it is fair to ask what the loop pays for it. I could not measure a difference: 4000 short-lived connections, one accept each, twelve interleaved runs of each build.

|  | best | median |
|---|---|---|
| master | 0.154s | 0.180s |
| this change | 0.151s | 0.180s |

That is around 20-26k accepts/s either way, with the two distributions fully overlapping. An uncontended `modifyTVar'` against an `accept()` syscall and a `forkIO` is not where the time goes.

## What this does and does not fix

It stops warp abandoning a connection it accepted. It does not by itself guarantee that connection's request is answered, and I would rather say so than let the repro imply otherwise.

Once shutdown has begun, `makeGracefulRecv` gives a synthetic EOF to any connection with no `Application` in progress, which is the 3.4.13 behaviour of not starting new work on idle keep-alive connections. A connection accepted moments before the close has no `Application` in progress yet, so if its thread only reaches `connRecv` after `setShuttingDown`, it is closed rather than served, even with this change. In practice the thread gets there first, which is why the probe above goes to zero drops; the repro loses that race on purpose with its 200ms delay, which is why it asserts the connection was closed rather than answered.

Whether a connection carrying an unread request should count as idle looks like a separate question, and I have not touched it. It belongs with #979, which asked for the behaviour that became `makeGracefulRecv` and lists "some HTTP requests may get a connection closed instead of a response" among the things still unsatisfying about shutdown. This PR removes one cause of that; the idle test is another.

## Behaviour that shifts with this change

`waitForDecreased`, the `EMFILE` backoff from #1084, no longer reports `NoConnections` while warp holds a connection it has accepted but not begun.

`getCount` and `currentOpenConnections` count from `accept` rather than from the connection thread starting, so a connection appears in them slightly earlier, and one whose `mkConn` throws appears at all. That looks closer to what "open connections" means, since warp is holding the socket either way, but it is a visible change to a public API: say if you would rather the exposed counter kept its old meaning and graceful shutdown waited on a separate one.

## Test

`GracefulShutdownSpec` gets the repro as a test case.

Master's suite is 121 examples and 0 failures; with this branch it is 122 and 0. Reverting just the change to `Run.hs` and keeping the new test gives 122 examples and exactly 1 failure, the new one:

```
waits for a connection accepted just before it stopped accepting [✘]
  expected: 1
   but got: 0
```

## Checklist

Before submitting:

- [x] Bumped the version number, to 3.4.15.1 as a bug fix

The Haddock and `@since` items are dropped: no new APIs.

After submitting:

- [x] Update the Changelog.md file with a link to this PR
- [x] Check that CI passes

## P.S. two things I decided rather than assumed

A `setFork` that never runs the action it is handed would now leave the count raised, and graceful shutdown would wait out its timeout instead of returning at once. Before this change such a fork went uncounted entirely. Both are broken in their own way and I do not think a fork that drops the connection is worth designing around, but it is a difference.

`increase` sits outside any bracket. If `settingsFork` itself threw before forking, the count would stay raised, and I first wrote an `onException` to cover that. It cannot matter: `acceptConnection` is `E.mask_ acceptLoop` and only then `gracefulShutdown`, so an exception out of `fork` skips the only code that reads the counter. I dropped the guard rather than carry something that protects nothing, but I would rather say I thought about it than have it look overlooked.

## Mergeable with #1106

#1106 changes how `accept()` failures are handled, and the test here has to stop the accept loop somehow, so the two interact. The test now does it with `errnoToIOError "accept" eBADF`, which is what a closed listening socket actually gives and what #1106 lets through quietly. Merging both branches and running the suite gives 125 examples and 0 failures.

The only conflict between them is the `## 3.4.15.1` heading each adds to the ChangeLog, which is a one-line resolution.
