### PR TITLE
warp: wait for accepted connections without changing what getCount counts

### DIFF
--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for warp
 
+## 3.4.15.1
+
+* Graceful shutdown no longer stops while a connection warp has accepted is
+  still unfinished. It now waits on a count raised when the accept loop
+  accepts a connection, rather than on the connection count reported by
+  `getCount`, which is raised later, when the thread serving the connection
+  is scheduled.
+
 ## 3.4.15
 
 * Support `103 Early Hints` over HTTP/2: the HTTP/2 handler installs

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -266,9 +266,14 @@ runSettingsConnectionMakerSecure
 runSettingsConnectionMakerSecure oldSettings getConnMaker app = do
     settingsBeforeMainLoop oldSettings
     (ServerState{serverConnectionCounter}, newSettings) <- makeServerState oldSettings
+    -- Connections warp is holding, raised when accept hands one over rather
+    -- than when the thread serving it is scheduled.  Kept apart from
+    -- serverConnectionCounter, which is exposed as getCount and keeps its
+    -- meaning of connections that have been opened.
+    acceptedCounter <- newCounter
     withII newSettings $ \ii ->
         initFdExhaustionRef >>=
-            acceptConnection newSettings getConnMaker app serverConnectionCounter ii
+            acceptConnection newSettings getConnMaker app serverConnectionCounter acceptedCounter ii
 
 -- | Running an action with internal info.
 --
@@ -311,13 +316,17 @@ acceptConnection
     -> IO (IO (Connection, Transport), SockAddr)
     -> Application
     -> Counter
+        -- ^ Connections that have been opened, which is what 'getCount' reports.
+    -> Counter
+        -- ^ Connections warp has accepted, which is what it has to finish with
+        -- before it can stop.
     -> InternalInfo
     -> IORef FdExhaustion
         -- ^ This ref will be used to "debounce" the call to 'settingsOnException'
         -- when we hit an 'IOError' with 'eMFILE' in the case that Warp is not
         -- the reason the file descriptors are exhausted.
     -> IO ()
-acceptConnection set getConnMaker app counter ii fdRef = do
+acceptConnection set getConnMaker app counter accepted ii fdRef = do
     -- First mask all exceptions in acceptLoop. This is necessary to
     -- ensure that no async exception is throw between the call to
     -- acceptNewConnection and the registering of connClose.
@@ -327,7 +336,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
     -- In some cases, we want to stop Warp here without graceful shutdown.
     -- So, async exceptions are allowed here.
     -- That's why `finally` is not used.
-    gracefulShutdown set counter
+    gracefulShutdown set accepted
   where
     acceptLoop = do
         -- Allow async exceptions before receiving the next connection maker.
@@ -344,7 +353,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
         case mx of
             Nothing -> return ()
             Just (mkConn, addr) -> do
-                fork set mkConn addr app counter ii
+                fork set mkConn addr app counter accepted ii
                 acceptLoop
 
     acceptNewConnection = do
@@ -381,7 +390,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
         -- get called an enormous amount of times per second.
         when (fdExhaustion /= FdExhausted) $
             settingsOnException set Nothing $ E.toException e
-        hasDecreased <- waitForDecreased counter
+        hasDecreased <- waitForDecreased accepted
         -- If we get 'NoConnections', that means the file
         -- descriptor exhaustion is outside of our control.
         -- We flag it so that 'settingsOnException' doesn't get
@@ -396,30 +405,37 @@ fork
     -> SockAddr
     -> Application
     -> Counter
+    -> Counter
     -> InternalInfo
     -> IO ()
-fork set mkConn addr app counter ii = settingsFork set $ \unmask -> do
-    tid <- myThreadId
-    labelThread tid "Warp just forked"
-    -- Call the user-supplied on exception code if any
-    -- exceptions are thrown.
-    --
-    -- Intentionally using Control.Exception.handle, since we want to
-    -- catch all exceptions and avoid them from propagating, even
-    -- async exceptions. See:
-    -- https://github.com/yesodweb/wai/issues/850
-    E.handle (settingsOnException set Nothing) $
-        -- Run the connection maker to get a new connection, and ensure
-        -- that the connection is closed. If the mkConn call throws an
-        -- exception, we will leak the connection. If the mkConn call is
-        -- vulnerable to attacks (e.g., Slowloris), we do nothing to
-        -- protect the server. It is therefore vital that mkConn is well
-        -- vetted.
+fork set mkConn addr app counter accepted ii = do
+    -- Count the connection here rather than in the thread below.  The accept
+    -- loop does not wait for that thread to be scheduled, so counting there
+    -- leaves a window in which the connection is accepted and not counted,
+    -- and 'gracefulShutdown' waits on this counter.
+    increase accepted
+    settingsFork set $ \unmask -> (`E.finally` decrease accepted) $ do
+        tid <- myThreadId
+        labelThread tid "Warp just forked"
+        -- Call the user-supplied on exception code if any
+        -- exceptions are thrown.
         --
-        -- We grab the connection before registering timeouts since the
-        -- timeouts will be useless during connection creation, due to the
-        -- fact that async exceptions are still masked.
-        E.bracket mkConn cleanUp (serve unmask)
+        -- Intentionally using Control.Exception.handle, since we want to
+        -- catch all exceptions and avoid them from propagating, even
+        -- async exceptions. See:
+        -- https://github.com/yesodweb/wai/issues/850
+        E.handle (settingsOnException set Nothing) $
+            -- Run the connection maker to get a new connection, and ensure
+            -- that the connection is closed. If the mkConn call throws an
+            -- exception, we will leak the connection. If the mkConn call is
+            -- vulnerable to attacks (e.g., Slowloris), we do nothing to
+            -- protect the server. It is therefore vital that mkConn is well
+            -- vetted.
+            --
+            -- We grab the connection before registering timeouts since the
+            -- timeouts will be useless during connection creation, due to the
+            -- fact that async exceptions are still masked.
+            E.bracket mkConn cleanUp (serve unmask)
   where
     cleanUp (conn, _) =
         connClose conn `E.finally` do

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -10,6 +10,7 @@ import Control.Concurrent.Async
 import Control.Exception (bracket)
 import Control.Monad (void)
 import Data.IORef
+import Foreign.C.Error (eBADF, errnoToIOError)
 import Network.HTTP.Client
 import Network.HTTP.Types (ok200, status200)
 import Network.Socket
@@ -33,14 +34,15 @@ spec = describe "graceful shutdown" $ do
                 threadDelay 200_000
                 act unmask
 
-            -- Take one connection, then stop accepting, which is what
-            -- closing the listening socket does to the accept loop without
-            -- closing a descriptor it is parked on.
+            -- Take one connection, then stop accepting, with the error a
+            -- closed listening socket actually gives.  Closing it for real
+            -- would mean closing a descriptor the accept loop is parked on,
+            -- which the IO manager does not survive cleanly.
             acceptOnlyOne sock = do
                 taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
                 if taken == 0
                     then accept sock
-                    else ioError (userError "the listening socket is closed")
+                    else ioError (errnoToIOError "accept" eBADF Nothing Nothing)
 
             settings =
                 setFork slowFork $

--- a/warp/test/GracefulShutdownSpec.hs
+++ b/warp/test/GracefulShutdownSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 
 module GracefulShutdownSpec (spec) where
 
@@ -8,16 +9,61 @@ import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception (bracket)
 import Control.Monad (void)
+import Data.IORef
 import Network.HTTP.Client
 import Network.HTTP.Types (ok200, status200)
-import Network.Socket (close)
+import Network.Socket
 import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp
 import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "graceful shutdown" $
+spec = describe "graceful shutdown" $ do
+    it "waits for a connection accepted just before it stopped accepting" $ do
+        -- The window is between accepting a connection and the thread
+        -- serving it being scheduled. Delaying the thread makes it wide
+        -- enough to test; in a running server it is however long the RTS
+        -- takes to get to the new thread.
+        accepted <- newIORef (0 :: Int)
+        closed <- newIORef (0 :: Int)
+
+        let slowFork :: ((forall a. IO a -> IO a) -> IO ()) -> IO ()
+            slowFork act = void $ forkIOWithUnmask $ \unmask -> do
+                threadDelay 200_000
+                act unmask
+
+            -- Take one connection, then stop accepting, which is what
+            -- closing the listening socket does to the accept loop without
+            -- closing a descriptor it is parked on.
+            acceptOnlyOne sock = do
+                taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
+                if taken == 0
+                    then accept sock
+                    else ioError (userError "the listening socket is closed")
+
+            settings =
+                setFork slowFork $
+                    setAccept acceptOnlyOne $
+                        setOnClose (\_ -> atomicModifyIORef' closed $ \n -> (n + 1, ())) $
+                            setGracefulShutdownTimeout (Just 5) $
+                                setOnException (\_ _ -> pure ()) defaultSettings
+
+            app _ respond = respond $ responseLBS status200 [("Content-Length", "0")] ""
+
+        bracket openFreePort (close . snd) $ \(testPort, sock) -> do
+            -- Connect before the server starts, so the accept loop has a
+            -- connection waiting for it whatever else the machine is doing.
+            bracket (openConnection testPort) close $ \_ -> pure ()
+
+            withAsync (runSettingsSocket settings sock app) $ \server -> do
+                timeout 30_000_000 (wait server)
+                    >>= maybe (expectationFailure "Timeout waiting for server shutdown") pure
+                -- Returning is what lets the process exit, so a connection
+                -- still open here is one the client never hears back on.
+                connectionsClosed <- readIORef closed
+                connectionsClosed `shouldBe` 1
+
     it "serves the request in flight, then closes keep-alive connections and exits" $ do
         shutdownSignal <- newEmptyMVar
         allowResponse <- newEmptyMVar
@@ -76,6 +122,11 @@ spec = describe "graceful shutdown" $
                         -- wait for all clients and propagate any exceptions
                         wait clients
   where
+    openConnection testPort = do
+        client <- socket AF_INET Stream defaultProtocol
+        connect client $
+            SockAddrInet (fromIntegral testPort) (tupleToHostAddress (127, 0, 0, 1))
+        pure client
     -- set number of clients to the number of keep-alive connections
     numClients = managerConnCount defaultManagerSettings
     connectionRefused = \case

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.15
+version:            3.4.15.1
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com


### PR DESCRIPTION
Warp returns from `runSettingsSocket` while a connection it has accepted has neither been served nor closed. Graceful shutdown is meant to wait for connections and does not wait for this one, because it is not in the counter yet.

This is one of two shapes of the same fix. The other is #1104, which moves the existing counter so it is raised at accept: a smaller diff, but it changes slightly what `getCount` and `currentOpenConnections` report. This one leaves those alone and gives graceful shutdown its own counter. **Only one of the two should be merged.** I would take this one, because the counter `getCount` reports was added deliberately in 3.4.11 and 3.4.13 and redefining it as a side effect of an unrelated bug fix seems a poor trade for eight lines. The choice is yours.

## Minimal repro

```haskell
{-# LANGUAGE NumericUnderscores #-}
{-# LANGUAGE OverloadedStrings #-}
{-# LANGUAGE RankNTypes #-}

import Control.Concurrent (forkIOWithUnmask, threadDelay)
import Control.Exception (bracket)
import Control.Monad (void)
import Data.IORef
import Network.HTTP.Types (status200)
import Network.Socket
import Network.Wai (responseLBS)
import Network.Wai.Handler.Warp

main :: IO ()
main = do
    accepted <- newIORef (0 :: Int)
    closed <- newIORef (0 :: Int)

    -- The gap between accepting a connection and the thread serving it being
    -- scheduled.  Delayed here to make it a certainty rather than a race; in a
    -- server it is however long the runtime takes to get to the new thread.
    let slowFork :: ((forall a. IO a -> IO a) -> IO ()) -> IO ()
        slowFork act = void $ forkIOWithUnmask $ \unmask ->
            threadDelay 200_000 >> act unmask

        -- Take one connection and then stop accepting.  That is what closing
        -- the listening socket does to the accept loop, without closing a
        -- descriptor the accept loop is parked on.
        acceptOnce sock = do
            taken <- atomicModifyIORef' accepted $ \n -> (n + 1, n)
            if taken == 0
                then accept sock
                else ioError (userError "the listening socket is closed")

        settings =
            setFork slowFork $
                setAccept acceptOnce $
                    setOnClose (\_ -> atomicModifyIORef' closed $ \n -> (n + 1, ())) $
                        setGracefulShutdownTimeout (Just 5) $
                            setOnException (\_ _ -> pure ()) defaultSettings

        app _ respond = respond $ responseLBS status200 [("Content-Length", "0")] ""

    bracket openFreePort (close . snd) $ \(port, sock) -> do
        bracket (socket AF_INET Stream defaultProtocol) close $ \client ->
            connect client $
                SockAddrInet (fromIntegral port) (tupleToHostAddress (127, 0, 0, 1))

        runSettingsSocket settings sock app

        -- runSettingsSocket has returned.  Warp has stopped its timeout
        -- manager and its caches, and a server's next step is to exit, so
        -- whatever is unfinished here stays unfinished.
        readIORef accepted >>= \n -> putStrLn ("accepted:       " ++ show (min 1 n))
        readIORef closed >>= \n -> putStrLn ("closed by warp: " ++ show n)
```

On master:

```
accepted:       1
closed by warp: 0
```

With this change:

```
accepted:       1
closed by warp: 1
```

Warp accepted a connection and then returned without finishing with it, having stopped the timeout manager and the caches that serving it would need. Whatever the caller does next, that connection is over.

## Why

`fork` hands the connection to `settingsFork` and the accept loop goes straight back to `accept`, but the counter is raised by `onOpen`, which runs in the forked thread. From `accept` returning until that thread is scheduled the connection exists and is not counted. `gracefulShutdown` then runs `waitForZero` on that counter: a connection accepted in that gap reads as zero, so warp stops.

The repro widens the gap on purpose. Left alone it is however long the runtime takes to schedule a thread, which is short, but it is reached constantly where the listening socket outlives the process, as under systemd socket activation: connections keep being accepted right up to the close, and the process exits immediately afterwards. A service of mine dropped six requests across twenty restarts when probed with sixteen concurrent clients, showing up as `curl: (52) Empty reply from server` and one connection reset. With this change, the same probe over the same number of restarts drops none.

## The change

A second counter, raised in `fork` before `settingsFork` and lowered in a `finally` around the whole thread body, so it counts every connection warp is holding from the moment `accept` hands it over until its thread is done with it. `gracefulShutdown` waits on that one.

`waitForDecreased`, the `EMFILE` backoff from #1084, moves to it too: a connection warp has accepted is holding a descriptor whether or not its thread has run, so this is the count that answers whether there is anything to wait for. It is internal, so nothing observable changes.

`onOpen` and `onClose` are untouched, so `getCount` and `currentOpenConnections` keep counting connections that have been opened, exactly as before.

The cost is one `newCounter` and one more argument through `acceptConnection` and `fork`, both internal to `Run.hs` and not exported.

The thread body moves one level deeper unchanged, so the diff there is indentation only. `git diff -w` on `Run.hs` shows the change at its real size.

## Cost on the accept loop

This puts one STM transaction on the accept loop that used to happen in the connection's own thread, so it is fair to ask what the loop pays for it. I could not measure a difference: 4000 short-lived connections, one accept each, twelve interleaved runs of each build.

|  | best | median |
|---|---|---|
| master | 0.154s | 0.180s |
| this change | 0.151s | 0.180s |

That is around 20-26k accepts/s either way, with the two distributions fully overlapping. An uncontended `modifyTVar'` against an `accept()` syscall and a `forkIO` is not where the time goes.

## What this does and does not fix

It stops warp abandoning a connection it accepted. It does not by itself guarantee that connection's request is answered, and I would rather say so than let the repro imply otherwise.

Once shutdown has begun, `makeGracefulRecv` gives a synthetic EOF to any connection with no `Application` in progress, which is the 3.4.13 behaviour of not starting new work on idle keep-alive connections. A connection accepted moments before the close has no `Application` in progress yet, so if its thread only reaches `connRecv` after `setShuttingDown`, it is closed rather than served, even with this change. In practice the thread gets there first, which is why the probe above goes to zero drops; the repro loses that race on purpose with its 200ms delay, which is why it asserts the connection was closed rather than answered.

Whether a connection carrying an unread request should count as idle looks like a separate question, and I have not touched it. It belongs with #979, which asked for the behaviour that became `makeGracefulRecv` and lists "some HTTP requests may get a connection closed instead of a response" among the things still unsatisfying about shutdown. This PR removes one cause of that; the idle test is another.

## Test

`GracefulShutdownSpec` gets the repro as a test case, the same one as #1104.

Master's suite is 121 examples and 0 failures; with this branch it is 122 and 0. Reverting just the change to `Run.hs` and keeping the new test gives 122 examples and exactly 1 failure, the new one:

```
waits for a connection accepted just before it stopped accepting [✘]
  expected: 1
   but got: 0
```

## Checklist

Before submitting:

- [x] Bumped the version number, to 3.4.15.1 as a bug fix

The Haddock and `@since` items are dropped: no new APIs.

After submitting:

- [ ] Update the Changelog.md file with a link to this PR
- [ ] Check that CI passes

## Mergeable with #1106

#1106 changes how `accept()` failures are handled, and the test here has to stop the accept loop somehow, so the two interact. The test now does it with `errnoToIOError "accept" eBADF`, which is what a closed listening socket actually gives and what #1106 lets through quietly. Merging both branches and running the suite gives 125 examples and 0 failures.

The only conflict between them is the `## 3.4.15.1` heading each adds to the ChangeLog, which is a one-line resolution.
