### PR TITLE
warp: tell the caller when the accept loop loses its listener

### DIFF
--- a/wai-app-static/wai-app-static.cabal
+++ b/wai-app-static/wai-app-static.cabal
@@ -46,7 +46,7 @@ library
                    , filepath
                    , wai-extra                 >= 3.0      && < 3.2
                    , optparse-applicative      >= 0.7
-                   , warp                      >= 3.0.11   && < 3.5
+                   , warp                      >= 3.0.11   && < 3.6
                    , base64-bytestring         >= 0.1
                    , cryptohash-md5            >= 0.11.101
 

--- a/warp-tls/warp-tls.cabal
+++ b/warp-tls/warp-tls.cabal
@@ -21,7 +21,7 @@ Library
   Build-Depends:     base                          >= 4.12     && < 5
                    , bytestring                    >= 0.9
                    , wai                           >= 3.2      && < 3.3
-                   , warp                          >= 3.3.29   && < 3.5
+                   , warp                          >= 3.3.29   && < 3.6
                    , tls                           >= 2.1.3    && < 2.5
                    , network                       >= 2.2.1
                    , streaming-commons

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -6,13 +6,17 @@
   for a reason the listening socket will keep giving, such as `ENFILE` or
   `ENOMEM`. Previously the accept loop ended and the caller was handed a `()`,
   which is what a graceful shutdown returns, so a server that could no longer
-  accept was indistinguishable from one that had been asked to stop.
+  accept was indistinguishable from one that had been asked to stop. POSIX
+  only: on Windows `network` reports a socket error without an errno, so warp
+  cannot tell one `accept()` failure from another there.
   [#1106](https://github.com/yesodweb/wai/pull/1106)
 * The accept loop now retries, rather than stopping, on the errors `accept()`
   reports for a single queued connection: `ENETDOWN`, `EPROTO`, `ENOPROTOOPT`,
   `EHOSTDOWN`, `ENONET`, `EHOSTUNREACH` and `ENETUNREACH`. `accept(2)` asks for
   these to be treated like `EAGAIN`, which is how `ECONNABORTED` was already
-  handled. One unreachable client no longer stops the server.
+  handled. One unreachable client no longer stops the server. POSIX only: on
+  Windows `network` reports a socket error without an errno for warp to match
+  on.
   [#1106](https://github.com/yesodweb/wai/pull/1106)
 
 ## 3.4.15

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -8,7 +8,8 @@
   which is what a graceful shutdown returns, so a server that could no longer
   accept was indistinguishable from one that had been asked to stop. POSIX
   only: on Windows `network` reports a socket error without an errno, so warp
-  cannot tell one `accept()` failure from another there.
+  cannot tell one `accept()` failure from another and behaviour there is
+  unchanged.
   [#1106](https://github.com/yesodweb/wai/pull/1106)
 * The accept loop now retries, rather than stopping, on the errors `accept()`
   reports for a single queued connection: `ENETDOWN`, `EPROTO`, `ENOPROTOOPT`,
@@ -16,7 +17,7 @@
   these to be treated like `EAGAIN`, which is how `ECONNABORTED` was already
   handled. One unreachable client no longer stops the server. POSIX only: on
   Windows `network` reports a socket error without an errno for warp to match
-  on.
+  on, so behaviour there is unchanged.
   [#1106](https://github.com/yesodweb/wai/pull/1106)
 
 ## 3.4.15

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for warp
 
+## 3.4.15.1
+
+* `runSettings` and friends now rethrow when `accept()` fails for a reason
+  other than the listening socket being closed on purpose. Previously the
+  accept loop ended and the caller was handed a `()`, which is what a graceful
+  shutdown returns, so a server that could no longer accept was
+  indistinguishable from one that had been asked to stop.
+
 ## 3.4.15
 
 * Support `103 Early Hints` over HTTP/2: the HTTP/2 handler installs

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -3,10 +3,16 @@
 ## 3.5.0
 
 * Breaking change: `runSettings` and friends now rethrow when `accept()` fails
-  for a reason other than the listening socket being closed on purpose.
-  Previously the accept loop ended and the caller was handed a `()`, which is
-  what a graceful shutdown returns, so a server that could no longer accept was
-  indistinguishable from one that had been asked to stop.
+  for a reason the listening socket will keep giving, such as `ENFILE` or
+  `ENOMEM`. Previously the accept loop ended and the caller was handed a `()`,
+  which is what a graceful shutdown returns, so a server that could no longer
+  accept was indistinguishable from one that had been asked to stop.
+  [#1106](https://github.com/yesodweb/wai/pull/1106)
+* The accept loop now retries, rather than stopping, on the errors `accept()`
+  reports for a single queued connection: `ENETDOWN`, `EPROTO`, `ENOPROTOOPT`,
+  `EHOSTDOWN`, `ENONET`, `EHOSTUNREACH` and `ENETUNREACH`. `accept(2)` asks for
+  these to be treated like `EAGAIN`, which is how `ECONNABORTED` was already
+  handled. One unreachable client no longer stops the server.
   [#1106](https://github.com/yesodweb/wai/pull/1106)
 
 ## 3.4.15

--- a/warp/ChangeLog.md
+++ b/warp/ChangeLog.md
@@ -1,12 +1,13 @@
 # ChangeLog for warp
 
-## 3.4.15.1
+## 3.5.0
 
-* `runSettings` and friends now rethrow when `accept()` fails for a reason
-  other than the listening socket being closed on purpose. Previously the
-  accept loop ended and the caller was handed a `()`, which is what a graceful
-  shutdown returns, so a server that could no longer accept was
+* Breaking change: `runSettings` and friends now rethrow when `accept()` fails
+  for a reason other than the listening socket being closed on purpose.
+  Previously the accept loop ended and the caller was handed a `()`, which is
+  what a graceful shutdown returns, so a server that could no longer accept was
   indistinguishable from one that had been asked to stop.
+  [#1106](https://github.com/yesodweb/wai/pull/1106)
 
 ## 3.4.15
 

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -397,13 +397,15 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                             , eHOSTUNREACH
                             , eNETUNREACH
                             ]
+                    isFdExhaustion = isErrno eMFILE
+                    isIntentionallyClosedSocket = isErrno eBADF
                 if | isQueuedConnectionError -> do
                         -- Important to mark the exhaustion issue to be resolved
                         resetFdExhaustion fdRef
                         acceptNewConnection
                      -- Keep in mind to reset the ref when anything other
                      -- than this branch runs
-                   | isErrno eMFILE -> do
+                   | isFdExhaustion -> do
                         handleFdExhaustion e
                         acceptNewConnection
                      -- A graceful shutdown ends this loop by closing the
@@ -412,7 +414,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                      -- closing it, so every later accept() is handed -1 and
                      -- fails that way. Matching EBADF alone therefore cannot
                      -- miss a deliberate shutdown.
-                   | isErrno eBADF -> do
+                   | isIntentionallyClosedSocket -> do
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e
                         return Nothing

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -25,6 +25,7 @@ import Data.IORef (newIORef, readIORef, IORef, writeIORef)
 import Data.Streaming.Network (bindPortTCP)
 import Foreign.C.Error (
     Errno (..),
+    eBADF,
     eCONNABORTED,
     eHOSTDOWN,
     eHOSTUNREACH,
@@ -409,12 +410,12 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e
                         -- Closing the listening socket is how a graceful
-                        -- shutdown ends this loop, and it arrives here as an
-                        -- InvalidArgument, which warp already reads as the
-                        -- socket going away in the normal course of running
-                        -- (see 'defaultShouldDisplayException'). Returning
-                        -- Nothing for that one ends the loop quietly and
-                        -- 'runSettings' returns ().
+                        -- shutdown ends this loop, and it gives EBADF rather
+                        -- than merely tending to: 'close' swaps the descriptor
+                        -- for -1 before the syscall, so an accept() racing it
+                        -- has nothing else to find. Returning Nothing for that
+                        -- one ends the loop quietly and 'runSettings' returns
+                        -- ().
                         --
                         -- Every errno that is left is one the listening socket
                         -- will keep giving: descriptors exhausted system-wide,
@@ -424,7 +425,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         -- server that was asked to stop would be reported
                         -- identically and the caller could not tell which had
                         -- happened. Throw instead, so it can.
-                        if ioeGetErrorType e == InvalidArgument
+                        if isErrno eBADF
                             then return Nothing
                             else E.throwIO e
 

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -406,11 +406,12 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                    | isErrno eMFILE -> do
                         handleFdExhaustion e
                         acceptNewConnection
-                     -- Closing the listening socket is how a graceful shutdown
-                     -- ends this loop, and it gives EBADF rather than merely
-                     -- tending to: 'close' swaps the descriptor for -1 before
-                     -- the syscall, so an accept() racing it has nothing else
-                     -- to find.
+                     -- A graceful shutdown ends this loop by closing the
+                     -- listening socket, and that always arrives here as
+                     -- EBADF: 'close' replaces the descriptor with -1 before
+                     -- closing it, so every later accept() is handed -1 and
+                     -- fails that way. Matching EBADF alone therefore cannot
+                     -- miss a deliberate shutdown.
                    | isErrno eBADF -> do
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -431,7 +431,17 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         -- as resolved here, but just for completeness' sake.
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e
+#if WINDOWS
+                        -- None of the guards above can match on Windows, where
+                        -- network reports a socket error with no errno on it,
+                        -- so every accept() failure arrives here including the
+                        -- EBADF of a deliberate shutdown. Throwing would turn
+                        -- an ordinary shutdown into an exception, so Windows
+                        -- keeps ending the loop the way it always has.
+                        return Nothing
+#else
                         E.throwIO e
+#endif
 
     handleFdExhaustion e = do
         fdExhaustion <- readIORef fdRef

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -371,13 +371,14 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                 let getErrno (Errno cInt) = cInt
                     isErrno err = ioe_errno e == Just (getErrno err)
                     -- Errors about one queued connection rather than about the
-                    -- listening socket. Linux reports the new socket's
-                    -- already-pending network errors through accept(), and
-                    -- accept(2) says to treat those like EAGAIN and retry,
-                    -- which is what eCONNABORTED does here already. The
-                    -- connection they refer to has left the queue, so the
-                    -- retry blocks for a new one rather than spinning on the
-                    -- same failure.
+                    -- listening socket. eCONNABORTED is the familiar one, a
+                    -- peer that went away before it could be accepted. Linux
+                    -- also reports the new socket's already-pending network
+                    -- errors through accept(), and accept(2) asks for those to
+                    -- be treated the same way, retried like EAGAIN. Either
+                    -- way the connection has left the queue, so the retry
+                    -- blocks for a new one rather than spinning on the same
+                    -- failure.
                     --
                     -- eOPNOTSUPP is on that list in accept(2) and is left off
                     -- this one on purpose: it also means the listening socket
@@ -387,7 +388,8 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                     isQueuedConnectionError =
                         any
                             isErrno
-                            [ eNETDOWN
+                            [ eCONNABORTED
+                            , eNETDOWN
                             , ePROTO
                             , eNOPROTOOPT
                             , eHOSTDOWN
@@ -395,7 +397,7 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                             , eHOSTUNREACH
                             , eNETUNREACH
                             ]
-                if | isErrno eCONNABORTED || isQueuedConnectionError -> do
+                if | isQueuedConnectionError -> do
                         -- Important to mark the exhaustion issue to be resolved
                         resetFdExhaustion fdRef
                         acceptNewConnection
@@ -404,30 +406,29 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                    | isErrno eMFILE -> do
                         handleFdExhaustion e
                         acceptNewConnection
+                     -- Closing the listening socket is how a graceful shutdown
+                     -- ends this loop, and it gives EBADF rather than merely
+                     -- tending to: 'close' swaps the descriptor for -1 before
+                     -- the syscall, so an accept() racing it has nothing else
+                     -- to find.
+                   | isErrno eBADF -> do
+                        resetFdExhaustion fdRef
+                        settingsOnException set Nothing $ E.toException e
+                        return Nothing
+                     -- Everything left is something the listening socket will
+                     -- keep giving: descriptors exhausted system-wide, no
+                     -- memory for a socket, a socket that cannot accept.
+                     -- Ending the loop for those would return the same () a
+                     -- graceful shutdown returns, so a server that died and a
+                     -- server that was asked to stop would be reported
+                     -- identically and the caller could not tell which had
+                     -- happened. Throw instead, so it can.
                    | otherwise -> do
                         -- Maybe not important to mark the exhaustion issue
                         -- as resolved here, but just for completeness' sake.
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e
-                        -- Closing the listening socket is how a graceful
-                        -- shutdown ends this loop, and it gives EBADF rather
-                        -- than merely tending to: 'close' swaps the descriptor
-                        -- for -1 before the syscall, so an accept() racing it
-                        -- has nothing else to find. Returning Nothing for that
-                        -- one ends the loop quietly and 'runSettings' returns
-                        -- ().
-                        --
-                        -- Every errno that is left is one the listening socket
-                        -- will keep giving: descriptors exhausted system-wide,
-                        -- no memory for a socket, a socket that cannot accept.
-                        -- Returning Nothing for those would end the loop and
-                        -- return that same (), so a server that died and a
-                        -- server that was asked to stop would be reported
-                        -- identically and the caller could not tell which had
-                        -- happened. Throw instead, so it can.
-                        if isErrno eBADF
-                            then return Nothing
-                            else E.throwIO e
+                        E.throwIO e
 
     handleFdExhaustion e = do
         fdExhaustion <- readIORef fdRef

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -23,7 +23,18 @@ import qualified Data.ByteString as S
 import Data.Functor (($>))
 import Data.IORef (newIORef, readIORef, IORef, writeIORef)
 import Data.Streaming.Network (bindPortTCP)
-import Foreign.C.Error (Errno (..), eCONNABORTED, eMFILE)
+import Foreign.C.Error (
+    Errno (..),
+    eCONNABORTED,
+    eHOSTDOWN,
+    eHOSTUNREACH,
+    eMFILE,
+    eNETDOWN,
+    eNETUNREACH,
+    eNONET,
+    eNOPROTOOPT,
+    ePROTO,
+ )
 import GHC.Conc.Sync (labelThread, myThreadId)
 import GHC.IO.Exception (IOErrorType (..), IOException (..))
 import Network.Socket (
@@ -358,7 +369,32 @@ acceptConnection set getConnMaker app counter ii fdRef = do
             Left e -> do
                 let getErrno (Errno cInt) = cInt
                     isErrno err = ioe_errno e == Just (getErrno err)
-                if | isErrno eCONNABORTED -> do
+                    -- Errors about one queued connection rather than about the
+                    -- listening socket. Linux reports the new socket's
+                    -- already-pending network errors through accept(), and
+                    -- accept(2) says to treat those like EAGAIN and retry,
+                    -- which is what eCONNABORTED does here already. The
+                    -- connection they refer to has left the queue, so the
+                    -- retry blocks for a new one rather than spinning on the
+                    -- same failure.
+                    --
+                    -- eOPNOTSUPP is on that list in accept(2) and is left off
+                    -- this one on purpose: it also means the listening socket
+                    -- is not SOCK_STREAM, which is a permanent condition that
+                    -- retrying would spin on forever. Throwing tells whoever
+                    -- passed that socket, which is the only thing that helps.
+                    isQueuedConnectionError =
+                        any
+                            isErrno
+                            [ eNETDOWN
+                            , ePROTO
+                            , eNOPROTOOPT
+                            , eHOSTDOWN
+                            , eNONET
+                            , eHOSTUNREACH
+                            , eNETUNREACH
+                            ]
+                if | isErrno eCONNABORTED || isQueuedConnectionError -> do
                         -- Important to mark the exhaustion issue to be resolved
                         resetFdExhaustion fdRef
                         acceptNewConnection
@@ -380,12 +416,14 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         -- Nothing for that one ends the loop quietly and
                         -- 'runSettings' returns ().
                         --
-                        -- Every other errno is an accept() that broke on its
-                        -- own. Returning Nothing there too would end the loop
-                        -- the same way and return that same (), so a server
-                        -- that died and a server that was asked to stop would
-                        -- be reported identically and the caller could not
-                        -- tell which had happened. Throw instead, so it can.
+                        -- Every errno that is left is one the listening socket
+                        -- will keep giving: descriptors exhausted system-wide,
+                        -- no memory for a socket, a socket that cannot accept.
+                        -- Returning Nothing for those would end the loop and
+                        -- return that same (), so a server that died and a
+                        -- server that was asked to stop would be reported
+                        -- identically and the caller could not tell which had
+                        -- happened. Throw instead, so it can.
                         if ioeGetErrorType e == InvalidArgument
                             then return Nothing
                             else E.throwIO e

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -376,13 +376,16 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         -- shutdown ends this loop, and it arrives here as an
                         -- InvalidArgument, which warp already reads as the
                         -- socket going away in the normal course of running
-                        -- (see 'defaultShouldDisplayException').
+                        -- (see 'defaultShouldDisplayException'). Returning
+                        -- Nothing for that one ends the loop quietly and
+                        -- 'runSettings' returns ().
                         --
-                        -- Anything else is an accept() that broke on its own,
-                        -- and has to reach the caller: ending the loop hands
-                        -- back a () that cannot be told apart from a clean
-                        -- stop, leaving the caller holding a server that will
-                        -- never accept again and does not know it.
+                        -- Every other errno is an accept() that broke on its
+                        -- own. Returning Nothing there too would end the loop
+                        -- the same way and return that same (), so a server
+                        -- that died and a server that was asked to stop would
+                        -- be reported identically and the caller could not
+                        -- tell which had happened. Throw instead, so it can.
                         if ioeGetErrorType e == InvalidArgument
                             then return Nothing
                             else E.throwIO e

--- a/warp/Network/Wai/Handler/Warp/Run.hs
+++ b/warp/Network/Wai/Handler/Warp/Run.hs
@@ -372,7 +372,20 @@ acceptConnection set getConnMaker app counter ii fdRef = do
                         -- as resolved here, but just for completeness' sake.
                         resetFdExhaustion fdRef
                         settingsOnException set Nothing $ E.toException e
-                        return Nothing
+                        -- Closing the listening socket is how a graceful
+                        -- shutdown ends this loop, and it arrives here as an
+                        -- InvalidArgument, which warp already reads as the
+                        -- socket going away in the normal course of running
+                        -- (see 'defaultShouldDisplayException').
+                        --
+                        -- Anything else is an accept() that broke on its own,
+                        -- and has to reach the caller: ending the loop hands
+                        -- back a () that cannot be told apart from a clean
+                        -- stop, leaving the caller holding a server that will
+                        -- never accept again and does not know it.
+                        if ioeGetErrorType e == InvalidArgument
+                            then return Nothing
+                            else E.throwIO e
 
     handleFdExhaustion e = do
         fdExhaustion <- readIORef fdRef

--- a/warp/test/AcceptFailureSpec.hs
+++ b/warp/test/AcceptFailureSpec.hs
@@ -5,11 +5,15 @@ module AcceptFailureSpec (spec) where
 
 import Control.Concurrent
 import Control.Exception
-import Foreign.C.Error (eNFILE, errnoToIOError)
+import qualified Data.ByteString.Lazy as BL
+import Data.IORef
+import Foreign.C.Error (eNETDOWN, eNFILE, eOPNOTSUPP, errnoToIOError)
+import HTTP (responseBody, sendGET)
 import Network.HTTP.Types (status200)
 import Network.Socket
 import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp
+import System.Timeout (timeout)
 import Test.Hspec
 
 -- Run a server on an ephemeral port and report how runSettingsSocket ended.
@@ -67,3 +71,49 @@ spec = do
                     expectationFailure
                         "runSettingsSocket returned normally after accept() failed, \
                         \so a lost listener looks just like a clean shutdown"
+
+        -- Not a reason to stop: the socket is fine and the connection that
+        -- failed is already off the queue, so serving continues.
+        it "keeps accepting when one queued connection fails" $ do
+            failuresLeft <- newIORef (3 :: Int)
+            let flakyAccept sock = do
+                    left <- atomicModifyIORef' failuresLeft $ \n -> (max 0 (n - 1), n)
+                    if left > 0
+                        then ioError (errnoToIOError "accept" eNETDOWN Nothing Nothing)
+                        else accept sock
+            served <- newIORef Nothing
+            r <- runServerUntil flakyAccept $ \sock closeListenSocket -> do
+                port <- socketPort sock
+                body <-
+                    try $
+                        responseBody
+                            <$> sendGET ("http://127.0.0.1:" ++ show port ++ "/")
+                writeIORef served (Just (body :: Either SomeException BL.ByteString))
+                closeListenSocket
+            outcome <- readIORef served
+            case outcome of
+                Just (Right body) -> body `shouldBe` "ok"
+                Just (Left e) ->
+                    expectationFailure $
+                        "the server stopped accepting after a queued connection \
+                        \failed, so the next request went unanswered: "
+                            <> show e
+                Nothing -> expectationFailure "the request was never made"
+            case r of
+                Right () -> return ()
+                Left e -> expectationFailure $ "graceful shutdown threw: " <> show e
+
+        -- eOPNOTSUPP is a queued-connection error in accept(2) and also what a
+        -- listening socket that is not SOCK_STREAM answers. The two are
+        -- indistinguishable here, and retrying the second spins forever, so it
+        -- is thrown rather than retried.
+        it "rethrows rather than spinning when the socket cannot accept" $ do
+            let unsupportedAccept _ =
+                    ioError (errnoToIOError "accept" eOPNOTSUPP Nothing Nothing)
+            r <- timeout 5_000_000 $ runServerUntil unsupportedAccept $ \_ _ -> return ()
+            case r of
+                Nothing -> expectationFailure "the accept loop spun instead of giving up"
+                Just (Left _) -> return ()
+                Just (Right ()) ->
+                    expectationFailure
+                        "runSettingsSocket returned normally on a socket that cannot accept"

--- a/warp/test/AcceptFailureSpec.hs
+++ b/warp/test/AcceptFailureSpec.hs
@@ -7,7 +7,14 @@ import Control.Concurrent
 import Control.Exception
 import qualified Data.ByteString.Lazy as BL
 import Data.IORef
-import Foreign.C.Error (eNETDOWN, eNFILE, eOPNOTSUPP, errnoToIOError)
+import Foreign.C.Error (
+    Errno (..),
+    eNETDOWN,
+    eNFILE,
+    eOPNOTSUPP,
+    errnoToIOError,
+ )
+import GHC.IO.Exception (IOException (..))
 import HTTP (responseBody, sendGET)
 import Network.HTTP.Types (status200)
 import Network.Socket
@@ -15,6 +22,16 @@ import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp
 import System.Timeout (timeout)
 import Test.Hspec
+
+-- Did this come out of accept() failing with this errno?
+--
+-- Worth checking rather than taking any exception: a test that accepts
+-- whatever it is given would still pass if the accept loop started throwing
+-- something else entirely.
+failedWith :: Errno -> SomeException -> Bool
+failedWith (Errno wanted) e = case fromException e of
+    Just ioe -> ioe_errno ioe == Just wanted
+    Nothing -> False
 
 -- Run a server on an ephemeral port and report how runSettingsSocket ended.
 --
@@ -66,7 +83,10 @@ spec = do
             let failingAccept _ = ioError (errnoToIOError "accept" eNFILE Nothing Nothing)
             r <- runServerUntil failingAccept $ \_ _ -> return ()
             case r of
-                Left _ -> return ()
+                Left e
+                    | failedWith eNFILE e -> return ()
+                    | otherwise ->
+                        expectationFailure $ "expected the ENFILE from accept(), got: " <> show e
                 Right () ->
                     expectationFailure
                         "runSettingsSocket returned normally after accept() failed, \
@@ -113,7 +133,10 @@ spec = do
             r <- timeout 5_000_000 $ runServerUntil unsupportedAccept $ \_ _ -> return ()
             case r of
                 Nothing -> expectationFailure "the accept loop spun instead of giving up"
-                Just (Left _) -> return ()
+                Just (Left e)
+                    | failedWith eOPNOTSUPP e -> return ()
+                    | otherwise ->
+                        expectationFailure $ "expected the EOPNOTSUPP from accept(), got: " <> show e
                 Just (Right ()) ->
                     expectationFailure
                         "runSettingsSocket returned normally on a socket that cannot accept"

--- a/warp/test/AcceptFailureSpec.hs
+++ b/warp/test/AcceptFailureSpec.hs
@@ -10,8 +10,6 @@ import Network.HTTP.Types (status200)
 import Network.Socket
 import Network.Wai (responseLBS)
 import Network.Wai.Handler.Warp
-import Network.Wai.Handler.Warp.Counter
-import System.Timeout (timeout)
 import Test.Hspec
 
 -- Run a server on an ephemeral port and report how runSettingsSocket ended.
@@ -49,20 +47,6 @@ runServerUntil accept' end = do
 
 spec :: Spec
 spec = do
-    -- Running out of descriptors does not arrive through the branch the next
-    -- group covers. eMFILE has its own, which waits for a connection to close
-    -- and then retries. That wait is the hazard: it used to block until the
-    -- connection count dropped *below* what it was on entry, so a server
-    -- holding no connections when the descriptors ran out waited for a
-    -- decrease that could never come, and stopped accepting for good without
-    -- raising anything. A server can sit like that indefinitely, logging
-    -- "Too many open files" and then going quiet.
-    describe "waiting for descriptors to free up" $
-        it "gives up when there are no connections to wait for" $ do
-            counter <- newCounter
-            r <- timeout 1_000_000 (waitForDecreased counter)
-            r `shouldBe` Just NoConnections
-
     describe "a listener that goes away" $ do
         it "ends the accept loop quietly when the socket is closed on purpose" $ do
             r <- runServerUntil accept $ \_ closeListenSocket -> closeListenSocket

--- a/warp/test/AcceptFailureSpec.hs
+++ b/warp/test/AcceptFailureSpec.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module AcceptFailureSpec (spec) where
+
+import Control.Concurrent
+import Control.Exception
+import Foreign.C.Error (eNFILE, errnoToIOError)
+import Network.HTTP.Types (status200)
+import Network.Socket
+import Network.Wai (responseLBS)
+import Network.Wai.Handler.Warp
+import Network.Wai.Handler.Warp.Counter
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- Run a server on an ephemeral port and report how runSettingsSocket ended.
+--
+-- The caller supplies the accept action, so a test can make accept() fail with
+-- an errno of its choosing, and an action to run once the server is up.
+runServerUntil
+    :: (Socket -> IO (Socket, SockAddr))
+    -> (Socket -> IO () -> IO ())
+    -> IO (Either SomeException ())
+runServerUntil accept' end = do
+    shutdownSlot <- newEmptyMVar
+    let application _ respond = respond (responseLBS status200 [] "ok")
+        settings =
+            setAccept accept' $
+                setOnException (\_ _ -> return ()) $
+                    setInstallShutdownHandler (putMVar shutdownSlot) defaultSettings
+
+    bracket openListenSocket close $ \sock -> do
+        outcome <- newEmptyMVar
+        _ <- forkIO $ do
+            r <- try (runSettingsSocket settings sock application)
+            putMVar outcome r
+        closeListenSocket <- takeMVar shutdownSlot
+        threadDelay 200_000
+        end sock closeListenSocket
+        takeMVar outcome
+  where
+    openListenSocket = do
+        sock <- socket AF_INET Stream defaultProtocol
+        setSocketOption sock ReuseAddr 1
+        bind sock (SockAddrInet 0 (tupleToHostAddress (127, 0, 0, 1)))
+        listen sock 5
+        return sock
+
+spec :: Spec
+spec = do
+    -- Running out of descriptors does not arrive through the branch the next
+    -- group covers. eMFILE has its own, which waits for a connection to close
+    -- and then retries. That wait is the hazard: it used to block until the
+    -- connection count dropped *below* what it was on entry, so a server
+    -- holding no connections when the descriptors ran out waited for a
+    -- decrease that could never come, and stopped accepting for good without
+    -- raising anything. A server can sit like that indefinitely, logging
+    -- "Too many open files" and then going quiet.
+    describe "waiting for descriptors to free up" $
+        it "gives up when there are no connections to wait for" $ do
+            counter <- newCounter
+            r <- timeout 1_000_000 (waitForDecreased counter)
+            r `shouldBe` Just NoConnections
+
+    describe "a listener that goes away" $ do
+        it "ends the accept loop quietly when the socket is closed on purpose" $ do
+            r <- runServerUntil accept $ \_ closeListenSocket -> closeListenSocket
+            case r of
+                Right () -> return ()
+                Left e -> expectationFailure $ "graceful shutdown threw: " <> show e
+
+        -- Without this, accept() failing leaves the caller with a plain (),
+        -- which is exactly what a graceful shutdown returns. A server that can
+        -- no longer accept is then indistinguishable from one that was asked
+        -- to stop, so whatever supervises it never learns that it is dead.
+        it "rethrows when accept fails for a reason nobody asked for" $ do
+            let failingAccept _ = ioError (errnoToIOError "accept" eNFILE Nothing Nothing)
+            r <- runServerUntil failingAccept $ \_ _ -> return ()
+            case r of
+                Left _ -> return ()
+                Right () ->
+                    expectationFailure
+                        "runSettingsSocket returned normally after accept() failed, \
+                        \so a lost listener looks just like a clean shutdown"

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.15.1
+version:            3.5.0
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com

--- a/warp/warp.cabal
+++ b/warp/warp.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               warp
-version:            3.4.15
+version:            3.4.15.1
 license:            MIT
 license-file:       LICENSE
 maintainer:         michael@snoyman.com
@@ -179,6 +179,7 @@ test-suite spec
     build-tool-depends: hspec-discover:hspec-discover
     hs-source-dirs:     test .
     other-modules:
+        AcceptFailureSpec
         BufferSpec
         ConduitSpec
         ConnectionSpec


### PR DESCRIPTION
When `accept()` fails for a reason nobody asked for, warp ends the accept loop and hands the caller a plain `()`. That is exactly what a graceful shutdown returns, so a server that can no longer accept is indistinguishable from one that was asked to stop. Whatever supervises it never learns it is dead, and it sits there holding a socket it will never accept on again. This rethrows instead, while still ending quietly when the listening socket is closed on purpose.

## Minimal repro

`accept()` fails with `ENFILE`, which is the system-wide descriptor limit rather than this process's own, so warp's `EMFILE` retry does not cover it:

```haskell
{-# LANGUAGE NumericUnderscores #-}
{-# LANGUAGE OverloadedStrings #-}

import Control.Concurrent
import Control.Exception
import Foreign.C.Error (eNFILE, errnoToIOError)
import Network.HTTP.Types (status200)
import Network.Socket
import Network.Wai (responseLBS)
import Network.Wai.Handler.Warp

main :: IO ()
main = do
    let failingAccept _ = ioError (errnoToIOError "accept" eNFILE Nothing Nothing)
        app _ respond = respond (responseLBS status200 [] "ok")
        settings = setAccept failingAccept $ setOnException (\_ _ -> pure ()) defaultSettings

    bracket openFreePort (close . snd) $ \(_, sock) -> do
        outcome <- try (runSettingsSocket settings sock app)
        putStrLn $ case outcome :: Either SomeException () of
            Right () -> "returned () -- indistinguishable from a clean shutdown"
            Left e -> "threw: " ++ show e
```

On master:

```
returned () -- indistinguishable from a clean shutdown
```

With this change:

```
threw: accept: resource exhausted (Too many open files in system)
```

## When does `accept()` actually fail this way?

The branch this changes is everything that is not `ECONNABORTED` and not `EMFILE`. On master all of it ends the accept loop. From `accept(2)`, the ones a long-running server can realistically meet:

| errno | cause | today |
|---|---|---|
| `ENFILE` | system-wide open-file limit reached | ends the loop silently |
| `ENOBUFS`, `ENOMEM` | no free memory, often the socket buffer limit rather than system memory | ends the loop silently |
| `ENETDOWN`, `EHOSTUNREACH`, ... | a network error already pending on one queued connection | ends the loop silently |
| `EPERM` | firewall rules forbid the connection (Linux) | ends the loop silently |
| `EMFILE` | this process's own descriptor limit | retried, since #1084 |
| `EBADF` | the listening socket was closed | ends the loop, which is the graceful shutdown path |
| `EINVAL` | the socket is not listening | ends the loop silently, as if a shutdown had been asked for |

`ENFILE` is the one I would lead with: it is the same situation as `EMFILE`, descriptor exhaustion, but counted system-wide. A box running several processes can hit it while warp sits well under its own limit, and warp handles the one and not the other. That asymmetry is the repro above.

`ENOBUFS`/`ENOMEM` are transient under memory pressure, and a server that stops for good on a transient condition is the same shape of problem.

## The second commit: some of those should be retried, not thrown

Rethrowing everything that is not a deliberate shutdown is too broad, and `accept(2)` says why:

> For reliable operation the application should detect the network errors defined for the protocol after `accept()` and treat them like `EAGAIN` by retrying. In the case of TCP/IP, these are `ENETDOWN`, `EPROTO`, `ENOPROTOOPT`, `EHOSTDOWN`, `ENONET`, `EHOSTUNREACH`, `EOPNOTSUPP`, and `ENETUNREACH`.

Linux reports the new socket's already-pending network errors through `accept()`. They describe one queued connection, not the listening socket, and today one unreachable client stops the whole server: master ends the accept loop for every one of them. So the loop now retries them, exactly as it already does for `ECONNABORTED`. The connection they refer to has left the queue by the time they are reported, so the retry blocks for a new connection rather than spinning on the same failure.

`EOPNOTSUPP` is on that list and deliberately not on the retried one. It is also what a listening socket that is not `SOCK_STREAM` answers; the two cannot be told apart here, and retrying the second would spin forever. It is thrown, which at least reaches whoever passed the socket. There is a test that it terminates rather than spins.

That makes the accept loop's failures three kinds rather than two:

| | |
|---|---|
| retry | it was about one queued connection |
| end quietly | the listening socket was closed on purpose |
| throw | the socket will keep giving this |

This is a second commit so it can be dropped if you would rather have the two-way version, though I think the three-way split is the one that is actually right.

## Why this is the wrong return value

`runSettings` returning `()` has one meaning to a caller: the server stopped because it was told to. That is the value a graceful shutdown produces, and callers act on it by exiting cleanly, or by letting a supervisor treat the exit as intended.

There is no way for the caller to tell that case apart from this one, in which `accept()` broke on its own and the server is alive, listening in name only, and will never answer anything again. `settingsOnException` is called, so it is not silent in the logs, but a log line is not a return value: nothing the caller can branch on says the server is finished.

Reported before as #603, which was closed by the `EMFILE` retry branch. That handles running out of descriptors in this process. The silent stop on every other errno stayed.

## The change

It cannot simply rethrow everything, because closing the listening socket is the documented way to end the loop. That arrives as `EBADF`, and exactly `EBADF`: `close` swaps the descriptor for -1 before the syscall, so an `accept()` racing it has nothing else to find. So the loop ends quietly on that one errno, retries what belongs to a queued connection, and throws the rest.

## Test

`AcceptFailureSpec` pins every direction, because a fix that turned deliberate shutdowns into exceptions would be worse than the bug:

- closing the listening socket on purpose still ends the loop quietly, with no exception;
- `accept()` failing with `ENFILE` reaches the caller;
- `accept()` failing with `ENETDOWN` is retried, and the next request is still served;
- `accept()` failing with `EOPNOTSUPP` terminates rather than spinning.

Master's suite passes, and so does this branch. Reverting just the changes to `Run.hs` while keeping the new tests fails one per behaviour this pins, so each stands on its own:

```
1) AcceptFailure, a listener that goes away, rethrows when accept fails for a reason nobody asked for
     runSettingsSocket returned normally after accept() failed, so a lost
     listener looks just like a clean shutdown
```

## Versioning

3.5.0. `runSettings` throws where it used to return, which is the "changing behavior of existing public API" case in CONTRIBUTING, so it is a major version under the PVP. I first bumped this to 3.4.15.1 on the grounds that anyone relying on the old behaviour was relying on not being told their server was dead; @Vlix called it as a major, which is the right reading of the rule, and it is now 3.5.0.

## Checklist

Before submitting:

- [x] Bumped the version number, to 3.5.0

The Haddock and `@since` items are dropped: no new APIs.

After submitting:

- [x] Update the Changelog.md file with a link to this PR
- [ ] Check that CI passes

## Relation to #873

#873 is a request to stop leaning on `InvalidArgument` to mean "the listener went away", because it is an implementation detail that could in principle have other causes, and the reporter is doing that test by hand in their own `setOnException`. This PR does not lean on it: whether the loop ends quietly or the exception reaches the caller is decided on `EBADF` alone.

Two things from that thread bear on this PR. @snoyberg ruled out a custom exception type as silently breaking existing code, and suggested instead exposing a predicate, `isListenSocketClosedException :: SomeException -> Bool`. The check added here is that predicate, written inline and unexported. If you want it, extracting and exporting it would serve this PR and close most of #873 at once; I have kept it inline so this stays a bug fix with no new API, but say the word and I will do it here or as a follow-up.

The other is from #979: `network`'s `close` atomically swaps the descriptor for -1 before the syscall, so `accept()` on a closed listening socket is *certain* to give `EBADF`, not merely likely. The deliberate-shutdown path is therefore reliable, which is what makes rethrowing everything else safe.

## P.S. one thing I decided rather than assumed


On the rethrow path `settingsOnException` is still called before the exception propagates, so a caller with a custom handler logs it and then also receives it from `runSettings`. I kept the existing reporting rather than making the new path quiet, on the grounds that a caller might have no logging of its own, but it does mean one failure reported twice. Also happy to change.
